### PR TITLE
Show docker/native in version output; fix create deregistering existing instances

### DIFF
--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -5,6 +5,22 @@
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/validate_wiki_id.yml"
   when: wiki is defined and wiki != ''
 
+- name: Check instance does not already exist
+  canasta_registry:
+    id: "{{ id }}"
+    state: query
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
+  register: _pre_check
+  ignore_errors: true
+
+- name: Fail early if instance already exists
+  ansible.builtin.fail:
+    msg: "Instance '{{ id }}' already exists at {{ _pre_check.instance.path }}"
+  when: _pre_check is succeeded
+
 - name: Create Canasta instance
   block:
     - name: Run create role

--- a/playbooks/version.yml
+++ b/playbooks/version.yml
@@ -83,5 +83,6 @@
     msg: >-
       Canasta CLI
       v{{ _version_file.content | b64decode | trim }}
-      (commit {{ _version_commit | default('unknown') }},
+      ({{ 'docker' if _build_commit_file.stat.exists else 'native' }},
+      commit {{ _version_commit | default('unknown') }},
       built {{ _version_date | default('unknown') }})


### PR DESCRIPTION
## Summary

### Version install type
Adds `docker` or `native` to the version string:
- `Canasta CLI v4.0.0 (docker, commit abc1234, built ...)`
- `Canasta CLI v4.0.0 (native, commit abc1234, built ...)`

### Fix create deregistering existing instances
When `canasta create` is called with an ID that already exists, it
correctly fails with an error. But the `rescue` block in create.yml
then runs cleanup which deregisters the existing instance from
conf.json. Moved the existence check before the block/rescue so
it fails without triggering cleanup.

## Test plan
- [ ] `canasta version` shows docker or native
- [ ] `canasta create -i existing-id` fails without modifying conf.json