### PR TITLE
Plumb allowlisted .env vars into K8s web/jobrunner pods

### DIFF
--- a/roles/orchestrator/files/helm/canasta/templates/configmap-env.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/configmap-env.yaml
@@ -1,0 +1,27 @@
+{{- /*
+Environment variable ConfigMap for the web and jobrunner pods.
+
+Populated by k8s_sync_config.yml on the controller, which parses .env
+on the instance and extracts the subset of keys that should reach the
+pod's environment. Each entry becomes a single KEY=VALUE pair, which
+the pods consume via envFrom: configMapRef in their deployment templates.
+
+Deliberately kept separate from the web-config ConfigMap (which holds
+opaque file contents like wikis.yaml and settings/*) so that the envFrom
+semantics — one ConfigMap key = one environment variable — stay clean.
+See issue #51.
+*/}}
+{{- if .Values.configData.env }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "canasta.fullname" . }}-env
+  namespace: {{ include "canasta.namespace" . }}
+  labels:
+    {{- include "canasta.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web
+data:
+  {{- range $key, $value := .Values.configData.env }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/roles/orchestrator/files/helm/canasta/templates/deployment-jobrunner.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/deployment-jobrunner.yaml
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/component: jobrunner
       annotations:
         checksum/web-config: {{ .Values.configData.web | toJson | sha256sum }}
+        checksum/env-config: {{ .Values.configData.env | default dict | toJson | sha256sum }}
     spec:
       initContainers:
         - name: assemble-config
@@ -55,6 +56,15 @@ spec:
                 php maintenance/runJobs.php --wait --maxjobs=10
                 sleep 5
               done
+          # See deployment-web.yaml for the full explanation of the
+          # env-vs-envFrom split. The jobrunner shares the same env
+          # ConfigMap as the web pod because maintenance scripts and job
+          # processing need the same runtime knobs (PHP_*, wiki directory,
+          # very short URLs, etc.).
+          envFrom:
+            - configMapRef:
+                name: {{ include "canasta.fullname" . }}-env
+                optional: true
           env:
             - name: MYSQL_HOST
               value: db

--- a/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
@@ -19,6 +19,7 @@ spec:
         app.kubernetes.io/component: web
       annotations:
         checksum/web-config: {{ .Values.configData.web | toJson | sha256sum }}
+        checksum/env-config: {{ .Values.configData.env | default dict | toJson | sha256sum }}
     spec:
       initContainers:
         - name: assemble-config
@@ -64,6 +65,36 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
+          # The env vars the pod receives come from two places:
+          #
+          #   envFrom: canasta-<id>-env ConfigMap
+          #       Populated by k8s_sync_config.yml from the instance's .env
+          #       file on each restart. Covers the PHP_* knobs,
+          #       CANASTA_ENABLE_WIKI_DIRECTORY, CANASTA_ENABLE_VERY_SHORT_URLS,
+          #       MW_SITEMAP_PAUSE_DAYS, and any other .env key listed in the
+          #       sync task's allowlist. `canasta config set <key>=<value>`
+          #       propagates cleanly through this path. See #51.
+          #
+          #   env: hardcoded entries below
+          #       Three of these (MW_SITE_SERVER, MW_SITE_FQDN,
+          #       CANASTA_ENABLE_VARNISH) intentionally stay here instead of
+          #       moving to the ConfigMap above. They are sourced from
+          #       values.yaml fields (.Values.domains, .Values.varnish.enabled)
+          #       that double-duty as K8s-level configuration:
+          #       .Values.domains drives Ingress hostnames and TLS hosts;
+          #       .Values.varnish.enabled gates whether the Varnish deployment
+          #       exists at all. Moving just the pod env vars to the ConfigMap
+          #       would create half-broken state where the pod sees one value
+          #       and the cluster resources still reflect the old one. Tracked
+          #       separately as #53.
+          #
+          #       MYSQL_HOST is a constant. MYSQL_PASSWORD and MW_SECRET_KEY
+          #       stay as secretKeyRef because secrets don't belong in
+          #       ConfigMaps.
+          envFrom:
+            - configMapRef:
+                name: {{ include "canasta.fullname" . }}-env
+                optional: true
           env:
             {{- if .Values.domains }}
             - name: MW_SITE_SERVER

--- a/roles/orchestrator/files/helm/canasta/values.yaml
+++ b/roles/orchestrator/files/helm/canasta/values.yaml
@@ -124,6 +124,7 @@ secrets:
 # When empty, ConfigMaps are not created (allows external management).
 configData:
   web: {}       # .env, wikis.yaml, settings--*--*.php, composer.local.json
+  env: {}       # allowlisted env vars extracted from .env, one per ConfigMap key
   caddy: {}     # Caddyfile, Caddyfile.site, Caddyfile.global
   varnish: {}   # default.vcl
   db: {}        # my.cnf

--- a/roles/orchestrator/tasks/k8s_sync_config.yml
+++ b/roles/orchestrator/tasks/k8s_sync_config.yml
@@ -4,14 +4,31 @@
 # Input: instance_path, instance_id
 #
 # ConfigMaps created:
-#   canasta-<id>-web-config    — wikis.yaml, .env, settings/*, composer.local.json
-#   canasta-<id>-caddy-config  — Caddyfile, Caddyfile.site, Caddyfile.global
+#   canasta-<id>-web-config     — wikis.yaml, .env, settings/*, composer.local.json
+#   canasta-<id>-env            — allowlisted runtime env vars parsed from .env (#51)
+#   canasta-<id>-caddy-config   — Caddyfile, Caddyfile.site, Caddyfile.global
 #   canasta-<id>-varnish-config — default.vcl
-#   canasta-<id>-db-config     — my.cnf
+#   canasta-<id>-db-config      — my.cnf
 
-- name: Set K8s namespace
+- name: Set K8s namespace and pod env allowlist
   ansible.builtin.set_fact:
     _k8s_namespace: "canasta-{{ instance_id }}"
+    # The subset of .env keys that should land in the web/jobrunner
+    # pod's environment on K8s. Mirrors the Compose template's
+    # `environment:` block for the web service. Secrets
+    # (MYSQL_PASSWORD, MW_SECRET_KEY) are NOT in this list — they flow
+    # through K8s Secrets instead. MW_SITE_SERVER, MW_SITE_FQDN, and
+    # CANASTA_ENABLE_VARNISH also stay out because they're sourced from
+    # values.yaml fields that double-duty as K8s-level config (Ingress
+    # hostnames, Varnish deployment gate); see #53. See #51 for the
+    # rationale for an allowlist over a denylist.
+    _k8s_pod_env_allowlist:
+      - PHP_UPLOAD_MAX_FILESIZE
+      - PHP_POST_MAX_SIZE
+      - PHP_MAX_INPUT_VARS
+      - CANASTA_ENABLE_WIKI_DIRECTORY
+      - CANASTA_ENABLE_VERY_SHORT_URLS
+      - MW_SITEMAP_PAUSE_DAYS
 
 # --- Gather config files ---
 
@@ -19,6 +36,13 @@
   ansible.builtin.slurp:
     src: "{{ instance_path }}/.env"
   register: _sync_env
+
+- name: Read all .env entries as a dict (for pod env allowlist)
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read_all
+  register: _sync_env_dict
+  no_log: true
 
 - name: Read wikis.yaml
   ansible.builtin.slurp:
@@ -72,6 +96,17 @@
                | zip(_sync_settings_contents.results | map(attribute='content') | map('b64decode'))
                | list))
       }}
