### PR TITLE
Add vars override to all delegate_to: localhost calls

### DIFF
--- a/playbooks/_pull_latest_playbooks.yml
+++ b/playbooks/_pull_latest_playbooks.yml
@@ -13,6 +13,9 @@
   ansible.builtin.stat:
     path: "{{ _repo_dir }}/BUILD_COMMIT"
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
   register: _docker_build
 
 - name: Report Docker image already updated
@@ -27,6 +30,9 @@
       ansible.builtin.stat:
         path: "{{ _repo_dir }}/.git"
       delegate_to: localhost
+      vars:
+        ansible_connection: local
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
       register: _is_git_repo
 
     - name: Fail if not a git repository
@@ -40,6 +46,9 @@
       ansible.builtin.slurp:
         src: "{{ _repo_dir }}/VERSION"
       delegate_to: localhost
+      vars:
+        ansible_connection: local
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
       register: _current_version
 
     - name: Fetch latest from remote
@@ -47,6 +56,9 @@
         cmd: "git fetch origin"
         chdir: "{{ _repo_dir }}"
       delegate_to: localhost
+      vars:
+        ansible_connection: local
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
       changed_when: false
 
     - name: Check for updates
@@ -54,6 +66,9 @@
         cmd: "git log HEAD..origin/main --oneline"
         chdir: "{{ _repo_dir }}"
       delegate_to: localhost
+      vars:
+        ansible_connection: local
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
       register: _pending_updates
       changed_when: false
 
@@ -70,6 +85,9 @@
             cmd: "git pull --ff-only origin main"
             chdir: "{{ _repo_dir }}"
           delegate_to: localhost
+          vars:
+            ansible_connection: local
+            ansible_python_interpreter: "{{ ansible_playbook_python }}"
           changed_when: true
           register: _pull_result
           failed_when: false
@@ -86,6 +104,9 @@
           ansible.builtin.slurp:
             src: "{{ _repo_dir }}/VERSION"
           delegate_to: localhost
+          vars:
+            ansible_connection: local
+            ansible_python_interpreter: "{{ ansible_playbook_python }}"
           register: _new_version
 
         - name: Report update

--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -51,6 +51,9 @@
         id: "{{ id }}"
         state: absent
       delegate_to: localhost
+      vars:
+        ansible_connection: local
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
       ignore_errors: true
 
     - name: Report failure

--- a/playbooks/host_add.yml
+++ b/playbooks/host_add.yml
@@ -10,6 +10,9 @@
     state: directory
     mode: "0755"
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Parse SSH destination (user@host or host)
   ansible.builtin.set_fact:
@@ -22,6 +25,9 @@
   register: _existing_hosts
   ignore_errors: true
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Initialize hosts structure
   ansible.builtin.set_fact:
@@ -52,6 +58,9 @@
     dest: "{{ _config_dir }}/hosts.yml"
     mode: "0644"
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Report
   ansible.builtin.debug:

--- a/playbooks/host_list.yml
+++ b/playbooks/host_list.yml
@@ -10,6 +10,9 @@
   register: _existing_hosts
   ignore_errors: true
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: No hosts message
   ansible.builtin.debug:

--- a/playbooks/host_remove.yml
+++ b/playbooks/host_remove.yml
@@ -10,6 +10,9 @@
   register: _existing_hosts
   ignore_errors: true
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Fail if hosts.yml does not exist
   ansible.builtin.fail:
@@ -37,6 +40,9 @@
     dest: "{{ _config_dir }}/hosts.yml"
     mode: "0644"
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Report
   ansible.builtin.debug:

--- a/playbooks/list.yml
+++ b/playbooks/list.yml
@@ -6,6 +6,9 @@
   canasta_registry:
     state: cleanup
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
   register: _cleanup_result
   when: cleanup | default(false) | bool
 
@@ -23,6 +26,9 @@
     state: query_all
     filter_host: "{{ target_host | default(omit) }}"
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
   register: _all_instances
 
 - name: No instances

