### PR TITLE
Make canasta-docker work for local operations on macOS

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -42,18 +42,37 @@ else
 fi
 
 # Detect the docker socket's GID so the container user can access it.
+#
+# On Linux, the host stat is reliable. On macOS Docker Desktop, the
+# host-side symlink reports a different GID (e.g. 1/daemon) than the
+# socket actually has inside Docker Desktop's Linux VM (typically 0/root),
+# so we also probe the socket from inside a throwaway container of the
+# canasta-ansible image when it's already pulled.
+DOCKER_SOCK_GID=""
 if [[ -S "$DOCKER_SOCK_PATH" ]]; then
-    if stat -c '%g' "$DOCKER_SOCK_PATH" >/dev/null 2>&1; then
-        DOCKER_SOCK_GID="$(stat -c '%g' "$DOCKER_SOCK_PATH")"
-    else
-        DOCKER_SOCK_GID="$(stat -f '%g' "$DOCKER_SOCK_PATH")"
+    if docker image inspect "$IMAGE" >/dev/null 2>&1; then
+        DOCKER_SOCK_GID="$(docker run --rm \
+            -v "$DOCKER_SOCK_PATH:/var/run/docker.sock" \
+            --entrypoint stat "$IMAGE" -c '%g' /var/run/docker.sock 2>/dev/null || true)"
     fi