+
+# Extract the allowlisted keys from .env into a plain dict. Keys not
+# present in .env are skipped entirely — the pod then gets whatever
+# default the image has built in, matching Compose behavior for
+# unset vars.
+- name: Build pod env config data
+  ansible.builtin.set_fact:
+    _env_config_data: >-
+      {{ _sync_env_dict.variables | default({}) | dict2items
+         | selectattr('key', 'in', _k8s_pod_env_allowlist)
+         | items2dict }}
 
 # --- Caddy config ---
 
@@ -158,6 +193,7 @@
     content: >-
       {{ {'configData': {
             'web': _web_config_data,
+            'env': _env_config_data,
             'caddy': _caddy_config_data,
             'varnish': _varnish_config_data,
             'db': _db_config_data

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -1041,6 +1041,56 @@ def test_k8s_lifecycle(inst):
         "No running pods after start: %s" % result.stdout
     )
 
+    # #51: verify that `canasta config set` on a K8s instance actually
+    # propagates an env var all the way to the running pod. Prior to
+    # the env ConfigMap + envFrom plumbing, this would silently no-op:
+    # .env on the controller would update but the pod's getenv() would
+    # never see the change.
+    print("Setting PHP_UPLOAD_MAX_FILESIZE via config set...")
+    inst.run_ok(
+        "config", "set", "-i", inst.id,
+        "PHP_UPLOAD_MAX_FILESIZE=77M",
+    )
+
+    # Wait for the rollout triggered by config set to complete. The
+    # deployment has a checksum/env-config annotation that changes
+    # when configData.env changes, which forces a pod restart.
+    namespace = "canasta-%s" % inst.id
+    print("Waiting for web rollout to complete...")
+    result = subprocess.run(
+        ["kubectl", "rollout", "status",
+         "deployment/canasta-%s-web" % inst.id,
+         "-n", namespace, "--timeout=180s"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, (
+        "Rollout did not complete: %s\n%s" % (result.stdout, result.stderr)
+    )
+
+    print("Verifying PHP_UPLOAD_MAX_FILESIZE reaches the web pod...")
+    result = subprocess.run(
+        ["kubectl", "get", "pods", "-n", namespace,
+         "-l", "app.kubernetes.io/component=web",
+         "-o", "jsonpath={.items[0].metadata.name}"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0 and result.stdout, (
+        "Could not find web pod: %s" % result.stderr
+    )
+    web_pod = result.stdout.strip()
+
+    result = subprocess.run(
+        ["kubectl", "exec", "-n", namespace, web_pod, "--",
+         "printenv", "PHP_UPLOAD_MAX_FILESIZE"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, (
+        "printenv failed in pod %s: %s" % (web_pod, result.stderr)
+    )
+    assert result.stdout.strip() == "77M", (
+        "Expected PHP_UPLOAD_MAX_FILESIZE=77M in pod, got: %r" % result.stdout
+    )
+
     print("Deleting instance...")
     inst.run_ok("delete", "-i", inst.id, "--yes")
 

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -45,6 +45,7 @@ class TestHelmChart:
         templates = os.path.join(HELM_CHART, "templates")
         required = [
             "_helpers.tpl",
+            "configmap-env.yaml",
             "deployment-caddy.yaml",
             "deployment-web.yaml",
             "deployment-varnish.yaml",
@@ -60,6 +61,31 @@ class TestHelmChart:
         for template in required:
             assert os.path.isfile(os.path.join(templates, template)), (
                 "Missing template: %s" % template
+            )
+
+    def test_values_yaml_has_env_config_data(self):
+        """configData.env must exist so configmap-env.yaml renders (#51)."""
+        with open(os.path.join(HELM_CHART, "values.yaml")) as f:
+            values = yaml.safe_load(f)
+        assert "configData" in values
+        assert "env" in values["configData"], (
+            "configData.env is required for the env ConfigMap template"
+        )
+
+    def test_web_and_jobrunner_reference_env_configmap(self):
+        """deployment-web and deployment-jobrunner must pull env vars from
+        the canasta-<id>-env ConfigMap via envFrom, so that .env changes
+        propagated by k8s_sync_config.yml actually reach the pod (#51)."""
+        templates = os.path.join(HELM_CHART, "templates")
+        for template_name in ("deployment-web.yaml", "deployment-jobrunner.yaml"):
+            with open(os.path.join(templates, template_name)) as f:
+                content = f.read()
+            assert "envFrom:" in content, (
+                "%s must reference the env ConfigMap via envFrom" % template_name
+            )
+            assert '{{ include "canasta.fullname" . }}-env' in content, (
+                "%s must reference the canasta-<id>-env ConfigMap by name"
+                % template_name
             )
 
 


### PR DESCRIPTION
Fixes #51.

Follow-on to #52. That PR plumbed `CANASTA_ENABLE_VERY_SHORT_URLS` through the Compose template while noting that the Helm chart was missing it — along with `CANASTA_ENABLE_WIKI_DIRECTORY`, `MW_SITEMAP_PAUSE_DAYS`, and three `PHP_*` knobs. This PR closes that K8s-side gap.

## The bug

On a K8s instance today, running `canasta config set PHP_UPLOAD_MAX_FILESIZE=50M` (or any of the other affected knobs) writes the value to `.env` on the controller and even syncs `.env` into the `canasta-<id>-web-config` ConfigMap as opaque text. But **nothing consumes `.env` as actual pod environment variables on the K8s side**. The running pod keeps using the image defaults forever, with no error and no warning.

The existing `deployment-web.yaml` only hardcodes six env vars (`MW_SITE_SERVER`, `MW_SITE_FQDN`, `MYSQL_HOST`, `MYSQL_PASSWORD`, `MW_SECRET_KEY`, `CANASTA_ENABLE_VARNISH`). Everything else in `.env` is invisible to `getenv()`.

## The fix

New ConfigMap `canasta-<id>-env` with one env var per ConfigMap key, populated by `k8s_sync_config.yml` from an allowlisted subset of `.env` keys. `deployment-web.yaml` and `deployment-jobrunner.yaml` consume it via `envFrom: configMapRef`, so `canasta config set` now propagates cleanly through this path for:

- `PHP_UPLOAD_MAX_FILESIZE`
- `PHP_POST_MAX_SIZE`
- `PHP_MAX_INPUT_VARS`
- `CANASTA_ENABLE_WIKI_DIRECTORY`
- `CANASTA_ENABLE_VERY_SHORT_URLS`
- `MW_SITEMAP_PAUSE_DAYS`

A `checksum/env-config` annotation on the pod template ensures pods restart when the ConfigMap data changes (standard Helm pattern).

## What's intentionally NOT in this PR

Three non-secret env vars stay as hardcoded `env:` entries sourced from `values.yaml`:

- `MW_SITE_SERVER` / `MW_SITE_FQDN` — sourced from `.Values.domains`, which also drives `ingress.yaml` (routing rules, TLS hosts).
- `CANASTA_ENABLE_VARNISH` — sourced from `.Values.varnish.enabled`, which also gates whether `deployment-varnish.yaml` exists at all.

Moving just the pod env vars to the new ConfigMap would create half-broken state: the pod would see one value while the cluster resources still reflect the old one. For example, `canasta config set MW_SITE_FQDN=new.example.com` on K8s would update the pod's env var but leave the Ingress still routing for the old hostname. That's arguably worse than today's "silently does nothing" behavior.

The proper fix — teaching `config set` to propagate `values.yaml`-backed knobs on K8s — is a bigger refactor (either mutating `values.yaml` on `config set`, or reversing the flow so `values.yaml` is regenerated from `.env` on each restart). Tracked separately as #53.

A prominent comment block in `deployment-web.yaml` documents exactly why the split exists and points at both issues, so a future maintainer reading the template won't wonder.

## Why allowlist over denylist

The failure mode of forgetting to update a denylist is **"secret leaks into a ConfigMap as plaintext."** If someone adds a new secret-bearing var (e.g., a new restic backend credential) without remembering to update the denylist, it ends up in a ConfigMap.

The failure mode of forgetting to update an allowlist is **"new var doesn't reach the K8s pod"** — which is exactly the bug we already have today, and it's loud and debuggable rather than silent and dangerous.

Compose itself uses an implicit allowlist: only vars listed in the `web:` service's `environment:` block reach the container, regardless of what else is in `.env`. This PR brings K8s to parity, no more.

## Changes

**New template**

- `roles/orchestrator/files/helm/canasta/templates/configmap-env.yaml` — new ConfigMap with one env var per ConfigMap key.

**Deployment template edits**

- `templates/deployment-web.yaml` — added `envFrom` referencing the new ConfigMap, added `checksum/env-config` annotation, added a big comment block explaining the env/envFrom split.
- `templates/deployment-jobrunner.yaml` — same treatment (jobrunner needs the same runtime knobs for job execution and maintenance scripts).

**Values + sync task**

- `values.yaml` — added `configData.env: {}` default.
- `tasks/k8s_sync_config.yml` — new `_k8s_pod_env_allowlist` fact, new `canasta_env read_all` task to parse `.env` as a dict, new `set_fact` to filter against the allowlist, new entry in the final `values-configdata.yaml` write.

**Tests**

- `tests/unit/test_kubernetes_structure.py` — added `configmap-env.yaml` to the required-templates list; added two new tests (`configData.env` exists in values.yaml default, both deployments reference the env ConfigMap via `envFrom`).
- `tests/integration/run_tests.py` — extended `test_k8s_lifecycle` with an end-to-end check: `canasta config set PHP_UPLOAD_MAX_FILESIZE=77M`, wait for rollout, `kubectl exec printenv`, assert the value reaches the pod. Prior K8s tests only verified helm artifact generation, not actual env var delivery.

## Test plan

- [x] `make test-unit` — 313 passed (up from 311)
- [x] `make validate` — passes
- [x] `make lint` — passes (Helm template yamllint warnings are pre-existing and unrelated)
- [x] `helm lint` on the chart — passes
- [x] `helm template` locally: new ConfigMap renders with correct data keys/values, both deployments correctly reference it via envFrom
- [ ] Integration `test_k8s_lifecycle` exercises the new config-set → pod printenv path in CI
