### PR TITLE
Cover 17 more canasta commands with integration tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,13 +90,13 @@ jobs:
       - name: Run core tests
         run: >-
           .venv/bin/python tests/integration/run_tests.py
-          lifecycle import upgrade
+          lifecycle import upgrade version doctor host-management
         timeout-minutes: 20
 
   integration-features:
     name: "Integration: Features"
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -115,7 +115,8 @@ jobs:
         run: >-
           .venv/bin/python tests/integration/run_tests.py
           extension-skin wiki-farm config-side-effects backup backup-advanced
-        timeout-minutes: 20
+          devmode sitemap maintenance
+        timeout-minutes: 30
 
   integration-gitops:
     name: "Integration: GitOps"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,7 +115,7 @@ jobs:
         run: >-
           .venv/bin/python tests/integration/run_tests.py
           extension-skin wiki-farm config-side-effects backup backup-advanced
-          devmode sitemap maintenance
+          sitemap maintenance
         timeout-minutes: 30
 
   integration-gitops:

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -973,11 +973,11 @@ def test_doctor(inst):
 
 def test_host_management(inst):
     """`canasta host add/list/remove` manages entries in hosts.yml."""
-    # host_name is a positional argument in the canasta CLI, not a flag.
     host_name = "canasta-int-test-host-%s" % inst.id
     print("Adding host entry %s..." % host_name)
     inst.run_ok(
-        "host", "add", host_name,
+        "host", "add",
+        "--name", host_name,
         "--ssh", "user@example.invalid",
     )
 
@@ -988,7 +988,7 @@ def test_host_management(inst):
     )
 
     print("Removing host entry %s..." % host_name)
-    inst.run_ok("host", "remove", host_name)
+    inst.run_ok("host", "remove", "--name", host_name)
 
     print("Verifying host is gone...")
     output = inst.run_quiet("host", "list")

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -997,29 +997,6 @@ def test_host_management(inst):
     )
 
 
-def test_devmode(inst):
-    """Enable and disable development mode on a running instance."""
-    print("Creating instance...")
-    inst.run_ok(
-        "create", "-i", inst.id, "-w", "main",
-        "-n", "localhost", "-p", inst.work_dir,
-        "-e", inst.env_file,
-    )
-    wait_for_wiki(inst.http_port)
-
-    print("Enabling devmode...")
-    inst.run_ok("devmode", "enable", "-i", inst.id)
-
-    print("Wiki should still be reachable after devmode enable...")
-    wait_for_wiki(inst.http_port, timeout=120)
-
-    print("Disabling devmode...")
-    inst.run_ok("devmode", "disable", "-i", inst.id)
-
-    print("Wiki should still be reachable after devmode disable...")
-    wait_for_wiki(inst.http_port, timeout=120)
-
-
 def test_sitemap(inst):
     """Generate and remove an XML sitemap."""
     print("Creating instance...")
@@ -1077,7 +1054,6 @@ ALL_TESTS = {
     "version": test_version,
     "doctor": test_doctor,
     "host-management": test_host_management,
-    "devmode": test_devmode,
     "sitemap": test_sitemap,
     "maintenance": test_maintenance,
 }

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -611,9 +611,10 @@ def test_config_side_effects(inst):
     )
 
     print("Setting an arbitrary key for config unset to remove...")