--- a/playbooks/storage_setup_efs.yml
+++ b/playbooks/storage_setup_efs.yml
@@ -43,6 +43,9 @@
     setting_key: defaultStorageClass
     setting_value: "{{ storage_class_name | default('efs') }}"
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Report setup complete
   ansible.builtin.debug:

--- a/playbooks/storage_setup_nfs.yml
+++ b/playbooks/storage_setup_nfs.yml
@@ -97,6 +97,9 @@
     setting_key: defaultStorageClass
     setting_value: "{{ storage_class_name | default('nfs') }}"
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Report setup complete
   ansible.builtin.debug:

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -13,6 +13,9 @@
     state: query_all
     filter_host: "{{ target_host | default(omit) }}"
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
   register: _upgrade_instances
 
 - name: Report dry run

--- a/playbooks/version.yml
+++ b/playbooks/version.yml
@@ -15,6 +15,9 @@
     path: "{{ playbook_dir }}/BUILD_COMMIT"
   register: _build_commit_file
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Read baked-in BUILD_COMMIT
   ansible.builtin.slurp:
@@ -22,6 +25,9 @@
   register: _build_commit_content
   when: _build_commit_file.stat.exists
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Read baked-in BUILD_DATE
   ansible.builtin.slurp:
@@ -29,6 +35,9 @@
   register: _build_date_content
   when: _build_commit_file.stat.exists
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Get git commit from checkout
   ansible.builtin.command:
@@ -39,6 +48,9 @@
   ignore_errors: true
   when: not _build_commit_file.stat.exists
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Get git commit date from checkout
   ansible.builtin.command:
@@ -49,6 +61,9 @@
   ignore_errors: true
   when: not _build_commit_file.stat.exists
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Resolve commit and date
   ansible.builtin.set_fact:

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -53,6 +53,9 @@
     id: "{{ id }}"
     state: query
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
   register: _existing
   ignore_errors: true
 
@@ -370,6 +373,9 @@
         state: get_setting
         setting_key: defaultStorageClass
       delegate_to: localhost
+      vars:
+        ansible_connection: local
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
       register: _default_sc
       when: storage_class is not defined or storage_class == ''
 
@@ -499,6 +505,9 @@
     build_from: "{{ build_from | default(omit) }}"
     state: present
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Register instance in target host config
   canasta_registry:

--- a/roles/devmode/tasks/disable.yml
+++ b/roles/devmode/tasks/disable.yml
@@ -52,6 +52,9 @@
     build_from: "{{ _instance_result.instance.buildFrom | default(omit) }}"
     state: present
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Set dev mode fact
   ansible.builtin.set_fact:

--- a/roles/devmode/tasks/enable.yml
+++ b/roles/devmode/tasks/enable.yml
@@ -187,6 +187,9 @@
     build_from: "{{ _instance_result.instance.buildFrom | default(omit) }}"
     state: present
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Set dev mode fact
   ansible.builtin.set_fact:

--- a/tests/integration/remote/run_tests.sh
+++ b/tests/integration/remote/run_tests.sh
@@ -31,6 +31,7 @@ SSH_USER="testuser"
 # Use a hostname alias that SSH config maps to localhost:2222
 SSH_HOST="canasta-test-remote"
 INSTANCE_ID="remote-test"
+export CANASTA_TEST_DATA="${CANASTA_TEST_DATA:-/tmp/canasta-test-data}"
 
 # Use a temporary config dir for test isolation
 export CANASTA_CONFIG_DIR
@@ -92,7 +93,7 @@ echo ""
 
 # --- Test 1: Create with -H ---
 echo "Test 1: canasta create with -H"
-if canasta -H "${REMOTE_HOST}" create -i "${INSTANCE_ID}" -w main -n localhost 2>&1; then
+if canasta -H "${REMOTE_HOST}" create -i "${INSTANCE_ID}" -w main -n localhost -p "${CANASTA_TEST_DATA}" 2>&1; then
     pass "create with -H"
 else
     fail "create with -H"

