### PR TITLE
Add static audit of integration test command coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test-unit test-integration test lint docs validate clean
+.PHONY: test-unit test-integration test lint docs validate audit-coverage clean
 
 VENV := .venv
 PYTHON := $(VENV)/bin/python
@@ -39,6 +39,12 @@ docs: venv
 
 validate: venv
 	$(PYTHON) scripts/validate_definitions.py
+
+# --- Coverage audit ----------------------------------------------------------
+# Static report of which canasta commands have at least one integration
+# test exercising them. Doesn't run any tests; just walks the test source.
+audit-coverage: venv
+	$(PYTHON) scripts/audit_command_coverage.py
 
 # --- Clean -------------------------------------------------------------------
 

--- a/scripts/audit_command_coverage.py
+++ b/scripts/audit_command_coverage.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Static integration-test coverage report for the canasta CLI.
+
+Walks tests/integration/run_tests.py with Python's ast module, finds every
+inst.run / inst.run_ok / inst.run_quiet call, and extracts the command name
+(or `<group> <subcommand>` pair) from the first one or two string arguments.
+Cross-references against meta/command_definitions.yml to report:
+
+  * which commands have at least one integration test that exercises them
+  * which commands are not exercised by any integration test
+  * which test functions exercise each command
+
+Static analysis only — does not run the tests, does not need a Docker
+daemon. Catches everything that's a literal string in a `run` call. Misses
+commands invoked via interpolated names (none today). Does not measure
+flag-level coverage; for that, read the test source.
+
+Usage:
+    python scripts/audit_command_coverage.py
+    python scripts/audit_command_coverage.py --strict   # exit 1 if any
+                                                          # command is
+                                                          # uncovered
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import sys
+from collections import defaultdict
+
+import yaml
+
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+TEST_FILE = os.path.join(REPO_ROOT, "tests", "integration", "run_tests.py")
+DEFS_FILE = os.path.join(REPO_ROOT, "meta", "command_definitions.yml")
+
+RUN_METHODS = {"run", "run_ok", "run_quiet"}
+
+
+def load_commands():
+    """Return (all_command_names, subcommand_groups).
+
+    all_command_names is the canonical set from command_definitions.yml,
+    using underscore separation for subcommands (e.g. "backup_create").
+    subcommand_groups is the set of first-segment names that have at
+    least one underscore subcommand (e.g. "backup", "config").
+    """
+    with open(DEFS_FILE) as f:
+        defs = yaml.safe_load(f)
+    names = {c["name"] for c in defs.get("commands", [])}
+    groups = {n.split("_", 1)[0] for n in names if "_" in n}
+    return names, groups
+
+
+def _string_const(node):
+    """Return the value of an ast string Constant, or None."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def extract_test_invocations(test_file, subcommand_groups):
+    """Walk the test file and yield (test_func_name, command_name) tuples.
+
+    command_name is the canonical underscore-joined form
+    (e.g. "create", "backup_create"). Calls whose first argument is not
+    a string literal are ignored — there are none in run_tests.py today,
+    but if any are added the audit will silently miss them.
+    """
+    with open(test_file) as f:
+        tree = ast.parse(f.read(), filename=test_file)
+
+    # Map line number ranges -> enclosing test function name so each
+    # extracted invocation can be attributed to its test.
+    func_ranges = []  # list of (start_line, end_line, name)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("test_"):
+            func_ranges.append(
+                (node.lineno, getattr(node, "end_lineno", node.lineno), node.name),
+            )
+
+    def func_for_line(lineno):
+        for start, end, name in func_ranges:
+            if start <= lineno <= end:
+                return name
+        return None
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr in RUN_METHODS):
+            continue
+        # Filter to inst.run* calls (the test instance method).
+        if not (isinstance(func.value, ast.Name) and func.value.id == "inst"):
+            continue
+
+        # First positional arg is the command name (or group name).
+        if not node.args:
+            continue
+        first = _string_const(node.args[0])
+        if first is None:
+            continue
+
+        # If the first arg is a subcommand group, the second positional
+        # arg is the actual subcommand name.
+        if first in subcommand_groups and len(node.args) >= 2:
+            second = _string_const(node.args[1])
+            if second is not None:
+                command = "%s_%s" % (first, second)
+            else:
+                command = first
+        else:
+            command = first
+
+        yield func_for_line(node.lineno), command
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with status 1 if any command is uncovered.",
+    )
+    parser.add_argument(
+        "--show-tests",
+        action="store_true",
+        help="For each covered command, list the test functions exercising it.",
+    )
+    args = parser.parse_args()
+
+    all_commands, groups = load_commands()
+    coverage = defaultdict(set)  # command -> {test_func_name, ...}
+    unknown = set()              # invoked commands not in definitions
+
+    for test_name, command in extract_test_invocations(TEST_FILE, groups):
+        if command in all_commands:
+            coverage[command].add(test_name or "?")
+        else:
+            unknown.add(command)
+
+    covered = sorted(c for c in all_commands if c in coverage)
+    uncovered = sorted(c for c in all_commands if c not in coverage)
+
+    total = len(all_commands)
+    n_covered = len(covered)
+    pct = (n_covered * 100.0 / total) if total else 0.0
+
+    print("Integration test coverage: %d / %d commands (%.1f%%)" % (n_covered, total, pct))
+    print("=" * 60)
+    print()
+
+    print("Covered (%d):" % n_covered)
+    for cmd in covered:
+        if args.show_tests:
+            tests = sorted(coverage[cmd])
+            print("  %-32s %s" % (cmd, ", ".join(tests)))
+        else:
+            print("  %s" % cmd)
+    print()
+
+    print("NOT covered (%d):" % len(uncovered))
+    for cmd in uncovered:
+        print("  %s" % cmd)
+    print()
+
+    if unknown:
+        print("WARNING: %d invocations matched no known command:" % len(unknown))
+        for cmd in sorted(unknown):
+            print("  %s" % cmd)
+        print()
+
+    if args.strict and uncovered:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_audit_command_coverage.py
+++ b/tests/unit/test_audit_command_coverage.py
@@ -1,0 +1,152 @@
+"""Tests for scripts/audit_command_coverage.py."""
+
+import os
+import sys
+import tempfile
+
+import pytest
+
+
+SCRIPTS_DIR = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "scripts"),
+)
+sys.path.insert(0, SCRIPTS_DIR)
+
+import audit_command_coverage as audit  # noqa: E402
+
+
+GROUPS = {"backup", "config", "extension", "skin", "gitops", "host",
+          "maintenance", "sitemap", "devmode", "storage"}
+
+
+def write_test_file(content):
+    """Write content to a temp .py file and return its path."""
+    fd, path = tempfile.mkstemp(suffix=".py", prefix="test_audit_")
+    os.close(fd)
+    with open(path, "w") as f:
+        f.write(content)
+    return path
+
+
+class TestExtractInvocations:
+    def test_simple_command(self):
+        path = write_test_file(
+            'def test_x(inst):\n'
+            '    inst.run_ok("create", "-i", "x")\n'
+        )
+        try:
+            results = list(audit.extract_test_invocations(path, GROUPS))
+            assert results == [("test_x", "create")]
+        finally:
+            os.unlink(path)
+
+    def test_subcommand(self):
+        path = write_test_file(
+            'def test_x(inst):\n'
+            '    inst.run_ok("backup", "create", "-i", "x")\n'
+        )
+        try:
+            results = list(audit.extract_test_invocations(path, GROUPS))
+            assert results == [("test_x", "backup_create")]
+        finally:
+            os.unlink(path)
+
+    def test_multiline_call(self):
+        path = write_test_file(
+            'def test_x(inst):\n'
+            '    inst.run_ok(\n'
+            '        "create", "-i", "x",\n'
+            '        "-w", "main",\n'
+            '    )\n'
+        )
+        try:
+            results = list(audit.extract_test_invocations(path, GROUPS))
+            assert results == [("test_x", "create")]
+        finally:
+            os.unlink(path)
+
+    def test_run_quiet_and_run(self):
+        path = write_test_file(
+            'def test_x(inst):\n'
+            '    inst.run_quiet("list")\n'
+            '    inst.run("doctor")\n'
+            '    inst.run_ok("create", "-i", "x")\n'
+        )
+        try:
+            results = list(audit.extract_test_invocations(path, GROUPS))
+            assert sorted(results) == [
+                ("test_x", "create"),
+                ("test_x", "doctor"),
+                ("test_x", "list"),
+            ]
+        finally:
+            os.unlink(path)
+
+    def test_attribution_to_correct_test(self):
+        path = write_test_file(
+            'def test_a(inst):\n'
+            '    inst.run_ok("create", "-i", "x")\n'
+            '\n'
+            'def test_b(inst):\n'
+            '    inst.run_ok("delete", "-i", "x")\n'
+        )
+        try:
+            results = list(audit.extract_test_invocations(path, GROUPS))
+            assert sorted(results) == [
+                ("test_a", "create"),
+                ("test_b", "delete"),
+            ]
+        finally:
+            os.unlink(path)
+
+    def test_non_inst_run_ignored(self):
+        path = write_test_file(
+            'def test_x(inst):\n'
+            '    other.run_ok("create")\n'
+            '    subprocess.run_ok("backup", "create")\n'
+            '    inst.run_ok("delete", "-i", "x")\n'
+        )
+        try:
+            results = list(audit.extract_test_invocations(path, GROUPS))
+            assert results == [("test_x", "delete")]
+        finally:
+            os.unlink(path)
+
+    def test_non_string_first_arg_ignored(self):
+        # An interpolated command name (e.g. inst.run_ok(cmd, ...))
+        # cannot be statically extracted; the audit silently skips it.
+        path = write_test_file(
+            'def test_x(inst):\n'
+            '    cmd = "create"\n'
+            '    inst.run_ok(cmd, "-i", "x")\n'
+        )
+        try:
+            results = list(audit.extract_test_invocations(path, GROUPS))
+            assert results == []
+        finally:
+            os.unlink(path)
+
+    def test_subcommand_group_with_only_first_arg(self):
+        # If second arg isn't a string literal, fall back to the group name
+        path = write_test_file(
+            'def test_x(inst):\n'
+            '    sub = "create"\n'
+            '    inst.run_ok("backup", sub)\n'
+        )
+        try:
+            results = list(audit.extract_test_invocations(path, GROUPS))
+            assert results == [("test_x", "backup")]
+        finally:
+            os.unlink(path)
+
+
+class TestLoadCommands:
+    def test_real_definitions_load(self):
+        # Smoke test against the real command_definitions.yml
+        names, groups = audit.load_commands()
+        assert "create" in names
+        assert "backup_create" in names
+        assert "backup" in groups
+        assert "config" in groups
+        # 'create' is a top-level command, not a group
+        assert "create" not in groups


### PR DESCRIPTION
Fixes #37.

## What this adds

A small static-analysis script — `scripts/audit_command_coverage.py` — that walks `tests/integration/run_tests.py` with Python's `ast` module, extracts every `inst.run` / `inst.run_ok` / `inst.run_quiet` call, and cross-references against `meta/command_definitions.yml` to report which canasta commands have at least one integration test exercising them.

Run it on demand via `make audit-coverage` or directly:

```
$ make audit-coverage
Integration test coverage: 31 / 58 commands (53.4%)
============================================================

Covered (31):
  add
  backup_check
  backup_create
  backup_init
  ...
  upgrade

NOT covered (27):
  backup_delete
  backup_diff
  backup_files
  backup_schedule_list
  backup_schedule_remove
  backup_schedule_set
  backup_unlock
  config_get
  config_unset
  devmode_disable
  devmode_enable
  doctor
  gitops_fix_submodules
  gitops_join
  gitops_rm
  gitops_sync
  host_add
  host_list
  host_remove
  maintenance_extension
  maintenance_script
  maintenance_update
  sitemap_generate
  sitemap_remove
  storage_setup_efs
  storage_setup_nfs
  version
```

`--show-tests` lists the test functions exercising each covered command. `--strict` exits 1 if anything is uncovered (so it can be wired into CI as a regression guard later).

## Why this and not Python subprocess coverage

I started looking at instrumenting the integration tests with `coverage.process_startup()` so each `canasta.py` invocation and each Ansible module subprocess would get measured. After mapping out the codebase the trade-off didn't justify it:

| Category | Lines | Coverable by Python tools |
|---|---:|---|
| `canasta.py` | 759 | yes (currently 0% — would jump to ~70-80%) |
| `roles/*/library/*.py` (5 custom modules) | 1,175 | already 84-95% from unit tests |
| Other Python | 769 | mostly tooling |
| **`roles/*/tasks/*.yml`** | **6,634** | **no** |
| **`playbooks/*.yml`** | **1,787** | **no** |

~75% of the actual work code is YAML, and **none of it is reachable by any Python coverage tool**. The dynamic-instrumentation pipeline would be ~150-200 lines of CI YAML + a merge job + ongoing maintenance, and at the end of that we'd still be unable to answer "is the playbook task I just added being tested?"

A static command-presence audit answers a question that's *closer to what we actually want to know* than Python line coverage ever could, with ~100 lines of script and zero CI cost.

## Limitations

- Can't see commands invoked through interpolated names (none today). The script silently skips them.
- Doesn't measure flag-level coverage. "`canasta create` is covered" doesn't tell you that `--build-from` specifically isn't tested.
- Doesn't know which test actually *succeeded* — only that the command was invoked.

## Test plan

- [x] 9 new unit tests in `tests/unit/test_audit_command_coverage.py` covering simple commands, subcommands, multi-line calls, all three `run*` variants, per-test attribution, non-`inst` calls being ignored, interpolated names being silently skipped, subcommand groups with non-string second args, and a smoke test against the real `command_definitions.yml`
- [x] Full unit suite passing locally (305 tests, was 296 + 9 new)
- [x] `make audit-coverage` produces the snapshot above on the current main
- [ ] CI passes
