### PR TITLE
Convert single-value positionals (host_name, config_get key) to flags

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -408,11 +408,11 @@ commands:
     description: "Show configuration settings"
     long_description: |
       Show configuration settings from the instance .env file.
-      With no arguments, prints all settings. With a KEY argument,
-      prints just that value.
+      With no --key, prints all settings. With --key, prints
+      just that value.
     examples:
       - "canasta config get -i mysite"
-      - "canasta config get -i mysite MW_SITE_SERVER"
+      - "canasta config get -i mysite --key MW_SITE_SERVER"
     playbook: config_get.yml
     parameters:
       - name: id
@@ -420,8 +420,8 @@ commands:
         type: string
         description: "Canasta instance ID"
       - name: key
+        short: k
         type: string
-        positional: true
         description: "Configuration key to query"
       - name: force
         short: f
@@ -1213,13 +1213,13 @@ commands:
       Add or update a host definition in $CANASTA_CONFIG_DIR/hosts.yml.
       Saved hosts can then be targeted by short name with --host.
     examples:
-      - "canasta host add prod1 --ssh ubuntu@prod1.example.com"
-      - "canasta host add prod2 --ssh canasta@10.0.0.5 --python /usr/bin/python3"
+      - "canasta host add --name prod1 --ssh ubuntu@prod1.example.com"
+      - "canasta host add --name prod2 --ssh canasta@10.0.0.5 --python /usr/bin/python3"
     playbook: host_add.yml
     parameters:
       - name: host_name
         long: name
-        positional: true
+        short: n
         type: string
         required: true
         description: "Short name for the host (used with --host)"
@@ -1234,12 +1234,12 @@ commands:
   - name: host_remove
     description: "Remove a host entry from the persistent hosts.yml"
     examples:
-      - "canasta host remove prod1"
+      - "canasta host remove --name prod1"
     playbook: host_remove.yml
     parameters:
       - name: host_name
         long: name
-        positional: true
+        short: n
         type: string
         required: true
         description: "Short name of the host to remove"

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -81,11 +81,19 @@ class TestBuildParser:
                 "-o", "invalid"
             ])
 
-    def test_positional_argument(self, parser):
-        args = parser.parse_args(["config", "get", "-i", "mysite", "KEY"])
+    def test_config_get_key_flag(self, parser):
+        args = parser.parse_args(
+            ["config", "get", "-i", "mysite", "--key", "KEY"],
+        )
         assert args.key == "KEY"
 
-    def test_positional_argument_optional(self, parser):
+    def test_config_get_key_short_flag(self, parser):
+        args = parser.parse_args(
+            ["config", "get", "-i", "mysite", "-k", "KEY"],
+        )
+        assert args.key == "KEY"
+
+    def test_config_get_key_optional(self, parser):
         args = parser.parse_args(["config", "get", "-i", "mysite"])
         assert args.key is None
 


### PR DESCRIPTION
Fixes #44.

## Background

Per the discussion on the issue, the canasta CLI uses `--flag` consistently for everything except a few commands that took positional parameters. The two **single-value** positionals — `host_name` (in `host add/remove`) and `config_get.key` — were the most surprising, because they don't follow the rest of the CLI's pattern. The integration test in #40 fell into this trap on the very first attempt: `canasta host add --host-name foo --ssh ...` looks correct, but argparse rejects it because `host_name` is positional.

## Change

Convert the two single-value positionals to flags:

```
# Before
canasta host add prod1 --ssh ubuntu@prod1
canasta host remove prod1
canasta config get -i mysite MW_SITE_SERVER

# After
canasta host add --name prod1 --ssh ubuntu@prod1     # also: -n prod1
canasta host remove --name prod1                     # also: -n prod1
canasta config get -i mysite --key MW_SITE_SERVER    # also: -k MW_SITE_SERVER
```

The CLI variable name (`dest`) stays as `host_name` and `key`, so **the playbooks need no changes** — they still read `{{ host_name }}` and `{{ key }}` exactly as before.

## What I left as positional and why

| Parameter | Stays positional because |
|---|---|
| `config_set.settings` | Multi-value `KEY=val KEY=val ...` — flag form would be `--settings A --settings B --settings C` |
| `config_unset.keys` | Same |
| `extension_enable/disable.extensions` | Same |
| `skin_enable/disable.skins` | Same |
| `maintenance_script/extension/exec.{script_args,exec_args}` | Variadic shell pass-through (`-- php -v`) — must be positional |
| `backup_schedule_set.cron_expression` | Multi-token shell-quoted string (`"0 2 * * *"`); already broken in CI per existing comment |

## What I dropped from #44's original scope

The issue also mentioned `allow_abbrev=False` as a defensive hardening. While investigating, I realized **the abbreviation collision I claimed in the issue was wrong**: `--host-name` was failing because there was simply no `--host-name` flag registered (since `host_name` is positional), not because argparse was abbreviating it to `--host`. argparse's abbrev only works in the user-shorter direction (`--ho` → `--host`), not the user-longer direction. So removing `allow_abbrev=True` doesn't fix any existing bug; I'd be adding a defensive measure for a hypothetical future trap.

I'd rather keep this PR minimal and focused on the actual user-visible fix. If we want the abbrev hardening later for defensive reasons, it's a separate one-line change.

## Test plan

- [x] Updated `tests/unit/test_canasta_cli.py` to test the new `--key`/`-k` flags instead of the positional form
- [x] All 306 unit tests pass
- [x] `validate_definitions.py` clean
- [x] `make docs` regenerates without errors
- [x] Manually verified all four new invocations work end-to-end against my local registry:
  - `canasta host add --name foo --ssh user@example.invalid` ✓
  - `canasta host add -n foo --ssh user@example.invalid` ✓
  - `canasta host remove --name foo` / `-n foo` ✓
  - `canasta host list` ✓

## Note on PR #40

PR #40's `test_host_management` currently uses the positional form (`canasta host add prod1 ...`). When this PR merges, that test will break. I'll push a follow-up commit to #40 switching it to the new `--name` flag form once we agree on this PR's approach.