+    # canasta config set rejects unknown keys unless --force is given.
     inst.run_ok(
         "config", "set", "-i", inst.id,
-        "CANASTA_TEST_MARKER=hello", "--no-restart",
+        "CANASTA_TEST_MARKER=hello", "--force", "--no-restart",
     )
     env = read_env(inst.env_path())
     assert env.get("CANASTA_TEST_MARKER") == "hello", (
@@ -624,7 +625,7 @@ def test_config_side_effects(inst):
     print("Removing the marker key with config unset...")
     inst.run_ok(
         "config", "unset", "-i", inst.id,
-        "--keys", "CANASTA_TEST_MARKER", "--no-restart",
+        "CANASTA_TEST_MARKER", "--force", "--no-restart",
     )
     env = read_env(inst.env_path())
     assert "CANASTA_TEST_MARKER" not in env, (
@@ -1031,9 +1032,10 @@ def test_maintenance(inst):
     )
 
     print("Running showSiteStats.php as a generic maintenance script...")
+    # script_args is a variadic positional, not a --script-args flag.
     inst.run_ok(
         "maintenance", "script", "-i", inst.id, "-w", "main",
-        "--script-args", "showSiteStats.php",
+        "showSiteStats.php",
     )
 
 

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -973,11 +973,11 @@ def test_doctor(inst):
 
 def test_host_management(inst):
     """`canasta host add/list/remove` manages entries in hosts.yml."""
+    # host_name is a positional argument in the canasta CLI, not a flag.
     host_name = "canasta-int-test-host-%s" % inst.id
     print("Adding host entry %s..." % host_name)
     inst.run_ok(
-        "host", "add",
-        "--host-name", host_name,
+        "host", "add", host_name,
         "--ssh", "user@example.invalid",
     )
 
@@ -988,7 +988,7 @@ def test_host_management(inst):
     )
 
     print("Removing host entry %s..." % host_name)
-    inst.run_ok("host", "remove", "--host-name", host_name)
+    inst.run_ok("host", "remove", host_name)
 
     print("Verifying host is gone...")
     output = inst.run_quiet("host", "list")

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -601,6 +601,37 @@ def test_config_side_effects(inst):
         % (new_http_port, env.get("MW_SITE_FQDN"))
     )
 
