### PR TITLE
Surface unit test coverage in CI summary and as artifacts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,37 @@ jobs:
             --cov=scripts/validate_definitions.py \
             --cov=canasta.py \
             --cov-report=term-missing \
+            --cov-report=xml:coverage.xml \
+            --cov-report=html:htmlcov \
             --cov-fail-under=70
+
+      - name: Coverage summary
+        if: always() && hashFiles('coverage.xml') != ''
+        run: |
+          # Total as a single integer percentage, plus the per-module
+          # markdown table that coverage.py generates directly.
+          TOTAL=$(.venv/bin/coverage report --format=total)
+          {
+            echo "## Unit Test Coverage: ${TOTAL}%"
+            echo ""
+            .venv/bin/coverage report --format=markdown
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage HTML report
+        if: always() && hashFiles('htmlcov/index.html') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: htmlcov/
+          if-no-files-found: warn
+
+      - name: Upload coverage XML
+        if: always() && hashFiles('coverage.xml') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: warn
 
       - name: Validate command definitions
         run: .venv/bin/python scripts/validate_definitions.py

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ venv/
 docs/commands/*.md
 !docs/commands/.gitkeep
 .coverage
+coverage.xml
+htmlcov/
 
 # Instance data (never commit credentials or test instances)
 *.env


### PR DESCRIPTION
Fixes #35.

## Changes

The Tests workflow already runs `pytest --cov` with a 70% floor, but the result was only visible inside the workflow logs. This PR makes coverage visible at the top of every PR run by adding three things to `.github/workflows/tests.yml`:

1. **Coverage summary** — a new step that writes the total percentage and the per-module markdown table from `coverage report --format=markdown` to `$GITHUB_STEP_SUMMARY`. The table renders inline on the workflow run page.
2. **HTML coverage artifact** — `htmlcov/` uploaded as `coverage-html` so reviewers can download and browse line-by-line annotations from any PR run.
3. **XML coverage artifact** — `coverage.xml` uploaded as `coverage-xml` (also a hook for Codecov/SonarQube later if we want it).

I used `coverage report --format=total` and `--format=markdown` rather than parsing `coverage.xml` ourselves — the table layout already matches what coverage.py recommends, and it avoids the XML-parsing step entirely.

Also gitignored the new local outputs (`coverage.xml`, `htmlcov/`) so they don't show up in `git status` after a local test run.

## Sample step summary output

Running locally against the current main on this branch produces:

```markdown
## Unit Test Coverage: 86%

| Name                                                       |    Stmts |     Miss |   Cover |
|----------------------------------------------------------- | -------: | -------: | ------: |
| roles/common/library/canasta_env.py                        |      113 |       12 |     89% |
| roles/common/library/canasta_farmsettings.py               |       42 |        2 |     95% |
| roles/common/library/canasta_registry.py                   |      191 |       31 |     84% |
| roles/common/library/canasta_wikis_yaml.py                 |      194 |       32 |     84% |
| roles/extensions_skins/library/canasta_settings_yaml.py    |      101 |       10 |     90% |
| **TOTAL**                                                  |  **641** |   **87** | **86%** |
```

## Test plan

- [x] `pytest` command runs locally with `--cov-report=xml --cov-report=html` and produces both `coverage.xml` and `htmlcov/`
- [x] `coverage report --format=total` returns a clean integer
- [x] `coverage report --format=markdown` produces the table shown above
- [x] No production / test code touched — CI-only change
- [ ] CI run on this PR shows the coverage summary on the workflow run page
- [ ] CI run on this PR uploads `coverage-html` and `coverage-xml` artifacts