--- a/tests/integration/remote/setup.sh
+++ b/tests/integration/remote/setup.sh
@@ -21,16 +21,23 @@ cat > "${OVERRIDE}" <<OVEOF
 services:
   remote-host:
     volumes:
-      - ${CANASTA_TEST_DATA}:/home/testuser
+      # Mount at the SAME path so Docker bind mounts from the instance
+      # resolve identically on both the host and inside this container.
+      - ${CANASTA_TEST_DATA}:${CANASTA_TEST_DATA}
+    environment:
+      - HOME=${CANASTA_TEST_DATA}
 OVEOF
 
 # Build and start the container
 echo "Building and starting container..."
 docker compose -f "${SCRIPT_DIR}/docker-compose.yml" -f "${OVERRIDE}" up -d --build
 
-# Create .ssh directory (the shared volume mount overwrites /home/testuser)
+# Change testuser's home to the shared data path so sshd finds authorized_keys
+docker exec "${CONTAINER_NAME}" usermod -d "${CANASTA_TEST_DATA}" testuser
+
+# Create .ssh directory in the shared data path
 docker exec "${CONTAINER_NAME}" bash -c \
-    "mkdir -p /home/testuser/.ssh && chmod 700 /home/testuser/.ssh && chown testuser:testuser /home/testuser/.ssh"
+    "mkdir -p ${CANASTA_TEST_DATA}/.ssh && chmod 700 ${CANASTA_TEST_DATA}/.ssh && chown testuser:testuser ${CANASTA_TEST_DATA}/.ssh"
 
 # Create canasta config directory
 docker exec "${CONTAINER_NAME}" bash -c \
@@ -44,9 +51,9 @@ ssh-keygen -t ed25519 -f "${KEY_FILE}" -N "" -q
 
 # Copy public key into container
 echo "Installing public key in container..."
-docker cp "${KEY_FILE}.pub" "${CONTAINER_NAME}:/home/testuser/.ssh/authorized_keys"
-docker exec "${CONTAINER_NAME}" chown testuser:testuser /home/testuser/.ssh/authorized_keys
-docker exec "${CONTAINER_NAME}" chmod 600 /home/testuser/.ssh/authorized_keys
+docker cp "${KEY_FILE}.pub" "${CONTAINER_NAME}:${CANASTA_TEST_DATA}/.ssh/authorized_keys"
+docker exec "${CONTAINER_NAME}" chown testuser:testuser "${CANASTA_TEST_DATA}/.ssh/authorized_keys"
+docker exec "${CONTAINER_NAME}" chmod 600 "${CANASTA_TEST_DATA}/.ssh/authorized_keys"
 
 # Make the Docker socket accessible to testuser.
 # On macOS the socket may have a different GID, so chmod is more reliable.


### PR DESCRIPTION
## Summary
After `switch_connection.yml` changes `ansible_connection` to `ssh`, any `delegate_to: localhost` without explicit `vars: { ansible_connection: local }` inherits the SSH connection and fails. Fixed 29 occurrences across 13 files.

### Files fixed:
- `roles/create/tasks/main.yml` (3 calls)
- `roles/devmode/tasks/enable.yml` (1 call)
- `roles/devmode/tasks/disable.yml` (1 call)
- `playbooks/list.yml` (2 calls)
- `playbooks/upgrade.yml` (1 call)
- `playbooks/_pull_latest_playbooks.yml` (7 calls)
- `playbooks/host_list.yml` (1 call)
- `playbooks/host_remove.yml` (2 calls)
- `playbooks/host_add.yml` (3 calls)
- `playbooks/version.yml` (5 calls)
- `playbooks/storage_setup_nfs.yml` (1 call)
- `playbooks/storage_setup_efs.yml` (1 call)
- `playbooks/create.yml` (1 call — rescue block)

## Test plan
- [x] All 282 unit tests pass
- [ ] `canasta -H user@remote create` works
- [ ] `canasta list` works with remote instances