### PR TITLE
Add CADDY_AUTO_HTTPS side-effect handler

### DIFF
--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -17,6 +17,13 @@
     - _config_value | regex_search('^[0-9]+$') is not none
     - _config_value | int < 1 or _config_value | int > 65535
 
+- name: Validate CADDY_AUTO_HTTPS value
+  ansible.builtin.fail:
+    msg: "CADDY_AUTO_HTTPS must be 'on' or 'off' (got '{{ _config_value }}')"
+  when:
+    - _config_key == 'CADDY_AUTO_HTTPS'
+    - _config_value | lower not in ['on', 'off']
+
 - name: Apply HTTP_PORT/HTTPS_PORT side effects
   when: _config_key in ['HTTP_PORT', 'HTTPS_PORT']
   block:
@@ -81,6 +88,70 @@
 
 # Kubernetes port changes: Ingress handles port routing, no cluster
 # recreation needed. The change takes effect on next helm upgrade.
+
+# Toggling CADDY_AUTO_HTTPS flips which port is "active" (the one
+# reflected in wikis.yaml and MW_SITE_*). The HTTP_PORT/HTTPS_PORT
+# handler above only fires when the port values change; we need a
+# parallel handler for when the *scheme* changes but the port values
+# don't. See #46.
+- name: Apply CADDY_AUTO_HTTPS side effects
+  when: _config_key == 'CADDY_AUTO_HTTPS'
+  block:
+    - name: Read both HTTP_PORT and HTTPS_PORT from .env
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read_all
+      register: _se_caddy_env
+
+    - name: Compute new active scheme/port/default
+      vars:
+        _new_http_only: "{{ _config_value | lower == 'off' }}"
+      ansible.builtin.set_fact:
+        _active_scheme: "{{ _new_http_only | ternary('http', 'https') }}"
+        _active_port: >-
+          {{ _new_http_only
+             | ternary(
+                 _se_caddy_env.variables.HTTP_PORT | default('80'),
+                 _se_caddy_env.variables.HTTPS_PORT | default('443')) }}
+        _default_port: "{{ _new_http_only | ternary('80', '443') }}"
+
+    - name: Read wikis.yaml for scheme update
+      canasta_wikis_yaml:
+        instance_path: "{{ instance_path }}"
+        state: read
+      register: _se_caddy_wikis
+
+    - name: Apply wikis.yaml/.env updates for new active scheme
+      when: _se_caddy_wikis.wikis | length > 0
+      block:
+        - name: Extract domain (strip path and existing port)
+          ansible.builtin.set_fact:
+            _base_domain: "{{ _se_caddy_wikis.wikis[0].url | regex_replace('/.*$', '') | regex_replace(':[0-9]+$', '') }}"
+
+        - name: Compute new domain suffix
+          ansible.builtin.set_fact:
+            _port_suffix: "{{ (_active_port == _default_port) | ternary('', ':' + _active_port) }}"
+
+        - name: Update wikis.yaml URLs with new active port
+          canasta_wikis_yaml:
+            instance_path: "{{ instance_path }}"
+            state: update_port
+            port: "{{ _active_port }}"
+            default_port: "{{ _default_port }}"
+
+        - name: Update MW_SITE_SERVER with new scheme and port
+          canasta_env:
+            path: "{{ instance_path }}/.env"
+            state: set
+            key: MW_SITE_SERVER
+            value: "{{ _active_scheme }}://{{ _base_domain }}{{ _port_suffix }}"
+
+        - name: Update MW_SITE_FQDN with new port
+          canasta_env:
+            path: "{{ instance_path }}/.env"
+            state: set
+            key: MW_SITE_FQDN
+            value: "{{ _base_domain }}{{ _port_suffix }}"
 
 - name: Apply MW_SITE_FQDN side effects
   when: _config_key == 'MW_SITE_FQDN'

--- a/roles/orchestrator/tasks/rewrite_caddy.yml
+++ b/roles/orchestrator/tasks/rewrite_caddy.yml
@@ -45,3 +45,14 @@
     src: "{{ role_path }}/templates/Caddyfile.j2"
     dest: "{{ instance_path }}/config/Caddyfile"
     mode: "0644"
+    # The Canasta web container's run-all.sh rsyncs $MW_ORIGIN_FILES
+    # over the bind-mounted instance_path with --chown=www-data:www-data,
+    # which leaves the host's config/ directory not writable by the
+    # host runner user (only the existing Caddyfile is). Ansible's
+    # default atomic write needs to create a temp file in the parent
+    # directory and would fail with "Destination ... not writable".
+    # unsafe_writes lets Ansible fall back to a direct overwrite of
+    # the existing Caddyfile, which the runner *can* do because it
+    # owns the file itself. The atomicity loss is fine — we're not
+    # racing any other writer here.
+    unsafe_writes: true

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -652,6 +652,57 @@ def test_config_side_effects(inst):
         % (new_http_port, env.get("MW_SITE_SERVER"))
     )
 
