### PR TITLE
Silence canasta-docker SSH agent skip warning by default

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -296,21 +296,23 @@ set -- ${NEW_ARGS[@]+"${NEW_ARGS[@]}"}
 # /private/tmp/com.apple.launchd.*/Listeners, which Docker Desktop's
 # virtiofs file sharing does not expose by default — bind-mounting
 # that path causes the container to fail to start with
-# "mountpoint ... is outside of rootfs". Detect that case and skip
-# the agent forward; the user can fall back to unencrypted keys or
-# point SSH_AUTH_SOCK at a path under $HOME / inside Docker Desktop's
-# shared paths.
+# "mountpoint ... is outside of rootfs". When SSH_AUTH_SOCK is at
+# such a path we silently skip the agent forward — passphraseless
+# keys in $HOME/.ssh continue to work via the $HOME mount. If the
+# user has passphrase-protected keys they will get an interactive
+# prompt inside the container the first time SSH is invoked, which
+# is self-explanatory; pointing SSH_AUTH_SOCK at a socket under
+# $HOME (or another shared path) re-enables forwarding. Set
+# CANASTA_DOCKER_VERBOSE=1 to see the skip message.
 SSH_FWD_OK=false
 if [[ -n "${SSH_AUTH_SOCK:-}" && -S "$SSH_AUTH_SOCK" ]]; then
     SSH_FWD_OK=true
     case "$SSH_AUTH_SOCK" in
         /private/tmp/com.apple.launchd.*|/var/folders/*)
             SSH_FWD_OK=false
-            echo "canasta-docker: SSH_AUTH_SOCK is at a path Docker Desktop" \
-                "cannot share ($SSH_AUTH_SOCK); skipping SSH agent forward." \
-                "Passphrase-protected SSH keys will prompt inside the" \
-                "container. To enable agent forwarding, point" \
-                "SSH_AUTH_SOCK at a socket under \$HOME." >&2
+            if [[ -n "${CANASTA_DOCKER_VERBOSE:-}" ]]; then
+                echo "canasta-docker: SSH_AUTH_SOCK is at a Docker-Desktop-unshareable path; skipping agent forward." >&2
+            fi
             ;;
     esac
 fi

--- a/tests/unit/test_canasta_docker.py
+++ b/tests/unit/test_canasta_docker.py
@@ -152,13 +152,11 @@ class TestSSHAgentForward:
     """SSH_AUTH_SOCK forwarding should be skipped when the socket lives in
     a path Docker Desktop's virtiofs cannot share."""
 
-    def test_skipped_when_socket_in_launchd_tmp(self):
-        # Create a real socket at a launchd-style path. /private/tmp is
-        # world-writable on macOS (and a regular dir on Linux), so this
-        # works on both. Path length stays well under the 104-byte
-        # AF_UNIX limit.
-        if not os.path.isdir("/private/tmp"):
-            pytest.skip("/private/tmp not present (non-macOS layout)")
+    def _make_launchd_socket(self):
+        """Create a real socket at a launchd-style path. /private/tmp is
+        world-writable on macOS (a regular dir on Linux too). Path length
+        stays well under the 104-byte AF_UNIX limit. Returns the socket
+        path; caller is responsible for cleanup via _cleanup_launchd."""
         launchd_dir = "/private/tmp/com.apple.launchd.CANASTA_TEST"
         sock_path = launchd_dir + "/Listeners"
         if os.path.lexists(sock_path):
@@ -166,6 +164,15 @@ class TestSSHAgentForward:
         if os.path.isdir(launchd_dir):
             shutil.rmtree(launchd_dir)
         os.makedirs(launchd_dir)
+        return sock_path, launchd_dir
+
+    def test_skipped_silently_when_socket_in_launchd_tmp(self):
+        # The skip happens silently by default — passphraseless keys in
+        # ~/.ssh continue to work via the $HOME mount, so the warning
+        # would just be noise on every command.
+        if not os.path.isdir("/private/tmp"):
+            pytest.skip("/private/tmp not present (non-macOS layout)")
+        sock_path, launchd_dir = self._make_launchd_socket()
         srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         try:
             srv.bind(sock_path)
@@ -179,7 +186,31 @@ class TestSSHAgentForward:
                 "expected SSH agent mount to be skipped, found %s"
                 % forwarded
             )
-            assert "skipping SSH agent forward" in stderr
+            assert "skipping" not in stderr, (
+                "skip message should be silent without "
+                "CANASTA_DOCKER_VERBOSE=1, got stderr:\n%s" % stderr
+            )
+        finally:
+            srv.close()
+            shutil.rmtree(launchd_dir, ignore_errors=True)
+
+    def test_skip_message_shown_with_verbose_env(self):
+        if not os.path.isdir("/private/tmp"):
+            pytest.skip("/private/tmp not present (non-macOS layout)")
+        sock_path, launchd_dir = self._make_launchd_socket()
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            srv.bind(sock_path)
+            _, stderr = run_dry(
+                ["doctor"],
+                env={
+                    "SSH_AUTH_SOCK": sock_path,
+                    "CANASTA_DOCKER_VERBOSE": "1",
+                },
+            )
+            assert "skipping agent forward" in stderr, (
+                "expected verbose skip message in stderr:\n%s" % stderr
+            )
         finally:
             srv.close()
             shutil.rmtree(launchd_dir, ignore_errors=True)
@@ -195,7 +226,7 @@ class TestSSHAgentForward:
             )
             assert_volume_mount(argv, sock_path, "/tmp/ssh-agent.sock")
             assert_env_var(argv, "SSH_AUTH_SOCK", "/tmp/ssh-agent.sock")
-            assert "skipping SSH agent forward" not in stderr
+            assert "skipping" not in stderr
         finally:
             srv.close()
 


### PR DESCRIPTION
The skip warning was firing on every canasta-docker invocation on macOS, because launchd-managed SSH agent sockets always sit in `/private/tmp/com.apple.launchd.*` and Docker Desktop's virtiofs won't share them.

For users with passphraseless keys in `~/.ssh` the skip is harmless — those keys still work via the `\$HOME` mount — so the warning was pure noise on every command.

## Change

- Skip happens silently by default
- Set `CANASTA_DOCKER_VERBOSE=1` to see the skip message for debugging
- Comment in the script documents the rationale and the workaround (point `SSH_AUTH_SOCK` at a path under `\$HOME`)

If a user actually has a passphrase-protected key, the first `ssh` inside the container will prompt them interactively, which is self-explanatory and points them at the underlying issue.

## Test plan

- [x] Existing test renamed to `test_skipped_silently_when_socket_in_launchd_tmp`, asserts the skip message is *absent* by default
- [x] New `test_skip_message_shown_with_verbose_env` covers the verbose path
- [x] All 10 canasta-docker tests still pass
- [x] Verified locally: \`canasta-docker doctor\` no longer shows the warning, \`CANASTA_DOCKER_VERBOSE=1 canasta-docker doctor\` shows it