### PR TITLE
Fix list and exec for remote instances: use SSH instead of delegate_to

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -307,7 +307,12 @@ def handle_interactive_exec(args):
                 " ".join(shlex.quote(a) for a in docker_cmd),
             )
             try:
-                ssh_args = ["ssh", "-t", host, remote_cmd]
+                ssh_args = ["ssh", "-t"]
+                # Include any custom SSH args (e.g. from ANSIBLE_SSH_ARGS)
+                extra_ssh = os.environ.get("ANSIBLE_SSH_ARGS", "")
+                if extra_ssh:
+                    ssh_args.extend(extra_ssh.split())
+                ssh_args.extend([host, remote_cmd])
                 os.execvp("ssh", ssh_args)
             except FileNotFoundError:
                 print("Error: ssh not found on PATH", file=sys.stderr)

--- a/playbooks/list.yml
+++ b/playbooks/list.yml
@@ -39,10 +39,16 @@
 - name: Build instance list with wiki details
   when: _all_instances.instances | length > 0
   block:
+    - name: Build SSH args from config
+      ansible.builtin.set_fact:
+        _ssh_extra: >-
+          {{ lookup('env', 'ANSIBLE_SSH_ARGS')
+             | default('-o StrictHostKeyChecking=accept-new', true) }}
+
     - name: Check instance directories exist
       ansible.builtin.command:
         cmd: >-
