### PR TITLE
canasta-docker: auto-mount and absolutize --envfile path

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -281,6 +281,22 @@ while [[ $i -lt ${#ARGS[@]} ]]; do
                 continue
             fi
             ;;
+        --envfile|-e)
+            if [[ $((i+1)) -lt ${#ARGS[@]} ]]; then
+                ENVFILE_ABS="$(to_abs_path "${ARGS[$((i+1))]}")"
+                NEW_ARGS+=("$arg" "$ENVFILE_ABS")
+                ENVFILE_DIR="$(dirname -- "$ENVFILE_ABS")"
+                CWD="$(pwd)"
+                case "$ENVFILE_DIR" in
+                    "$CWD"/*|"$CWD") ;; # Already covered
+                    *)
+                        MOUNTS+=(-v "$ENVFILE_DIR":"$ENVFILE_DIR":ro)
+                        ;;
+                esac
+                i=$((i+2))
+                continue
+            fi
+            ;;
     esac
     NEW_ARGS+=("$arg")
     i=$((i+1))

--- a/tests/unit/test_canasta_docker.py
+++ b/tests/unit/test_canasta_docker.py
@@ -21,6 +21,16 @@ import pytest
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 WRAPPER = os.path.join(REPO_ROOT, "canasta-docker")
+IMAGE_NAME = "ghcr.io/canastawiki/canasta-ansible:latest"
+
+
+def user_args(argv):
+    """Slice argv to just the args after the image name (i.e. the args
+    canasta.py sees), so tests can look for user-supplied flags without
+    matching the docker run flags that come before the image."""
+    if IMAGE_NAME in argv:
+        return argv[argv.index(IMAGE_NAME) + 1:]
+    return argv
 
 
 @pytest.fixture
@@ -145,6 +155,88 @@ class TestBuildFromMount:
         assert target not in v_mounts, (
             "build dir under cwd should not be double-mounted, found: %s"
             % v_mounts
+        )
+
+
+class TestEnvFileMount:
+    """--envfile/-e path should be auto-mounted into the container.
+
+    See #47 — without this, files outside $PWD/$HOME are invisible
+    to ansible inside the container, and even relative paths inside
+    $PWD fail because ansible-playbook's cwd isn't $PWD.
+    """
+
+    def _make_envfile(self, parent):
+        """Drop a minimal env file in `parent` and return its path."""
+        path = os.path.join(parent, "test.env")
+        with open(path, "w") as f:
+            f.write("HTTP_PORT=8080\nHTTPS_PORT=8443\nCADDY_AUTO_HTTPS=off\n")
+        return path
+
+    def test_envfile_outside_cwd_is_mounted_ro(self, short_tmp):
+        cwd_dir = tempfile.mkdtemp(prefix="cd-cwd-", dir="/tmp")
+        try:
+            envfile = self._make_envfile(short_tmp)
+            envfile_dir = os.path.dirname(envfile)
+            argv, _ = run_dry(
+                ["create", "-i", "x", "-w", "main", "-e", envfile],
+                cwd=cwd_dir,
+            )
+            assert_volume_mount(argv, envfile_dir, envfile_dir, ro=True)
+            # Look at args passed to canasta.py (after the image name);
+            # the first -e in the full argv is the docker run -e for
+            # DOCKER_HOST, not the user's flag.
+            uargv = user_args(argv)
+            e_idx = uargv.index("-e")
+            assert uargv[e_idx + 1] == envfile
+        finally:
+            shutil.rmtree(cwd_dir, ignore_errors=True)
+
+    def test_envfile_long_flag_form_also_handled(self, short_tmp):
+        cwd_dir = tempfile.mkdtemp(prefix="cd-cwd-", dir="/tmp")
+        try:
+            envfile = self._make_envfile(short_tmp)
+            envfile_dir = os.path.dirname(envfile)
+            argv, _ = run_dry(
+                ["create", "-i", "x", "-w", "main",
+                 "--envfile", envfile],
+                cwd=cwd_dir,
+            )
+            assert_volume_mount(argv, envfile_dir, envfile_dir, ro=True)
+        finally:
+            shutil.rmtree(cwd_dir, ignore_errors=True)
+
+    def test_envfile_relative_path_resolved_to_absolute(self, tmp_path):
+        envfile = tmp_path / "test.env"
+        envfile.write_text("HTTP_PORT=8080\n")
+        argv, _ = run_dry(
+            ["create", "-i", "x", "-w", "main", "-e", "test.env"],
+            cwd=str(tmp_path),
+        )
+        # Whether or not the parent dir is mounted (it's already covered
+        # by cwd), the rewritten arg should be absolute so ansible's
+        # slurp module can find it regardless of its own cwd.
+        uargv = user_args(argv)
+        e_idx = uargv.index("-e")
+        assert uargv[e_idx + 1] == str(envfile)
+
+    def test_envfile_inside_cwd_not_double_mounted(self, tmp_path):
+        envfile = tmp_path / "test.env"
+        envfile.write_text("HTTP_PORT=8080\n")
+        argv, _ = run_dry(
+            ["create", "-i", "x", "-w", "main", "-e", "test.env"],
+            cwd=str(tmp_path),
+        )
+        # The envfile's parent dir is $PWD (already mounted), so no
+        # extra -v entry should be added for it.
+        target = "%s:%s:ro" % (str(tmp_path), str(tmp_path))
+        v_mounts = [
+            argv[i + 1] for i, a in enumerate(argv)
+            if a == "-v" and i + 1 < len(argv)
+        ]
+        assert target not in v_mounts, (
+            "envfile parent dir under cwd should not be double-mounted, "
+            "found: %s" % v_mounts
         )
 
 


### PR DESCRIPTION
Fixes #47.

## Change

Adds an \`--envfile|-e\` case to the arg-rewrite loop in canasta-docker, mirroring the existing \`--path\`, \`--database\`, and \`--build-from\` cases. The wrapper now:

- Resolves relative envfile paths to absolute (so ansible's slurp module can find them regardless of its own cwd)
- Bind-mounts the envfile's parent directory into the container if it's outside \`\$PWD\`
- Skips the redundant mount if the envfile is already under \`\$PWD\` (which is mounted by default)

## Reproduction (before this PR)

\`\`\`
$ canasta-docker create -i x -w main -e /tmp/imgtest-env/test.env --build-from /tmp/canasta-build
Generated root database password (will be saved to .env)
Generated admin password.
Error: File not found: /tmp/imgtest-env/test.env
Error: Instance creation failed. Files cleaned up.
\`\`\`

\`\`\`
$ cp /tmp/imgtest-env/test.env ./test.env
$ canasta-docker create -i x -w main -e test.env --build-from /tmp/canasta-build
...
TASK [create : Read custom env file] *********
[ERROR]: Task failed: Module failed: File not found: test.env: [Errno 2] No such file or directory: 'test.env'
\`\`\`

## After this PR

The dry-run command line for the same invocation now contains:

\`\`\`
-v /tmp/imgtest-env:/tmp/imgtest-env:ro
...
-e /tmp/imgtest-env/test.env
\`\`\`

The parent dir is mounted RO, and the user's \`-e\` arg is the absolute path so ansible can find it.

## Test plan

- [x] 4 new unit tests in \`TestEnvFileMount\`: outside-cwd-mounted, long-flag form, relative-to-absolute, no-double-mount
- [x] All 14 canasta-docker unit tests pass
- [x] Full unit suite passes (311 total)
- [x] Manually verified via \`CANASTA_DOCKER_DRY_RUN=1\` against the failing reproduction
- [ ] CI passes

Also added a small \`user_args()\` helper to the test module that slices argv to just the args after the image name. The full \`docker run\` command contains its own \`-e DOCKER_HOST=...\` flag (added in #34), and the existing tests' \`argv.index("-e")\` was accidentally matching that one. New tests need to look at the user-supplied flags only.