### PR TITLE
Show host in canasta list output

### DIFF
--- a/playbooks/list.yml
+++ b/playbooks/list.yml
@@ -156,14 +156,27 @@
         label: "{{ item.item.key | default('?') }}"
       when: item is not skipped
 
+    - name: Compute host column width
+      vars:
+        # All host strings (default 'localhost'), plus a floor of 16
+        _host_lengths: >-
+          {{ (_all_instances.instances | dict2items
+              | map(attribute='value.host')
+              | map('default', 'localhost', true)
+              | map('length') | list) + [16] }}
+      ansible.builtin.set_fact:
+        # +2 for gutter between Host and Instance Path columns
+        _host_col_width: "{{ (_host_lengths | max) + 2 }}"
+
     - name: Display instances
       ansible.builtin.debug:
         msg: |
+          {% set hw = _host_col_width | int %}
           {% set ns = namespace(lines=[]) %}
-          {% set ns.lines = ns.lines + ["%-16s%-16s%s" % ("Canasta ID", "Orchestrator", "Status")] %}
-          {% set ns.lines = ns.lines + ["  Instance Path"] %}
-          {% set ns.lines = ns.lines + ["  %-14s%s" % ("Wiki ID", "Server Path")] %}
-          {% set ns.lines = ns.lines + ["─" * 50] %}
+          {% set ns.lines = ns.lines + ["%-16s%-*s%s" % ("Canasta ID", hw, "Host", "Instance Path")] %}
+          {% set ns.lines = ns.lines + ["%-16s%-16s%s" % ("", "Orchestrator", "Status")] %}
+          {% set ns.lines = ns.lines + ["  %-14s%s" % ("Wiki ID", "Wiki URL")] %}
+          {% set ns.lines = ns.lines + ["─" * (16 + hw + 20)] %}
           {% for inst_item in _all_instances.instances | dict2items %}
           {% set inst = inst_item %}
           {% set dir_ok = (_dir_exists | default({}))[inst.key] | default(false) %}
@@ -171,8 +184,9 @@
           {% set running = (_running_map | default({}))[inst.key] | default(false) %}
           {% set status = "running" if running else ("not found" if not dir_ok else "stopped") %}
           {% set orch = (inst.value.orchestrator | default('compose')) | upper %}
-          {% set ns.lines = ns.lines + ["%-16s%-16s%s" % (inst.key, orch, status | upper)] %}
-          {% set ns.lines = ns.lines + ["  " + inst.value.path] %}
+          {% set host = inst.value.host | default('localhost') %}
+          {% set ns.lines = ns.lines + ["%-16s%-*s%s" % (inst.key, hw, host, inst.value.path)] %}
+          {% set ns.lines = ns.lines + ["%-16s%-16s%s" % ("", orch, status | upper)] %}
           {% if wikis | length > 0 %}
           {% for w in wikis %}
           {% set url = w.url if '/' in w.url else w.url + '/' %}

--- a/playbooks/list.yml
+++ b/playbooks/list.yml
@@ -174,7 +174,7 @@
           {% set hw = _host_col_width | int %}
           {% set ns = namespace(lines=[]) %}
           {% set ns.lines = ns.lines + ["%-16s%-*s%s" % ("Canasta ID", hw, "Host", "Instance Path")] %}
-          {% set ns.lines = ns.lines + ["%-16s%-16s%s" % ("", "Orchestrator", "Status")] %}
+          {% set ns.lines = ns.lines + ["  %-14s%s" % ("Orchestrator", "Status")] %}
           {% set ns.lines = ns.lines + ["  %-14s%s" % ("Wiki ID", "Wiki URL")] %}
           {% set ns.lines = ns.lines + ["─" * (16 + hw + 20)] %}
           {% for inst_item in _all_instances.instances | dict2items %}
@@ -186,7 +186,7 @@
           {% set orch = (inst.value.orchestrator | default('compose')) | upper %}
           {% set host = inst.value.host | default('localhost') %}
           {% set ns.lines = ns.lines + ["%-16s%-*s%s" % (inst.key, hw, host, inst.value.path)] %}
-          {% set ns.lines = ns.lines + ["%-16s%-16s%s" % ("", orch, status | upper)] %}
+          {% set ns.lines = ns.lines + ["  %-14s%s" % (orch, status | upper)] %}
           {% if wikis | length > 0 %}
           {% for w in wikis %}
           {% set url = w.url if '/' in w.url else w.url + '/' %}


### PR DESCRIPTION
Fixes #32.

## Problem

`canasta list` did not show the **host** each instance lives on. In a multi-host setup managed from a single controller, this made it impossible to tell from the list which host any given instance was on. The "Server Path" column header was also misleading — it's the wiki's URL (host[:port][/path]), not a filesystem path.

## New format

```
Canasta ID      Host                               Instance Path
  Orchestrator  Status
  Wiki ID       Wiki URL
───────────────────────────────────────────────────────────────────────
sebok           wikiworks@migration.wikiworks.com  /home/wikiworks/sebok
  COMPOSE       RUNNING
  main          migration.wikiworks.com/
  draft         migration.wikiworks.com/draft

pge             cicalese@acknowledge.wiki          /home/cicalese/pge
  COMPOSE       RUNNING
  pge           acknowledge.wiki/
```

- **First line per instance:** Canasta ID, Host, Instance Path
- **Second line per instance:** Orchestrator and Status, aligned with the wiki rows below
- **Following lines:** Wiki ID and Wiki URL, one row per wiki

## Notes

- The Host column width is computed dynamically from the longest host in the registry, with a 16-char floor, so `user@host` strings don't overflow into the Instance Path column.
- "Wiki URL" replaces "Server Path". The "Wiki" prefix duplicates the row context on purpose — it reinforces that each row is about an individual wiki.

## Test plan

- [x] Unit tests still pass (282)
- [x] Manually verified with two remote-host instances (sebok, pge) — both show their hosts correctly and the column auto-sizes to fit the longer host
- [x] `test_lifecycle` integration test still satisfied (asserts `RUNNING` and instance ID presence, no specific column layout)
- [ ] CI passes
