### PR TITLE
Bypass interpreter discovery cache when switching remote hosts

### DIFF
--- a/roles/common/tasks/switch_connection.yml
+++ b/roles/common/tasks/switch_connection.yml
@@ -4,6 +4,16 @@
 #
 # Parses user@host format and sets ansible_host, ansible_connection,
 # ansible_user accordingly. Resets to local for localhost instances.
+#
+# Note on remote_python_interpreter: we use the explicit /usr/bin/python3
+# rather than `auto` because Ansible's interpreter-discovery result is
+# cached as a fact on the play target host (`localhost`). When the same
+# `localhost` host is reused across loop iterations to manage many
+# physical machines (canasta upgrade, canasta gitops sync, etc.), the
+# cached `discovered_interpreter_python` from iteration 1 leaks into
+# iteration 2, and Ansible tries to use the previous host's Python path
+# on the new host. /usr/bin/python3 bypasses discovery entirely and is
+# the canonical Python 3 path on every modern Linux distro. See #41.
 
 - name: Parse SSH user and hostname from registry host
   ansible.builtin.set_fact:
@@ -16,14 +26,14 @@
     ansible_host: "{{ _ssh_host }}"
     ansible_connection: "ssh"
     ansible_user: "{{ _ssh_user }}"
-    ansible_python_interpreter: auto
+    ansible_python_interpreter: /usr/bin/python3
   when: _instance_host != 'localhost' and _ssh_user | default('') != ''
 
 - name: Override connection for remote instance (no user)
   ansible.builtin.set_fact:
     ansible_host: "{{ _ssh_host }}"
     ansible_connection: "ssh"
-    ansible_python_interpreter: auto
+    ansible_python_interpreter: /usr/bin/python3
   when: _instance_host != 'localhost' and _ssh_user | default('') == ''
 
 - name: Reset connection for local instance


### PR DESCRIPTION
Fixes #41.

## Symptom

`canasta upgrade` (or any other command that loops over multiple registered remote instances from a single `localhost` play target) fails on the second iteration with:

```
Error: The module interpreter '/usr/bin/python3.12' was not found.
```

even when the second host has a working Python at a different path. The first host always upgrades cleanly. Reproduced in the wild against `migration.wikiworks.com` (works) followed by `acknowledge.wiki` (fails).

## Root cause

`roles/common/tasks/switch_connection.yml` uses `set_fact` to redirect `ansible_host` / `ansible_connection` / `ansible_python_interpreter` for each iteration of an instance loop, while keeping the play's target as `localhost` throughout. For each remote it set `ansible_python_interpreter: auto` so Ansible's interpreter discovery would find the right Python on that target.

That works for the first iteration. Discovery SSHes to the remote, finds (say) `/usr/bin/python3.12`, and **stashes the result on the play target's host facts as `discovered_interpreter_python`** (`ansible/plugins/action/__init__.py:340-344`):

```python
if not self._task.delegate_to or self._task.delegate_facts:
    task_vars['ansible_facts'][discovered_key] = self._discovered_interpreter
```

On the second iteration, switch_connection.yml sets `ansible_host` to the new remote and `ansible_python_interpreter: auto` again. But the cached `discovered_interpreter_python` fact from iteration 1 is still attached to `localhost`. When the next module runs, Ansible (`executor/module_common.py:348-357`) sees `auto`, checks the host facts, finds the cached value, and short-circuits discovery — using the previous host's Python path on the new host.

There is no clean playbook-level way to pop a fact out of the `ansible_facts` dict: `set_fact` with `None` leaves the key in place, and the discovery code checks `not in`, not `is None`. `meta: clear_facts` would clear *all* facts, which is too broad. Implementing a custom Python module just to pop one fact would be heavyweight for a single-line config issue.

## Fix

Use an explicit interpreter path (`/usr/bin/python3`) instead of `auto`. This bypasses the cache check entirely (the cache is only consulted when the value is in the `auto*` family — see `module_common.py:348`).

`/usr/bin/python3` is the canonical Python 3 symlink on every modern Linux distro that has python3 installed: Debian, Ubuntu, RHEL, CentOS, Fedora, Alpine, etc. The downside vs. `auto` is that hosts with Python only at unusual paths (e.g. `/opt/python/bin/python3`) would still need a manual override — but those were already broken without `auto`'s discovery succeeding, and they're vanishingly rare in practice.

## Test plan

- [x] Unit suite still passes (305 tests)
- [x] `make audit-coverage` and `make validate` still clean
- [ ] User to verify against the failing setup (`canasta upgrade` with sebok + pge in the registry)
- [ ] CI passes
