### PR TITLE
Fix list showing NOT FOUND for remote instances

### DIFF
--- a/playbooks/list.yml
+++ b/playbooks/list.yml
@@ -56,7 +56,10 @@
 
     - name: Build directory existence map
       ansible.builtin.set_fact:
-        _dir_exists: "{{ _dir_exists | default({}) | combine({item.item.key: (item.stat.exists | default(false))}) }}"
+        _dir_exists: >-
+          {{ _dir_exists | default({}) | combine({
+            item.item.key: item.stat.exists | default(false)
+          }) }}
       loop: "{{ _list_dir_checks.results }}"
       loop_control:
         label: "{{ item.item.key | default('?') }}"
@@ -119,10 +122,23 @@
       ignore_errors: true
       when: item.value.orchestrator | default('compose') in ['kubernetes', 'k8s']
 
+    - name: Combine running status results
+      ansible.builtin.set_fact:
+        _all_running_results: >-
+          {{ (_list_running_results.results | default([])
+              + _list_k8s_running_results.results | default([]))
+             | selectattr('item', 'defined') | list }}
+
     - name: Build running status map
       ansible.builtin.set_fact:
-        _running_map: "{{ _running_map | default({}) | combine({item.item.key: (item.rc == 0 and item.stdout | default('') | trim | length > 0 and item.stdout | trim != '0')}) }}"
-      loop: "{{ (_list_running_results.results | default([]) + _list_k8s_running_results.results | default([])) | selectattr('item', 'defined') | list }}"
+        _running_map: >-
+          {{ _running_map | default({}) | combine({
+            item.item.key:
+              (item.rc == 0
+               and item.stdout | default('') | trim | length > 0
+               and item.stdout | trim != '0')
+          }) }}
+      loop: "{{ _all_running_results }}"
       loop_control:
         label: "{{ item.item.key | default('?') }}"
       when: item is not skipped

--- a/playbooks/list.yml
+++ b/playbooks/list.yml
@@ -56,14 +56,11 @@
 
     - name: Build directory existence map
       ansible.builtin.set_fact:
-        _dir_exists: >-
-          {{ _dir_exists | default({}) | combine({
-            item.item.key: (item.stat.exists | default(false))
-          }) }}
+        _dir_exists: "{{ _dir_exists | default({}) | combine({item.item.key: (item.stat.exists | default(false))}) }}"
       loop: "{{ _list_dir_checks.results }}"
       loop_control:
         label: "{{ item.item.key | default('?') }}"
-      when: item is not skipped and item is not failed
+      when: item is not skipped
 
     - name: Read wikis for each instance
       canasta_wikis_yaml:
@@ -124,13 +121,8 @@
 
     - name: Build running status map
       ansible.builtin.set_fact:
-        _running_map: >-
-          {{ _running_map | default({}) | combine({
-            item.item.key: (item.rc == 0 and item.stdout | default('') | trim | length > 0 and item.stdout | trim != '0')
-          }) }}
-      loop: >-
-        {{ (_list_running_results.results | default([]) + _list_k8s_running_results.results | default([]))
-           | selectattr('item', 'defined') | list }}
+        _running_map: "{{ _running_map | default({}) | combine({item.item.key: (item.rc == 0 and item.stdout | default('') | trim | length > 0 and item.stdout | trim != '0')}) }}"
+      loop: "{{ (_list_running_results.results | default([]) + _list_k8s_running_results.results | default([])) | selectattr('item', 'defined') | list }}"
       loop_control:
         label: "{{ item.item.key | default('?') }}"
       when: item is not skipped


### PR DESCRIPTION
## Summary
`canasta list` showed `NOT FOUND` for remote instances even when the
directory exists and containers are running. The `stat` check succeeded
(visible in verbose output) but the directory existence map wasn't
being used correctly by the display template.

Changed `_dir_exists` and `_running_map` `set_fact` from `>-` folded
scalar to inline quoted format to ensure dict values are proper
booleans, not strings.

## Test plan
- [ ] `canasta list` shows correct status for remote instances
- [ ] `canasta list` shows correct status for local instances