-          {{ 'ssh -o StrictHostKeyChecking=accept-new '
+          {{ 'ssh ' + _ssh_extra + ' '
              + (item.value.host | default('localhost'))
              + ' test -d ' + (item.value.path | quote)
              if (item.value.host | default('localhost')) != 'localhost'
@@ -65,7 +71,7 @@
     - name: Read wikis for each instance
       ansible.builtin.command:
         cmd: >-
-          {{ 'ssh -o StrictHostKeyChecking=accept-new '
+          {{ 'ssh ' + _ssh_extra + ' '
              + (item.value.host | default('localhost'))
              + ' cat ' + (item.value.path | quote) + '/config/wikis.yaml'
              if (item.value.host | default('localhost')) != 'localhost'
@@ -93,7 +99,7 @@
     - name: Check running status for each instance
       ansible.builtin.command:
         cmd: >-
-          {{ 'ssh -o StrictHostKeyChecking=accept-new '
+          {{ 'ssh ' + _ssh_extra + ' '
              + (item.value.host | default('localhost'))
              + ' "cd ' + (item.value.path | quote)
              + ' && docker compose ps -q web"'

--- a/playbooks/list.yml
+++ b/playbooks/list.yml
@@ -40,61 +40,73 @@
   when: _all_instances.instances | length > 0
   block:
     - name: Check instance directories exist
-      ansible.builtin.stat:
-        path: "{{ item.value.path }}"
+      ansible.builtin.command:
+        cmd: >-
+          {{ 'ssh -o StrictHostKeyChecking=accept-new '
+             + (item.value.host | default('localhost'))
+             + ' test -d ' + (item.value.path | quote)
+             if (item.value.host | default('localhost')) != 'localhost'
+             else 'test -d ' + (item.value.path | quote) }}
       register: _list_dir_checks
       loop: >-
         {{ _all_instances.instances | dict2items }}
       loop_control:
         label: "{{ item.key }}"
-      delegate_to: "{{ (item.value.host | default('localhost')).split('@') | last }}"
-      vars:
-        ansible_connection: "{{ 'ssh' if (item.value.host | default('localhost')) != 'localhost' else 'local' }}"
-        ansible_user: "{{ (item.value.host | default('')).split('@')[0] if '@' in (item.value.host | default('')) else omit }}"
-        ansible_python_interpreter: "{{ 'auto' if (item.value.host | default('localhost')) != 'localhost' else ansible_playbook_python }}"
+      changed_when: false
       ignore_errors: true
 
     - name: Build directory existence map
-      vars:
-        _exists: "{{ item.stat.exists | default(false) }}"
       ansible.builtin.set_fact:
-        _dir_exists: "{{ _dir_exists | default({}) | combine({item.item.key: _exists}) }}"
+        _dir_exists: "{{ _dir_exists | default({}) | combine({item.item.key: (item.rc == 0)}) }}"
       loop: "{{ _list_dir_checks.results }}"
       loop_control:
         label: "{{ item.item.key | default('?') }}"
-      when: item is not skipped
 
     - name: Read wikis for each instance
-      canasta_wikis_yaml:
-        instance_path: "{{ item.value.path }}"
-        state: read
-      register: _list_wikis
+      ansible.builtin.command:
+        cmd: >-
+          {{ 'ssh -o StrictHostKeyChecking=accept-new '
+             + (item.value.host | default('localhost'))
+             + ' cat ' + (item.value.path | quote) + '/config/wikis.yaml'
+             if (item.value.host | default('localhost')) != 'localhost'
+             else 'cat ' + (item.value.path | quote) + '/config/wikis.yaml' }}
+      register: _list_wikis_raw
       loop: >-
         {{ _all_instances.instances | dict2items }}
       loop_control:
         label: "{{ item.key }}"
-      delegate_to: "{{ (item.value.host | default('localhost')).split('@') | last }}"
-      vars:
-        ansible_connection: "{{ 'ssh' if (item.value.host | default('localhost')) != 'localhost' else 'local' }}"
-        ansible_user: "{{ (item.value.host | default('')).split('@')[0] if '@' in (item.value.host | default('')) else omit }}"
-        ansible_python_interpreter: "{{ 'auto' if (item.value.host | default('localhost')) != 'localhost' else ansible_playbook_python }}"
+      changed_when: false
       ignore_errors: true
       when: (_dir_exists | default({}))[item.key] | default(false)
 
+    - name: Parse wikis from YAML output
+      ansible.builtin.set_fact:
+        _list_wikis_map: >-
+          {{ _list_wikis_map | default({}) | combine({
+            item.item.key: (item.stdout | from_yaml).wikis | default([])
+          }) }}
+      loop: "{{ _list_wikis_raw.results | default([]) }}"
+      loop_control:
+        label: "{{ item.item.key | default('?') }}"
+      when: item is not skipped and item.rc == 0
+
     - name: Check running status for each instance
       ansible.builtin.command:
-        cmd: "docker compose ps -q web"
-        chdir: "{{ item.value.path }}"
+        cmd: >-
+          {{ 'ssh -o StrictHostKeyChecking=accept-new '
+             + (item.value.host | default('localhost'))
+             + ' "cd ' + (item.value.path | quote)
+             + ' && docker compose ps -q web"'
+             if (item.value.host | default('localhost')) != 'localhost'
+             else 'docker compose ps -q web' }}
+        chdir: "{{ item.value.path
+                   if (item.value.host | default('localhost')) == 'localhost'
+                   else omit }}"
       register: _list_running_results
       loop: >-
         {{ _all_instances.instances | dict2items }}
       loop_control:
         label: "{{ item.key }}"
-      delegate_to: "{{ (item.value.host | default('localhost')).split('@') | last }}"
-      vars:
-        ansible_connection: "{{ 'ssh' if (item.value.host | default('localhost')) != 'localhost' else 'local' }}"
-        ansible_user: "{{ (item.value.host | default('')).split('@')[0] if '@' in (item.value.host | default('')) else omit }}"
-        ansible_python_interpreter: "{{ 'auto' if (item.value.host | default('localhost')) != 'localhost' else ansible_playbook_python }}"
       changed_when: false
       ignore_errors: true
       when:
@@ -112,14 +124,11 @@
         {{ _all_instances.instances | dict2items }}
       loop_control:
         label: "{{ item.key }}"
-      delegate_to: "{{ (item.value.host | default('localhost')).split('@') | last }}"
-      vars:
-        ansible_connection: "{{ 'ssh' if (item.value.host | default('localhost')) != 'localhost' else 'local' }}"
-        ansible_user: "{{ (item.value.host | default('')).split('@')[0] if '@' in (item.value.host | default('')) else omit }}"
-        ansible_python_interpreter: "{{ 'auto' if (item.value.host | default('localhost')) != 'localhost' else ansible_playbook_python }}"
       changed_when: false
       ignore_errors: true
-      when: item.value.orchestrator | default('compose') in ['kubernetes', 'k8s']
+      when: >-
+        item.value.orchestrator | default('compose')
+        in ['kubernetes', 'k8s']
 
     - name: Combine running status results
       ansible.builtin.set_fact:
@@ -152,8 +161,7 @@
           {% for inst_item in _all_instances.instances | dict2items %}
           {% set inst = inst_item %}
           {% set dir_ok = (_dir_exists | default({}))[inst.key] | default(false) %}
-          {% set wikis_result = _list_wikis.results | selectattr('item.key', 'equalto', inst.key) | list | first | default({}) %}
-          {% set wikis = wikis_result.wikis | default([]) if dir_ok else [] %}
+          {% set wikis = (_list_wikis_map | default({}))[inst.key] | default([]) %}
           {% set running = (_running_map | default({}))[inst.key] | default(false) %}
           {% set status = "running" if running else ("not found" if not dir_ok else "stopped") %}
           {% set orch = (inst.value.orchestrator | default('compose')) | upper %}

--- a/tests/integration/remote/run_tests.sh
+++ b/tests/integration/remote/run_tests.sh
@@ -100,13 +100,17 @@ else
 fi
 echo ""
 
-# --- Test 2: List (verify instance appears) ---
-echo "Test 2: canasta list (instance should appear)"
+# --- Test 2: List (verify instance appears with correct status) ---
+echo "Test 2: canasta list (instance should appear as RUNNING)"
 LIST_OUTPUT=$(canasta list 2>&1) || true
-if echo "${LIST_OUTPUT}" | grep -q "${INSTANCE_ID}"; then
-    pass "list shows remote instance"
+if ! echo "${LIST_OUTPUT}" | grep -q "${INSTANCE_ID}"; then
+    fail "list doesn't show remote instance (output: ${LIST_OUTPUT})"
+elif echo "${LIST_OUTPUT}" | grep -q "NOT FOUND"; then
+    fail "list shows NOT FOUND instead of RUNNING (output: ${LIST_OUTPUT})"
+elif echo "${LIST_OUTPUT}" | grep -q "RUNNING"; then
+    pass "list shows remote instance as RUNNING"
 else
-    fail "list shows remote instance (output: ${LIST_OUTPUT})"
+    fail "list shows unexpected status (output: ${LIST_OUTPUT})"
 fi
 echo ""
 

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -235,6 +235,12 @@ def test_lifecycle(inst):
     print("Listing instances...")
     output = inst.run_quiet("list")
     assert inst.id in output, "Instance not in list output"
+    assert "NOT FOUND" not in output, (
+        "Instance shows NOT FOUND instead of running status:\n%s" % output
+    )
+    assert "RUNNING" in output, (
+        "Instance should show RUNNING status:\n%s" % output
+    )
 
 
 def test_import_export(inst):


### PR DESCRIPTION
## Summary
`canasta list` showed `NOT FOUND` for remote instances because
`delegate_to` with `vars:` in loops doesn't reliably override the
connection inside `canasta-docker`. The stat check ran locally
(where the path doesn't exist) instead of on the remote host.

### Changes
- **list.yml**: Replace all `delegate_to` with direct SSH commands
  for remote hosts. Use `ANSIBLE_SSH_ARGS` env var for SSH config
  (needed for remote tests with non-standard ports).
- **canasta.py**: `handle_interactive_exec` SSH call also uses
  `ANSIBLE_SSH_ARGS` for consistency.
- **Integration tests**: Add RUNNING/NOT FOUND assertions to both
  remote and local lifecycle list checks.

### Root cause
`delegate_to` with `vars:` on loop items doesn't override connection
settings when the play host is `localhost` inside `canasta-docker`.
The `set_fact` approach (used by upgrade, delete) works because it
changes the play host's connection vars directly. For `list` which
loops over multiple instances, direct SSH commands are the reliable
approach.

## Test plan
- [x] Local test: `canasta list` shows RUNNING for remote instance
- [x] Local test: wikis displayed correctly
- [ ] Remote integration test passes (list shows RUNNING)
- [ ] Local integration test passes (list shows RUNNING)