+    print("Reading the value back with config get...")
+    output = inst.run_quiet(
+        "config", "get", "-i", inst.id, "--key", "HTTP_PORT",
+    )
+    assert new_http_port in output, (
+        "config get HTTP_PORT did not return %s:\n%s"
+        % (new_http_port, output)
+    )
+
+    print("Setting an arbitrary key for config unset to remove...")
+    inst.run_ok(
+        "config", "set", "-i", inst.id,
+        "CANASTA_TEST_MARKER=hello", "--no-restart",
+    )
+    env = read_env(inst.env_path())
+    assert env.get("CANASTA_TEST_MARKER") == "hello", (
+        "marker should be set in .env, got: %s"
+        % env.get("CANASTA_TEST_MARKER")
+    )
+
+    print("Removing the marker key with config unset...")
+    inst.run_ok(
+        "config", "unset", "-i", inst.id,
+        "--keys", "CANASTA_TEST_MARKER", "--no-restart",
+    )
+    env = read_env(inst.env_path())
+    assert "CANASTA_TEST_MARKER" not in env, (
+        "marker should be gone from .env after unset, still present: %s"
+        % env.get("CANASTA_TEST_MARKER")
+    )
+
     print("Resetting HTTP_PORT to 80...")
     inst.run_ok(
         "config", "set", "-i", inst.id,
@@ -671,6 +702,47 @@ def test_backup_advanced(inst):
     output = inst.run_quiet("backup", "list", "-i", inst.id)
     # Both snapshots are recent (<1h old), so both should survive
     assert "snap2" in output, "snap2 should remain after purge"
+
+    print("Resolving snapshot IDs from list output...")
+    # `backup list` prints one snapshot per row including a short ID;
+    # parse them out so we can target individual snapshots by ID.
+    snap_ids = []
+    for line in output.splitlines():
+        # Snapshot ID rows start with an 8-char hex ID
+        parts = line.split()
+        if parts and len(parts[0]) == 8 and all(
+            c in "0123456789abcdef" for c in parts[0]
+        ):
+            snap_ids.append(parts[0])
+    assert len(snap_ids) >= 2, (
+        "expected at least 2 snapshot IDs in list output, got: %s\n%s"
+        % (snap_ids, output)
+    )
+    snap1_id, snap2_id = snap_ids[0], snap_ids[1]
+
+    print("Listing files in snapshot %s..." % snap1_id)
+    output = inst.run_quiet(
+        "backup", "files", "-i", inst.id, "-s", snap1_id,
+    )
+    assert output.strip(), "backup files produced no output for %s" % snap1_id
+
+    print("Diffing snapshots %s..%s..." % (snap1_id, snap2_id))
+    inst.run_ok(
+        "backup", "diff", "-i", inst.id,
+        "-s", snap1_id, "--snapshot2", snap2_id,
+    )
+
+    print("Deleting snapshot %s..." % snap1_id)
+    inst.run_ok("backup", "delete", "-i", inst.id, "-s", snap1_id)
+
+    print("Verifying %s is gone..." % snap1_id)
+    output = inst.run_quiet("backup", "list", "-i", inst.id)
+    assert snap1_id not in output, (
+        "%s still in list after delete:\n%s" % (snap1_id, output)
+    )
+
+    print("Unlocking the backup repository (no-op when not locked)...")
+    inst.run_ok("backup", "unlock", "-i", inst.id)
 
     # Note: backup schedule set/list/remove tests are skipped in CI
     # because the cron expression positional argument doesn't survive
@@ -879,6 +951,115 @@ def test_k8s_lifecycle(inst):
     assert inst.id not in output, "Instance still in list after delete"
 
 
+def test_version(inst):
+    """`canasta version` reports a version string and orchestrator info."""
+    output = inst.run_quiet("version")
+    # The output format is governed by playbooks/version.yml; we just
+    # need to confirm the command runs and emits something. The exact
+    # version string is asserted on by tests/unit/ already.
+    assert output.strip(), "version produced no output"
+
+
+def test_doctor(inst):
+    """`canasta doctor` runs preflight checks against the local host."""
+    output = inst.run_quiet("doctor")
+    # Sanity-check that doctor at least mentions Docker — the actual
+    # OK/NOT RUNNING result depends on the runner environment but the
+    # check itself should always show up.
+    assert "Docker" in output, (
+        "doctor output should mention Docker:\n%s" % output
+    )
+
+
+def test_host_management(inst):
+    """`canasta host add/list/remove` manages entries in hosts.yml."""
+    host_name = "canasta-int-test-host-%s" % inst.id
+    print("Adding host entry %s..." % host_name)
+    inst.run_ok(
+        "host", "add",
+        "--host-name", host_name,
+        "--ssh", "user@example.invalid",
+    )
+
+    print("Listing hosts and verifying %s is present..." % host_name)
+    output = inst.run_quiet("host", "list")
+    assert host_name in output, (
+        "host %s not found in list output:\n%s" % (host_name, output)
+    )
+
+    print("Removing host entry %s..." % host_name)
+    inst.run_ok("host", "remove", "--host-name", host_name)
+
+    print("Verifying host is gone...")
+    output = inst.run_quiet("host", "list")
+    assert host_name not in output, (
+        "host %s still in list after remove:\n%s" % (host_name, output)
+    )
+
+
+def test_devmode(inst):
+    """Enable and disable development mode on a running instance."""
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir,
+        "-e", inst.env_file,
+    )
+    wait_for_wiki(inst.http_port)
+
+    print("Enabling devmode...")
+    inst.run_ok("devmode", "enable", "-i", inst.id)
+
+    print("Wiki should still be reachable after devmode enable...")
+    wait_for_wiki(inst.http_port, timeout=120)
+
+    print("Disabling devmode...")
+    inst.run_ok("devmode", "disable", "-i", inst.id)
+
+    print("Wiki should still be reachable after devmode disable...")
+    wait_for_wiki(inst.http_port, timeout=120)
+
+
+def test_sitemap(inst):
+    """Generate and remove an XML sitemap."""
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir,
+        "-e", inst.env_file,
+    )
+    wait_for_wiki(inst.http_port)
+
+    print("Generating sitemap...")
+    inst.run_ok("sitemap", "generate", "-i", inst.id, "-w", "main")
+
+    print("Removing sitemap...")
+    inst.run_ok("sitemap", "remove", "-i", inst.id, "-w", "main")
+
+
+def test_maintenance(inst):
+    """Run a MediaWiki maintenance script and the bundled update playbook."""
+    print("Creating instance...")
+    inst.run_ok(
+        "create", "-i", inst.id, "-w", "main",
+        "-n", "localhost", "-p", inst.work_dir,
+        "-e", inst.env_file,
+    )
+    wait_for_wiki(inst.http_port)
+
+    print("Running maintenance update (skip jobs to keep CI fast)...")
+    inst.run_ok(
+        "maintenance", "update", "-i", inst.id, "-w", "main",
+        "--skip-jobs",
+    )
+
+    print("Running showSiteStats.php as a generic maintenance script...")
+    inst.run_ok(
+        "maintenance", "script", "-i", inst.id, "-w", "main",
+        "--script-args", "showSiteStats.php",
+    )
+
+
 # --- Test runner ---
 
 ALL_TESTS = {
@@ -893,6 +1074,12 @@ ALL_TESTS = {
     "extension-skin": test_extension_skin,
     "wiki-farm": test_wiki_farm,
     "config-side-effects": test_config_side_effects,
+    "version": test_version,
+    "doctor": test_doctor,
+    "host-management": test_host_management,
+    "devmode": test_devmode,
+    "sitemap": test_sitemap,
+    "maintenance": test_maintenance,
 }
 
 


### PR DESCRIPTION
Fixes #39.

Adds five new integration test functions and extends two existing ones to exercise canasta commands that previously had no integration coverage. Per the static audit script in #38, this takes end-to-end command coverage from **31/58 (53.4%) to 46/58 (79.3%)** — 15 newly-covered commands.

## New tests

| Test | Commands covered |
|---|---|
| `test_version` | `version` |
| `test_doctor` | `doctor` |
| `test_host_management` | `host_add`, `host_list`, `host_remove` |
| `test_sitemap` | `sitemap_generate`, `sitemap_remove` |
| `test_maintenance` | `maintenance_update`, `maintenance_script` |

## Extended tests

- `test_config_side_effects` now also exercises `config get` (read the value back after setting it) and `config unset` (set a sentinel marker, then remove it and verify it's gone from `.env`).
- `test_backup_advanced` now parses snapshot IDs out of `backup list` and exercises `backup files`, `backup diff`, `backup delete`, and `backup unlock` against real snapshots.

## CI dispatch

- **integration-core** picks up `version`, `doctor`, `host-management` — all fast and either need no instance or only do CRUD on `hosts.yml`.
- **integration-features** picks up `sitemap`, `maintenance`. Each spins up its own instance, so bumped the job-level timeout from 25 → 35 minutes and the run step from 20 → 30 to absorb the additional creates.

## Out of scope

The remaining 12 uncovered commands need either real infrastructure or are too expensive for routine CI:

- `devmode_enable` / `devmode_disable` — `devmode enable` does a multi-GB image pull, extracts the entire MediaWiki tree out of a temp container via tar, then **rebuilds the canasta image with xdebug compiled in** (PECL build from source) before restarting containers. Easily the most expensive operation in the codebase. Worth its own follow-up issue to decide whether it's worth a scheduled-only test.
- `backup_schedule_set/list/remove` — broken in CI per existing comment in `test_backup_advanced` (cron expression positional argument doesn't survive the bash wrapper)
- `gitops_join`, `gitops_fix_submodules`, `gitops_rm`, `gitops_sync` — need a second host or specific gitops state
- `storage_setup_efs`, `storage_setup_nfs` — need cloud / NFS server
- `maintenance_extension` — needs a non-default extension installed first

## Test plan

- [x] All new tests run locally without unit-test regressions (296 unit tests still pass)
- [x] `scripts/validate_definitions.py` passes
- [x] Static audit (from #38) confirms 15 newly-covered commands (53.4% → 79.3%)
- [ ] CI passes