-else
-    DOCKER_SOCK_GID=""
+    if [[ -z "$DOCKER_SOCK_GID" ]]; then
+        if stat -c '%g' "$DOCKER_SOCK_PATH" >/dev/null 2>&1; then
+            DOCKER_SOCK_GID="$(stat -c '%g' "$DOCKER_SOCK_PATH")"
+        else
+            DOCKER_SOCK_GID="$(stat -f '%g' "$DOCKER_SOCK_PATH")"
+        fi
+    fi
 fi
 
 MOUNTS=(
     -v "$DOCKER_SOCK_PATH:/var/run/docker.sock"
+    # Force the in-container docker CLI to use the mounted socket. The
+    # host's $HOME (mounted below) brings $HOME/.docker/config.json with
+    # it; on macOS Docker Desktop that file selects the "desktop-linux"
+    # context, which points docker at a Mac-only socket path that does
+    # not exist inside the container. Setting DOCKER_HOST overrides any
+    # context selection and forces the canonical path.
+    -e "DOCKER_HOST=unix:///var/run/docker.sock"
     -v "$CONFIG_DIR":"$CONFIG_DIR"
     -e "CANASTA_CONFIG_DIR=$CONFIG_DIR"
     -v "$HOME":"$HOME"
@@ -241,6 +260,21 @@ while [[ $i -lt ${#ARGS[@]} ]]; do
                 continue
             fi
             ;;
+        --build-from)
+            if [[ $((i+1)) -lt ${#ARGS[@]} ]]; then
+                BUILD_FROM_ABS="$(to_abs_path "${ARGS[$((i+1))]}")"
+                NEW_ARGS+=("$arg" "$BUILD_FROM_ABS")
+                CWD="$(pwd)"
+                case "$BUILD_FROM_ABS" in
+                    "$CWD"/*|"$CWD") ;; # Already covered
+                    *)
+                        MOUNTS+=(-v "$BUILD_FROM_ABS":"$BUILD_FROM_ABS":ro)
+                        ;;
+                esac
+                i=$((i+2))
+                continue
+            fi
+            ;;
     esac
     NEW_ARGS+=("$arg")
     i=$((i+1))
@@ -251,7 +285,30 @@ set -- ${NEW_ARGS[@]+"${NEW_ARGS[@]}"}
 # $HOME/.ssh by default, and we set HOME to the host user's home).
 # Forward SSH agent if available (so passphrase-protected keys work
 # without prompting inside the container).
+#
+# On macOS, the OS launchd manages the SSH agent socket under
+# /private/tmp/com.apple.launchd.*/Listeners, which Docker Desktop's
+# virtiofs file sharing does not expose by default — bind-mounting
+# that path causes the container to fail to start with
+# "mountpoint ... is outside of rootfs". Detect that case and skip
+# the agent forward; the user can fall back to unencrypted keys or
+# point SSH_AUTH_SOCK at a path under $HOME / inside Docker Desktop's
+# shared paths.
+SSH_FWD_OK=false
 if [[ -n "${SSH_AUTH_SOCK:-}" && -S "$SSH_AUTH_SOCK" ]]; then
+    SSH_FWD_OK=true
+    case "$SSH_AUTH_SOCK" in
+        /private/tmp/com.apple.launchd.*|/var/folders/*)
+            SSH_FWD_OK=false
+            echo "canasta-docker: SSH_AUTH_SOCK is at a path Docker Desktop" \
+                "cannot share ($SSH_AUTH_SOCK); skipping SSH agent forward." \
+                "Passphrase-protected SSH keys will prompt inside the" \
+                "container. To enable agent forwarding, point" \
+                "SSH_AUTH_SOCK at a socket under \$HOME." >&2
+            ;;
+    esac
+fi
+if [[ "$SSH_FWD_OK" == "true" ]]; then
     MOUNTS+=(
         -v "$SSH_AUTH_SOCK:/tmp/ssh-agent.sock"
         -e "SSH_AUTH_SOCK=/tmp/ssh-agent.sock"

--- a/canasta-docker
+++ b/canasta-docker
@@ -50,7 +50,8 @@ fi
 # canasta-ansible image when it's already pulled.
 DOCKER_SOCK_GID=""
 if [[ -S "$DOCKER_SOCK_PATH" ]]; then
-    if docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    if [[ -z "${CANASTA_DOCKER_DRY_RUN:-}" ]] \
+        && docker image inspect "$IMAGE" >/dev/null 2>&1; then
         DOCKER_SOCK_GID="$(docker run --rm \
             -v "$DOCKER_SOCK_PATH:/var/run/docker.sock" \
             --entrypoint stat "$IMAGE" -c '%g' /var/run/docker.sock 2>/dev/null || true)"
@@ -89,7 +90,7 @@ CANASTA_PASSWD="$CONFIG_DIR/.canasta-passwd"
 PASSWD_STALE=false
 if [[ ! -f "$CANASTA_PASSWD" ]]; then
     PASSWD_STALE=true
-else
+elif [[ -z "${CANASTA_DOCKER_DRY_RUN:-}" ]]; then
     # Regenerate if the image changed (after upgrade) or UID changed.
     PASSWD_IMAGE_ID=$(docker inspect --format '{{.Id}}' "$IMAGE" 2>/dev/null || true)
     if [[ -n "$PASSWD_IMAGE_ID" ]] && ! grep -q "# $PASSWD_IMAGE_ID" "$CANASTA_PASSWD" 2>/dev/null; then
@@ -97,9 +98,14 @@ else
     fi
 fi
 if [[ "$PASSWD_STALE" == "true" ]]; then
-    docker run --rm --entrypoint cat "$IMAGE" /etc/passwd > "$CANASTA_PASSWD" 2>/dev/null || true
-    PASSWD_IMAGE_ID=$(docker inspect --format '{{.Id}}' "$IMAGE" 2>/dev/null || true)
-    echo "# $PASSWD_IMAGE_ID" >> "$CANASTA_PASSWD"
+    if [[ -z "${CANASTA_DOCKER_DRY_RUN:-}" ]]; then
+        docker run --rm --entrypoint cat "$IMAGE" /etc/passwd > "$CANASTA_PASSWD" 2>/dev/null || true
+        PASSWD_IMAGE_ID=$(docker inspect --format '{{.Id}}' "$IMAGE" 2>/dev/null || true)
+        echo "# $PASSWD_IMAGE_ID" >> "$CANASTA_PASSWD"
+    else
+        # Stub passwd file for tests so the read-only mount source exists.
+        : > "$CANASTA_PASSWD"
+    fi
 fi
 if ! grep -q "^[^:]*:[^:]*:$(id -u):" "$CANASTA_PASSWD" 2>/dev/null; then
     echo "canasta:x:$(id -u):$(id -g):canasta:$HOME:/bin/sh" >> "$CANASTA_PASSWD"
@@ -385,6 +391,16 @@ fi
 DOCKER_RUN_FLAGS=(-i)
 if [[ -t 0 ]]; then
     DOCKER_RUN_FLAGS+=(-t)
+fi
+
+# Dry-run mode for tests: print the assembled docker run command, one
+# argument per line, and exit. Does not invoke docker.
+if [[ -n "${CANASTA_DOCKER_DRY_RUN:-}" ]]; then
+    printf 'docker\n'
+    for a in run --rm "${DOCKER_RUN_FLAGS[@]}" "${MOUNTS[@]}" "$IMAGE" "$@" ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}; do
+        printf '%s\n' "$a"
+    done
+    exit 0
 fi
 
 exec docker run --rm "${DOCKER_RUN_FLAGS[@]}" \

--- a/tests/unit/test_canasta_docker.py
+++ b/tests/unit/test_canasta_docker.py
@@ -97,13 +97,23 @@ class TestDockerHostOverride:
 class TestBuildFromMount:
     """--build-from path should be auto-mounted into the container."""
 
-    def test_build_from_outside_cwd_is_mounted_ro(self, tmp_path):
-        build_dir = tmp_path / "canasta-build"
-        build_dir.mkdir()
-        argv, _ = run_dry(
-            ["create", "-i", "x", "-w", "main", "--build-from", str(build_dir)],
-        )
-        assert_volume_mount(argv, str(build_dir), str(build_dir), ro=True)
+    def test_build_from_outside_cwd_is_mounted_ro(self, short_tmp):
+        # Use two non-overlapping short_tmp dirs so the wrapper's
+        # "build path is already inside cwd" check doesn't fire.
+        # (On Linux CI, pytest's tmp_path lives under /tmp, so using
+        # the default cwd=/tmp would suppress the redundant mount.)
+        cwd_dir = tempfile.mkdtemp(prefix="cd-cwd-", dir="/tmp")
+        try:
+            build_dir = os.path.join(short_tmp, "canasta-build")
+            os.makedirs(build_dir)
+            argv, _ = run_dry(
+                ["create", "-i", "x", "-w", "main",
+                 "--build-from", build_dir],
+                cwd=cwd_dir,
+            )
+            assert_volume_mount(argv, build_dir, build_dir, ro=True)
+        finally:
+            shutil.rmtree(cwd_dir, ignore_errors=True)
 
     def test_build_from_relative_path_resolved_to_absolute(self, tmp_path):
         build_dir = tmp_path / "canasta-build"

--- a/tests/unit/test_canasta_docker.py
+++ b/tests/unit/test_canasta_docker.py
@@ -1,0 +1,215 @@
+"""Tests for the canasta-docker bash wrapper.
+
+Uses CANASTA_DOCKER_DRY_RUN=1 to make the wrapper print the assembled
+docker run command (one argument per line) instead of executing it.
+This lets us assert on argument parsing and conditional mounts without
+needing a Docker daemon.
+
+Note: macOS limits AF_UNIX paths to 104 bytes, so any test that creates
+real unix sockets uses short paths under /tmp rather than pytest's
+tmp_path fixture (which lives under /private/var/folders/...).
+"""
+
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+
+import pytest
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+WRAPPER = os.path.join(REPO_ROOT, "canasta-docker")
+
+
+@pytest.fixture
+def short_tmp():
+    """A short /tmp-based temporary directory (for AF_UNIX path limits)."""
+    d = tempfile.mkdtemp(prefix="cd-", dir="/tmp")
+    try:
+        yield d
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def run_dry(args, env=None, cwd=None):
+    """Invoke canasta-docker in dry-run mode and return (argv_lines, stderr)."""
+    base_env = os.environ.copy()
+    base_env["CANASTA_DOCKER_DRY_RUN"] = "1"
+    # Isolate per test so the script doesn't touch the user's real registry.
+    if "CANASTA_CONFIG_DIR" not in base_env or not base_env.get(
+        "CANASTA_CONFIG_DIR", ""
+    ).startswith("/tmp/cd-"):
+        base_env["CANASTA_CONFIG_DIR"] = tempfile.mkdtemp(
+            prefix="cd-", dir="/tmp",
+        )
+    if env:
+        base_env.update(env)
+    result = subprocess.run(
+        [WRAPPER] + list(args),
+        env=base_env,
+        cwd=cwd or "/tmp",
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "wrapper failed: rc=%d\nstdout:\n%s\nstderr:\n%s"
+        % (result.returncode, result.stdout, result.stderr)
+    )
+    return result.stdout.splitlines(), result.stderr
+
+
+def assert_env_var(argv, key, value):
+    """Assert that `-e KEY=VALUE` appears in the docker run argv."""
+    target = "%s=%s" % (key, value)
+    found = False
+    for i, a in enumerate(argv):
+        if a == "-e" and i + 1 < len(argv) and argv[i + 1] == target:
+            found = True
+            break
+    assert found, "expected -e %s in argv:\n%s" % (target, "\n".join(argv))
+
+
+def assert_volume_mount(argv, src, dst, ro=False):
+    """Assert that `-v SRC:DST[:ro]` appears in the docker run argv."""
+    target = "%s:%s%s" % (src, dst, ":ro" if ro else "")
+    found = False
+    for i, a in enumerate(argv):
+        if a == "-v" and i + 1 < len(argv) and argv[i + 1] == target:
+            found = True
+            break
+    assert found, "expected -v %s in argv:\n%s" % (target, "\n".join(argv))
+
+
+class TestDockerHostOverride:
+    """Verify the in-container docker CLI is forced to use the mounted socket."""
+
+    def test_docker_host_env_is_set(self):
+        argv, _ = run_dry(["doctor"])
+        assert_env_var(argv, "DOCKER_HOST", "unix:///var/run/docker.sock")
+
+    def test_docker_host_set_for_create(self):
+        argv, _ = run_dry(["create", "-i", "x", "-w", "main"])
+        assert_env_var(argv, "DOCKER_HOST", "unix:///var/run/docker.sock")
+
+
+class TestBuildFromMount:
+    """--build-from path should be auto-mounted into the container."""
+
+    def test_build_from_outside_cwd_is_mounted_ro(self, tmp_path):
+        build_dir = tmp_path / "canasta-build"
+        build_dir.mkdir()
+        argv, _ = run_dry(
+            ["create", "-i", "x", "-w", "main", "--build-from", str(build_dir)],
+        )
+        assert_volume_mount(argv, str(build_dir), str(build_dir), ro=True)
+
+    def test_build_from_relative_path_resolved_to_absolute(self, tmp_path):
+        build_dir = tmp_path / "canasta-build"
+        build_dir.mkdir()
+        # Run with cwd=tmp_path so the relative path resolves there
+        argv, _ = run_dry(
+            ["create", "-i", "x", "-w", "main", "--build-from", "canasta-build"],
+            cwd=str(tmp_path),
+        )
+        # The arg in the rewritten argv list should be absolute
+        bf_idx = argv.index("--build-from")
+        assert argv[bf_idx + 1] == str(build_dir)
+
+    def test_build_from_inside_cwd_not_double_mounted(self, tmp_path):
+        # When --build-from is inside $PWD, the existing $PWD mount covers it
+        # and no extra -v entry should be added for the build path.
+        build_dir = tmp_path / "build"
+        build_dir.mkdir()
+        argv, _ = run_dry(
+            ["create", "-i", "x", "-w", "main", "--build-from", "build"],
+            cwd=str(tmp_path),
+        )
+        # Count how many -v entries reference the build dir as source
+        target = "%s:%s:ro" % (str(build_dir), str(build_dir))
+        v_mounts = [
+            argv[i + 1] for i, a in enumerate(argv)
+            if a == "-v" and i + 1 < len(argv)
+        ]
+        assert target not in v_mounts, (
+            "build dir under cwd should not be double-mounted, found: %s"
+            % v_mounts
+        )
+
+
+class TestSSHAgentForward:
+    """SSH_AUTH_SOCK forwarding should be skipped when the socket lives in
+    a path Docker Desktop's virtiofs cannot share."""
+
+    def test_skipped_when_socket_in_launchd_tmp(self):
+        # Create a real socket at a launchd-style path. /private/tmp is
+        # world-writable on macOS (and a regular dir on Linux), so this
+        # works on both. Path length stays well under the 104-byte
+        # AF_UNIX limit.
+        if not os.path.isdir("/private/tmp"):
+            pytest.skip("/private/tmp not present (non-macOS layout)")
+        launchd_dir = "/private/tmp/com.apple.launchd.CANASTA_TEST"
+        sock_path = launchd_dir + "/Listeners"
+        if os.path.lexists(sock_path):
+            os.remove(sock_path)
+        if os.path.isdir(launchd_dir):
+            shutil.rmtree(launchd_dir)
+        os.makedirs(launchd_dir)
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            srv.bind(sock_path)
+            argv, stderr = run_dry(["doctor"], env={"SSH_AUTH_SOCK": sock_path})
+            forwarded = [
+                argv[i + 1] for i, a in enumerate(argv)
+                if a == "-v" and i + 1 < len(argv)
+                and argv[i + 1].endswith(":/tmp/ssh-agent.sock")
+            ]
+            assert not forwarded, (
+                "expected SSH agent mount to be skipped, found %s"
+                % forwarded
+            )
+            assert "skipping SSH agent forward" in stderr
+        finally:
+            srv.close()
+            shutil.rmtree(launchd_dir, ignore_errors=True)
+
+    def test_forwarded_when_socket_under_short_tmp(self, short_tmp):
+        # A socket at a non-launchd path should be forwarded normally.
+        sock_path = os.path.join(short_tmp, "agent.sock")
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            srv.bind(sock_path)
+            argv, stderr = run_dry(
+                ["doctor"], env={"SSH_AUTH_SOCK": sock_path},
+            )
+            assert_volume_mount(argv, sock_path, "/tmp/ssh-agent.sock")
+            assert_env_var(argv, "SSH_AUTH_SOCK", "/tmp/ssh-agent.sock")
+            assert "skipping SSH agent forward" not in stderr
+        finally:
+            srv.close()
+
+    def test_no_ssh_mount_when_unset(self):
+        argv, stderr = run_dry(["doctor"], env={"SSH_AUTH_SOCK": ""})
+        forwarded = [
+            argv[i + 1] for i, a in enumerate(argv)
+            if a == "-v" and i + 1 < len(argv)
+            and argv[i + 1].endswith(":/tmp/ssh-agent.sock")
+        ]
+        assert not forwarded
+        assert "skipping SSH agent forward" not in stderr
+
+
+class TestArgumentRewriting:
+    """Verify the wrapper rewrites relative -p/-d/--build-from paths to
+    absolute form so the container receives mountable paths."""
+
+    def test_path_arg_resolved_to_absolute(self, tmp_path):
+        target = tmp_path / "instance"
+        target.mkdir()
+        argv, _ = run_dry(
+            ["create", "-i", "x", "-w", "main", "-p", "instance"],
+            cwd=str(tmp_path),
+        )
+        p_idx = argv.index("-p")
+        assert argv[p_idx + 1] == str(target)


### PR DESCRIPTION
Fixes #29.

## Why this only bites local operations

When `canasta-docker` runs against a remote host (`canasta-docker --host prod1 ...`), the play targets the remote via SSH and the `docker info` precondition runs **on the remote host**, not in the canasta-ansible container. The in-container docker daemon is irrelevant for those flows, which is why `canasta-docker` worked fine for several days of remote-host management before this bug surfaced.

The bug only triggers for **local** operations — i.e. when there's no `--host` flag and the play targets `localhost` (== inside the canasta-ansible container). The original reproducer (`canasta create --build-from /tmp/canasta-build` with no `--host`) is exactly that path.

## Root cause

The host's `$HOME` is mounted into the container so that `~/.ssh`, `~/.kube`, and friends are visible. That mount also drags in `~/.docker/contexts/`. On macOS Docker Desktop, the active docker context is `desktop-linux`, which points the docker CLI at `unix:///Users/<user>/.docker/run/docker.sock` — a path that exists on the macOS host but **not** inside the Linux container. The in-container `docker` then reports:

```
ERROR: Cannot connect to the Docker daemon at unix:///Users/<user>/.docker/run/docker.sock.
Is the docker daemon running?
```

even though `/var/run/docker.sock` is mounted correctly. Reproduced on macOS Docker Desktop with `docker context show` returning `desktop-linux`. Switching to `docker context use default` (which points at `/var/run/docker.sock`) makes the bug go away — but most users won't have done that, and Docker Desktop selects `desktop-linux` by default.

## Fix

**Primary fix** — set `DOCKER_HOST=unix:///var/run/docker.sock` in the container env. This overrides any context selection that came in from the host's docker config and forces the in-container CLI to use the canonical mounted socket.

**Defensive: socket GID detection** — on macOS the host-side `stat` of `/var/run/docker.sock` may report a different GID than the socket actually has inside Docker Desktop's Linux VM (host: GID 1/`daemon`; container: GID 0/`root`). The wrapper now probes the GID from inside a throwaway container of the canasta-ansible image (when it's already pulled), falling back to host stat for Linux and first-run cases. Harmless when the host stat is already correct.

**Defensive: skip unshareable SSH agent socket** — on macOS the launchd-managed SSH agent socket lives at `/private/tmp/com.apple.launchd.*/Listeners`. On certain Docker Desktop configurations (depending on file-sharing mode and version), bind-mounting that path fails container start with:

```
runc create failed: ... error mounting "...com.apple.launchd.../Listeners" to rootfs at "/tmp/ssh-agent.sock":
... mountpoint "/run/host_virtiofs/private/tmp/ssh-agent.sock" is outside of rootfs
```

When `SSH_AUTH_SOCK` matches `/private/tmp/com.apple.launchd.*` or `/var/folders/*`, skip the agent forward and print a clear warning. No-op for anyone whose Docker Desktop can mount the path.

**Related: mount `--build-from` source tree** — the wrapper already auto-detects `--path` and `--database` arguments and bind-mounts them so the container can see the referenced files. `--build-from` was missing from that list, so even after fix #1, `canasta create --build-from /some/abs/path` would fail with "Canasta Dockerfile not found" because the source tree wasn't visible inside the container. Added `--build-from` to the same arg-rewrite/mount loop, mounted read-only.

## Test plan

- [x] Unit tests still pass (287)
- [x] On macOS Docker Desktop with `docker context show` = `desktop-linux`: `canasta-docker doctor` now reports `Docker daemon: OK (running)` (previously `NOT RUNNING`)
- [x] `canasta-docker list` succeeds against remote-host instances (sebok, pge) with no env workarounds
- [x] SSH agent forward is gracefully skipped with a clear warning when `SSH_AUTH_SOCK` is in `/private/tmp/com.apple.launchd.*`
- [ ] CI passes