+    # CADDY_AUTO_HTTPS toggle side effect (#46): flipping the scheme
+    # should switch the active port that's reflected in wikis.yaml /
+    # MW_SITE_SERVER, even though neither HTTP_PORT nor HTTPS_PORT
+    # changed.
+    print("Toggling CADDY_AUTO_HTTPS to on (HTTPS_PORT becomes active)...")
+    inst.run_ok(
+        "config", "set", "-i", inst.id,
+        "CADDY_AUTO_HTTPS=on", "--no-restart",
+    )
+
+    print("Checking wikis.yaml now references HTTPS_PORT %s..." % inst.https_port)
+    with open(wikis_yaml_path) as f:
+        wikis_content = f.read()
+    assert (":%s" % inst.https_port) in wikis_content, (
+        "wikis.yaml should contain HTTPS_PORT %s after CADDY_AUTO_HTTPS=on:"
+        "\n%s" % (inst.https_port, wikis_content)
+    )
+
+    env = read_env(inst.env_path())
+    assert env.get("MW_SITE_SERVER", "").startswith("https://"), (
+        "MW_SITE_SERVER should use https scheme: %s"
+        % env.get("MW_SITE_SERVER")
+    )
+    assert inst.https_port in env.get("MW_SITE_SERVER", ""), (
+        "MW_SITE_SERVER should contain HTTPS_PORT %s: %s"
+        % (inst.https_port, env.get("MW_SITE_SERVER"))
+    )
+    assert inst.https_port in env.get("MW_SITE_FQDN", ""), (
+        "MW_SITE_FQDN should contain HTTPS_PORT %s: %s"
+        % (inst.https_port, env.get("MW_SITE_FQDN"))
+    )
+
+    print("Toggling CADDY_AUTO_HTTPS back to off...")
+    inst.run_ok(
+        "config", "set", "-i", inst.id,
+        "CADDY_AUTO_HTTPS=off", "--no-restart",
+    )
+
+    print("Checking wikis.yaml is back to bare localhost (HTTP_PORT=80)...")
+    with open(wikis_yaml_path) as f:
+        wikis_content = f.read()
+    assert (":%s" % inst.https_port) not in wikis_content, (
+        "wikis.yaml should not reference HTTPS_PORT after toggle off:\n%s"
+        % wikis_content
+    )
+    env = read_env(inst.env_path())
+    assert env.get("MW_SITE_SERVER", "").startswith("http://"), (
+        "MW_SITE_SERVER should use http scheme after toggle off: %s"
+        % env.get("MW_SITE_SERVER")
+    )
+
 
 def test_backup_advanced(inst):
     """Test backup purge, schedule, check, and list operations."""


### PR DESCRIPTION
Fixes #46.

## What

Toggling `CADDY_AUTO_HTTPS` via `canasta config set` previously only flipped the value in `.env`. The dependent state — `wikis.yaml` URLs, `MW_SITE_SERVER`, `MW_SITE_FQDN` — kept the old port and (sometimes) the wrong scheme, leaving the instance in a broken state where `FarmConfigLoader` couldn't route requests.

This adds a `CADDY_AUTO_HTTPS` handler in `_side_effects.yml` that mirrors the existing `HTTP_PORT`/`HTTPS_PORT` handlers from #31, but inverted: the new scheme is known from the config value, so we read both port values from `.env` and pick the new active one.

## Verified end-to-end

I hit this while testing CanastaBase #147 under HTTPS. Reproduction + manual fix beforehand:

1. Create instance with `CADDY_AUTO_HTTPS=off`, `HTTP_PORT=8080`, `HTTPS_PORT=8443`
2. \`canasta config set CADDY_AUTO_HTTPS=on\` ← only this changes
3. wikis.yaml still has `localhost:8080`, MW_SITE_SERVER mixes scheme and port → routing breaks

After this fix, the same toggle:

```
$ canasta config set -i imgtest CADDY_AUTO_HTTPS=on --no-restart
Settings updated. Restart skipped.

$ cat .env
MW_SITE_SERVER=https://localhost:8443
MW_SITE_FQDN=localhost:8443
CADDY_AUTO_HTTPS=on

$ cat config/wikis.yaml
wikis:
- id: main
  url: localhost:8443
- id: second
  url: localhost:8443/second
```

And the reverse toggle correctly restores `http://localhost:8080`.

## Test plan

- [x] Unit suite passes (307)
- [x] \`make validate\` clean
- [x] Manually verified both toggle directions on a running instance with two wikis
- [x] Extended \`test_config_side_effects\` integration test to cover the new toggle in both directions (asserts wikis.yaml port, MW_SITE_SERVER scheme + port, MW_SITE_FQDN port)
- [ ] CI passes