### PR TITLE
Fix wikis.yaml omitting HTTP_PORT when CADDY_AUTO_HTTPS=off

### DIFF
--- a/roles/common/library/canasta_wikis_yaml.py
+++ b/roles/common/library/canasta_wikis_yaml.py
@@ -109,11 +109,11 @@ def parse_url(url):
     return server, path
 
 
-def update_url_port(url, new_port):
-    """Update the port in a wiki URL. Matches Go updateURLPort().
+def update_url_port(url, new_port, default_port="443"):
+    """Update the port in a wiki URL.
 
-    Strips existing port, adds new port unless it's 443.
-    Preserves path component.
+    Strips existing port, adds new port unless it equals default_port.
+    Preserves path component. default_port is "443" for HTTPS or "80" for HTTP.
     """
     domain = url
     path = ""
@@ -127,8 +127,8 @@ def update_url_port(url, new_port):
     if colon_idx != -1:
         domain = domain[:colon_idx]
 
-    # Add new port unless standard HTTPS
-    if new_port != "443":
+    # Add new port unless it's the default for the scheme
+    if new_port != default_port:
         domain = "%s:%s" % (domain, new_port)
 
     return domain + path
@@ -186,6 +186,7 @@ def run_module():
         wiki_path=dict(type="str", required=False),
         site_name=dict(type="str", required=False),
         port=dict(type="str", required=False),
+        default_port=dict(type="str", required=False, default="443"),
     )
 
     module = AnsibleModule(
@@ -200,6 +201,7 @@ def run_module():
     wiki_path = module.params.get("wiki_path")
     site_name = module.params.get("site_name")
     port = module.params.get("port")
+    default_port = module.params.get("default_port") or "443"
 
     result = {"changed": False}
 
@@ -289,7 +291,7 @@ def run_module():
         updated = []
         for w in wikis:
             w = dict(w)
-            w["url"] = update_url_port(w.get("url", ""), port)
+            w["url"] = update_url_port(w.get("url", ""), port, default_port)
             updated.append(w)
         if not module.check_mode:
             write_wikis(instance_path, updated)

--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -17,47 +17,67 @@
     - _config_value | regex_search('^[0-9]+$') is not none
     - _config_value | int < 1 or _config_value | int > 65535
 
-- name: Apply HTTPS_PORT side effects
-  when: _config_key == 'HTTPS_PORT'
+- name: Apply HTTP_PORT/HTTPS_PORT side effects
+  when: _config_key in ['HTTP_PORT', 'HTTPS_PORT']
   block:
-    - name: Read wikis.yaml for port update
-      canasta_wikis_yaml:
-        instance_path: "{{ instance_path }}"
+    - name: Read CADDY_AUTO_HTTPS to determine active scheme
+      canasta_env:
+        path: "{{ instance_path }}/.env"
         state: read
-      register: _se_wikis
+        key: CADDY_AUTO_HTTPS
+      register: _se_caddy_auto_https
 
-    - name: Extract domain (strip path and existing port)
+    - name: Determine active port key for this instance
       ansible.builtin.set_fact:
-        _base_domain: "{{ _se_wikis.wikis[0].url | regex_replace('/.*$', '') | regex_replace(':[0-9]+$', '') }}"
-      when: _se_wikis.wikis | length > 0
+        _active_port_key: "{{ (_se_caddy_auto_https.value | default('on') | lower == 'off') | ternary('HTTP_PORT', 'HTTPS_PORT') }}"
+        _active_scheme: "{{ (_se_caddy_auto_https.value | default('on') | lower == 'off') | ternary('http', 'https') }}"
+        _default_port: "{{ (_se_caddy_auto_https.value | default('on') | lower == 'off') | ternary('80', '443') }}"
 
-    - name: Compute new domain suffix
-      ansible.builtin.set_fact:
-        _port_suffix: "{{ (_config_value == '443') | ternary('', ':' + _config_value) }}"
-      when: _se_wikis.wikis | length > 0
+    # Only the "active" port (HTTP_PORT when http-only, HTTPS_PORT otherwise)
+    # is reflected in wikis.yaml and MW_SITE_*. Changing the inactive port
+    # only affects docker port mappings.
+    - name: Apply wikis.yaml/.env updates for active port
+      when: _config_key == _active_port_key
+      block:
+        - name: Read wikis.yaml for port update
+          canasta_wikis_yaml:
+            instance_path: "{{ instance_path }}"
+            state: read
+          register: _se_wikis
 
-    - name: Update wikis.yaml URLs with new port
-      canasta_wikis_yaml:
-        instance_path: "{{ instance_path }}"
-        state: update_port
-        port: "{{ _config_value }}"
-      when: _se_wikis.wikis | length > 0
+        - name: Extract domain (strip path and existing port)
+          ansible.builtin.set_fact:
+            _base_domain: "{{ _se_wikis.wikis[0].url | regex_replace('/.*$', '') | regex_replace(':[0-9]+$', '') }}"
+          when: _se_wikis.wikis | length > 0
 
-    - name: Update MW_SITE_SERVER with new port
-      canasta_env:
-        path: "{{ instance_path }}/.env"
-        state: set
-        key: MW_SITE_SERVER
-        value: "https://{{ _base_domain }}{{ _port_suffix }}"
-      when: _se_wikis.wikis | length > 0
+        - name: Compute new domain suffix
+          ansible.builtin.set_fact:
+            _port_suffix: "{{ (_config_value == _default_port) | ternary('', ':' + _config_value) }}"
+          when: _se_wikis.wikis | length > 0
 
-    - name: Update MW_SITE_FQDN with new port (domain only, no scheme)
-      canasta_env:
-        path: "{{ instance_path }}/.env"
-        state: set
-        key: MW_SITE_FQDN
-        value: "{{ _base_domain }}{{ _port_suffix }}"
-      when: _se_wikis.wikis | length > 0
+        - name: Update wikis.yaml URLs with new port
+          canasta_wikis_yaml:
+            instance_path: "{{ instance_path }}"
+            state: update_port
+            port: "{{ _config_value }}"
+            default_port: "{{ _default_port }}"
+          when: _se_wikis.wikis | length > 0
+
+        - name: Update MW_SITE_SERVER with new port
+          canasta_env:
+            path: "{{ instance_path }}/.env"
+            state: set
+            key: MW_SITE_SERVER
+            value: "{{ _active_scheme }}://{{ _base_domain }}{{ _port_suffix }}"
+          when: _se_wikis.wikis | length > 0
+
+        - name: Update MW_SITE_FQDN with new port (domain only, no scheme)
+          canasta_env:
+            path: "{{ instance_path }}/.env"
+            state: set
+            key: MW_SITE_FQDN
+            value: "{{ _base_domain }}{{ _port_suffix }}"
+          when: _se_wikis.wikis | length > 0
 
 # Kubernetes port changes: Ingress handles port routing, no cluster
 # recreation needed. The change takes effect on next helm upgrade.

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -206,13 +206,23 @@
     state: read_all
   register: _env_for_port
 
-- name: Build domain with port (matches Go BuildDomainWithPort)
+- name: Determine which port (if any) to append to the domain
+  ansible.builtin.set_fact:
+    _http_only: "{{ _env_for_port.variables.CADDY_AUTO_HTTPS | default('on') | lower == 'off' }}"
+    _https_port: "{{ _env_for_port.variables.HTTPS_PORT | default('443') }}"
+    _http_port: "{{ _env_for_port.variables.HTTP_PORT | default('80') }}"
+
+- name: Build domain with port
+  # When CADDY_AUTO_HTTPS=off, append HTTP_PORT (if non-standard).
+  # Otherwise, append HTTPS_PORT (if non-standard).
   ansible.builtin.set_fact:
     _domain_with_port: >-
       {{ domain_name | default('localhost') }}{{
-        (_env_for_port.variables.CADDY_AUTO_HTTPS | default('on') | lower != 'off'
-         and _env_for_port.variables.HTTPS_PORT | default('443') not in ['443', ''])
-        | ternary(':' ~ _env_for_port.variables.HTTPS_PORT | default('443'), '') }}
+        _http_only
+        | ternary(
+            (_http_port not in ['80', '']) | ternary(':' ~ _http_port, ''),
+            (_https_port not in ['443', '']) | ternary(':' ~ _https_port, '')
+          ) }}
 
 # --- Step 8: Create wikis.yaml ---
 - name: Copy user-provided wikis.yaml

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -151,7 +151,10 @@ def wait_for_wiki_at_path(http_port, api_path="/w/api.php", timeout=300):
         elapsed = int(time.time() + timeout - deadline)
         try:
             req = urllib.request.Request(api_url)
-            req.add_header("Host", "localhost")
+            # Match the URL stored in wikis.yaml so FarmConfigLoader routes
+            # correctly. Tests use non-standard HTTP_PORT with
+            # CADDY_AUTO_HTTPS=off, so wikis.yaml stores localhost:<port>.
+            req.add_header("Host", "localhost:%s" % http_port)
             with urllib.request.urlopen(req, timeout=10) as resp:
                 data = json.loads(resp.read())
                 if "query" in data:
@@ -188,7 +191,7 @@ def query_siteinfo(http_port, siprop, api_path="/w/api.php"):
         % (http_port, api_path, siprop)
     )
     req = urllib.request.Request(api_url)
-    req.add_header("Host", "localhost")
+    req.add_header("Host", "localhost:%s" % http_port)
     with urllib.request.urlopen(req, timeout=30) as resp:
         return json.loads(resp.read())
 
@@ -550,7 +553,7 @@ def test_wiki_farm(inst):
 
 
 def test_config_side_effects(inst):
-    """Verify config set side effects (port changes update wikis.yaml and Caddyfile)."""
+    """Verify config set side effects (port changes update wikis.yaml and .env)."""
     print("Creating instance...")
     inst.run_ok(
         "create", "-i", inst.id, "-w", "main",
@@ -559,13 +562,16 @@ def test_config_side_effects(inst):
     )
     wait_for_wiki(inst.http_port)
 
-    print("Setting HTTPS_PORT to 9443...")
+    # Test instance uses CADDY_AUTO_HTTPS=off, so HTTP_PORT is the active
+    # port (the one reflected in wikis.yaml and MW_SITE_SERVER).
+    new_http_port = "9080"
+    print("Setting HTTP_PORT to %s..." % new_http_port)
     inst.run_ok(
         "config", "set", "-i", inst.id,
-        "HTTPS_PORT=9443", "--no-restart",
+        "HTTP_PORT=%s" % new_http_port, "--no-restart",
     )
 
-    print("Checking wikis.yaml for port 9443...")
+    print("Checking wikis.yaml for port %s..." % new_http_port)
     wikis_yaml_path = os.path.join(
         inst.instance_path(), "config", "wikis.yaml",
     )
@@ -574,39 +580,44 @@ def test_config_side_effects(inst):
     )
     with open(wikis_yaml_path) as f:
         wikis_content = f.read()
-    assert ":9443" in wikis_content, (
-        "Port 9443 not found in wikis.yaml:\n%s" % wikis_content
+    assert (":%s" % new_http_port) in wikis_content, (
+        "Port %s not found in wikis.yaml:\n%s"
+        % (new_http_port, wikis_content)
     )
 
     # Note: The Caddyfile intentionally strips ports from server names.
     # Caddy binds to ports 80/443 inside the container; Docker maps the
-    # external HTTPS_PORT to container port 443. So the Caddyfile just
+    # external HTTP_PORT to container port 80. So the Caddyfile just
     # needs the domain, and the port change is verified via wikis.yaml
     # and MW_SITE_SERVER in .env.
     print("Checking MW_SITE_SERVER in .env...")
     env = read_env(inst.env_path())
-    assert "9443" in env.get("MW_SITE_SERVER", ""), (
-        "MW_SITE_SERVER should contain port 9443: %s" % env.get("MW_SITE_SERVER")
+    assert new_http_port in env.get("MW_SITE_SERVER", ""), (
+        "MW_SITE_SERVER should contain port %s: %s"
+        % (new_http_port, env.get("MW_SITE_SERVER"))
     )
-    assert "9443" in env.get("MW_SITE_FQDN", ""), (
-        "MW_SITE_FQDN should contain port 9443: %s" % env.get("MW_SITE_FQDN")
+    assert new_http_port in env.get("MW_SITE_FQDN", ""), (
+        "MW_SITE_FQDN should contain port %s: %s"
+        % (new_http_port, env.get("MW_SITE_FQDN"))
     )
 
-    print("Resetting HTTPS_PORT to 443...")
+    print("Resetting HTTP_PORT to 80...")
     inst.run_ok(
         "config", "set", "-i", inst.id,
-        "HTTPS_PORT=443", "--no-restart",
+        "HTTP_PORT=80", "--no-restart",
     )
 
     print("Verifying port reset...")
     with open(wikis_yaml_path) as f:
         wikis_content = f.read()
-    assert ":9443" not in wikis_content, (
-        "Port 9443 still in wikis.yaml after reset:\n%s" % wikis_content
+    assert (":%s" % new_http_port) not in wikis_content, (
+        "Port %s still in wikis.yaml after reset:\n%s"
+        % (new_http_port, wikis_content)
     )
     env = read_env(inst.env_path())
-    assert "9443" not in env.get("MW_SITE_SERVER", ""), (
-        "MW_SITE_SERVER still has 9443 after reset: %s" % env.get("MW_SITE_SERVER")
+    assert new_http_port not in env.get("MW_SITE_SERVER", ""), (
+        "MW_SITE_SERVER still has %s after reset: %s"
+        % (new_http_port, env.get("MW_SITE_SERVER"))
     )
 
 

--- a/tests/unit/test_canasta_wikis_yaml.py
+++ b/tests/unit/test_canasta_wikis_yaml.py
@@ -150,6 +150,33 @@ class TestUpdateUrlPort:
     def test_no_change_needed(self):
         assert canasta_wikis_yaml.update_url_port("example.com", "443") == "example.com"
 
+    # default_port: HTTP scheme uses 80 as the implicit default
+    def test_http_standard_port_stripped(self):
+        assert canasta_wikis_yaml.update_url_port(
+            "example.com:9080", "80", default_port="80"
+        ) == "example.com"
+
+    def test_http_nonstandard_port_appended(self):
+        assert canasta_wikis_yaml.update_url_port(
+            "example.com", "8080", default_port="80"
+        ) == "example.com:8080"
+
+    def test_http_port_replaced(self):
+        assert canasta_wikis_yaml.update_url_port(
+            "example.com:8080", "9080", default_port="80"
+        ) == "example.com:9080"
+
+    def test_http_preserves_path_standard_port(self):
+        assert canasta_wikis_yaml.update_url_port(
+            "example.com:8080/docs", "80", default_port="80"
+        ) == "example.com/docs"
+
+    def test_http_443_kept_when_default_is_80(self):
+        # 443 is non-standard for HTTP scheme, so it should be appended
+        assert canasta_wikis_yaml.update_url_port(
+            "example.com", "443", default_port="80"
+        ) == "example.com:443"
+
 
 class TestUpdateUrlDomain:
     def test_simple_domain_change(self):


### PR DESCRIPTION
Fixes #30.

## Problem

When creating an instance with a non-standard HTTP port and HTTPS disabled (`CADDY_AUTO_HTTPS=off`), the wiki URL stored in `wikis.yaml` omitted the port. `FarmConfigLoader.php` then 404'd browser requests because `Host: localhost:8080` didn't match the bare `localhost` entry.

The same gap existed in `config set` side effects: `HTTPS_PORT` updates propagated to `wikis.yaml`/`MW_SITE_*` but `HTTP_PORT` updates did not.

The bug was hidden from CI because `tests/integration/run_tests.py` overrode the request `Host` header to `localhost`, masking the routing failure that a real browser would hit at `localhost:8080`.

## Changes

- **`roles/create/tasks/main.yml`** — `_domain_with_port` now picks `HTTP_PORT` vs `HTTPS_PORT` based on `CADDY_AUTO_HTTPS`, with the matching default (`80` vs `443`) used to decide whether to append.
- **`roles/config/tasks/_side_effects.yml`** — `HTTP_PORT` and `HTTPS_PORT` side effects merged into one block. Only the "active" port (`HTTP_PORT` when http-only, `HTTPS_PORT` otherwise) is reflected in `wikis.yaml`, `MW_SITE_SERVER` (with the correct scheme), and `MW_SITE_FQDN`. Changing the inactive port only affects docker port mappings.
- **`roles/common/library/canasta_wikis_yaml.py`** — `update_url_port` and the `update_port` state accept a `default_port` parameter (defaults to `"443"` for backward compatibility) so HTTP callers can suppress `:80` the way HTTPS callers suppress `:443`.
- **`tests/integration/run_tests.py`** — `Host` header switched from `localhost` to `localhost:<port>` so tests actually exercise the FarmConfigLoader routing path that real browsers hit. `test_config_side_effects` rewritten to use `HTTP_PORT`, matching the test instances' scheme (`CADDY_AUTO_HTTPS=off`).
- **`tests/unit/test_canasta_wikis_yaml.py`** — 5 new tests covering `update_url_port` with `default_port="80"`.

## Test plan

- [x] Unit tests pass (287 total, 5 new)
- [x] `make validate` passes
- [x] End-to-end verified manually with a fresh `canasta create -e env-with-HTTP_PORT=8080`:
  - `wikis.yaml` correctly contains `localhost:8080`
  - `canasta add -u localhost:8080/second` preserves the port
  - `canasta config set HTTP_PORT=9080` updates `wikis.yaml`, `MW_SITE_SERVER` (`http://localhost:9080`), and `MW_SITE_FQDN`
  - `canasta config set HTTP_PORT=80` strips the port back out of all three locations
  - The wiki actually responds at `http://localhost:8080/wiki/Main_Page` without any manual `Caddyfile` or `wikis.yaml` editing
- [ ] CI integration tests pass