### PR TITLE
Make content PVC accessMode configurable for multi-node multi-replica web

### DIFF
--- a/docs/multi-node.md
+++ b/docs/multi-node.md
@@ -1,0 +1,422 @@
+# Multi-node Kubernetes deployments
+
+This guide walks through running Canasta on a multi-node Kubernetes
+cluster, with multiple web pods spread across nodes for load balancing
+and improved availability.
+
+For testing this end-to-end against a real cloud cluster, see
+[`MULTI_NODE_TEST_PLAN.md`](../../MULTI_NODE_TEST_PLAN.md) at the
+workspace root, which is the formal test plan we run before releases.
+
+## When you need this
+
+You probably want a multi-node multi-replica deployment if any of these
+are true:
+
+- Your wiki gets enough traffic that a single web pod is a bottleneck.
+- You need the wiki to keep serving page views during a node restart or
+  routine maintenance.
+- You're running on a managed Kubernetes service (EKS, GKE, AKS) where
+  multi-node clusters are the default and node failures are routine.
+
+You probably do **not** need this if:
+
+- You're running a small wiki on a single VM or single-node cluster.
+- Your traffic is low enough that a single web pod handles it without
+  load.
+- The database is your single point of failure (it usually is — see
+  the "Caveats and known limitations" section below before assuming
+  multi-replica web alone gives you HA).
+
+## What "multi-node multi-replica" actually buys you
+
+| Capability | Single-node default | Multi-node multi-replica web |
+|---|---|---|
+| Page-view load balancing across pods | No (one pod) | Yes |
+| Survives a single web pod crash | Yes (K8s reschedules) | Yes |
+| Survives a node failure | No (everything goes down) | **Only if pods are spread across nodes** — see caveats below |
+| Database HA | No | No (still a single DB pod by default; see "Caveats") |
+| Caddy HA | No | No (Caddy is still single-replica; see "Caveats") |
+
+So this guide gets you part of the way to a fully highly available
+deployment. The rest depends on what you do about the database, which
+is the bigger HA story.
+
+## Prerequisites
+
+- A multi-node Kubernetes cluster you can reach with `kubectl`.
+- ReadWriteMany-capable storage (NFS, EFS, CephFS, Longhorn-with-RWM,
+  or similar). Without RWM, you can have multiple replicas but they
+  cannot be spread across nodes.
+- `helm` 3.10 or newer on the host where you'll run `canasta`.
+- A domain name pointed at your cluster's ingress (for production HTTPS).
+- The Canasta-Ansible CLI installed and your controller's hosts.yml
+  configured to reach the host that has `kubectl` access to the cluster.
+
+## Step 1 — Provision the cluster
+
+Canasta-Ansible does not currently provision multi-node clusters for
+you. You need to bring up the cluster yourself, then point Canasta at
+it.
+
+### Self-managed k3s on cloud VMs (worked example: AWS EC2)
+
+This example uses two AWS EC2 instances. The same shape works on any
+cloud or on bare metal — just adapt the security-group / firewall
+sections to your provider.
+
+**EC2-specific bits**: launching the instances, security group rules,
+the use of private vs public IPs, and the `--tls-san` flag for the
+public IP. On other clouds (GCE, Azure, Hetzner, bare metal) the
+analogous concepts exist but the commands differ.
+
+#### 1a. Launch two instances
+
+```bash
+# Launch 2 EC2 instances:
+#   - AMI: Ubuntu 22.04 or 24.04 (amd64)
+#   - Type: t3.small or larger
+#   - Key pair: your SSH key
+#   - Security group rules:
+#     1. SSH (22/TCP) from your controller's IP
+#     2. HTTP (80/TCP) from anywhere (required for Let's Encrypt
+#        HTTP-01 challenge)
+#     3. HTTPS (443/TCP) from anywhere
+#     4. K8s API (6443/TCP) from your controller's IP
+#     5. *** All traffic (TCP + UDP) between instances in the same
+#        security group ***
+```
+
+The fifth rule is the one that catches people. **k3s uses VXLAN on
+UDP port 8472 for pod-to-pod networking across nodes.** If your
+security group only allows TCP between nodes, cross-node pod
+networking will silently fail — pods on the worker node will be
+unable to reach ClusterIP services (including CoreDNS) hosted on
+other nodes, and the symptoms look like generic DNS resolution
+failures inside pods. Always allow all UDP between nodes, not just
+all TCP.
+
+On other clouds, look for the equivalent: GCP firewall rules need
+"Allow all internal traffic" between cluster nodes; Azure NSGs
+need both TCP and UDP between subnets; etc.
+
+Record these values from the AWS console or CLI:
+
+- `NODE1_IP` — public IP of node 1 (will be the control plane)
+- `NODE2_IP` — public IP of node 2 (will be the worker)
+- `NODE1_PRIVATE` — **private** IP of node 1 (used for in-cluster
+  communication; the worker node joins via this address)
+
+#### 1b. Install k3s server on node 1
+
+```bash
+ssh ubuntu@<NODE1_IP>
+curl -sfL https://get.k3s.io | sudo sh -s - --tls-san <NODE1_IP>
+sudo cat /var/lib/rancher/k3s/server/node-token
+# Save this token: <TOKEN>
+exit
+```
+
+**EC2-specific note**: `--tls-san <NODE1_IP>` adds the public IP to
+the K8s API server's TLS certificate. Without it, kubectl from your
+controller laptop fails TLS validation when connecting to the public
+IP. On a cluster where the controller and k8s nodes share an internal
+network and the controller can reach the k8s API server by its
+internal IP, you don't need `--tls-san`.
+
+#### 1c. Join node 2 as a k3s worker
+
+```bash
+ssh ubuntu@<NODE2_IP>
+export K3S_URL=https://<NODE1_PRIVATE>:6443
+export K3S_TOKEN=<TOKEN>
+curl -sfL https://get.k3s.io | sudo -E sh -
+exit
+```
+
+This is vanilla k3s — no Canasta involvement. The same pattern works
+for adding more worker nodes later: each one runs the same `curl |
+sh` with the same `K3S_URL` and `K3S_TOKEN`.
+
+#### 1d. Configure kubectl on the controller
+
+```bash
+mkdir -p ~/.kube
+ssh ubuntu@<NODE1_IP> "sudo k3s kubectl config view --raw" > ~/.kube/config
+
+# Replace 127.0.0.1 with the public IP so the controller can reach
+# the API server. macOS:
+sed -i '' "s/127.0.0.1/<NODE1_IP>/" ~/.kube/config
+# Linux:
+# sed -i "s/127.0.0.1/<NODE1_IP>/" ~/.kube/config
+
+chmod 600 ~/.kube/config
+kubectl get nodes
+# Expected: 2 nodes, both Ready
+```
+
+### Managed Kubernetes (EKS, GKE, AKS)
+
+Skip k3s entirely. Provision your managed cluster the way your cloud
+provider documents — `eksctl`, Terraform, the cloud console, etc.
+Make sure to:
+
+- Launch worker nodes in at least two availability zones for real HA.
+- Configure your kubeconfig on the controller with whatever
+  cloud-specific tooling exists. For EKS this is
+  `aws eks update-kubeconfig --name <cluster> --region <region>`;
+  for GKE it's `gcloud container clusters get-credentials`; for AKS
+  it's `az aks get-credentials`.
+- Verify with `kubectl get nodes` that the controller can reach the
+  cluster.
+
+Once kubectl works, the rest of this guide is the same — Canasta
+treats any K8s cluster the same way regardless of where it came from.
+
+## Step 2 — Provision shared storage
+
+### Option A: NFS (works anywhere)
+
+You need an NFS server reachable from every node in the cluster. The
+simplest way is to install one on the same node that runs the k3s
+control plane, exporting a directory via NFS.
+
+```bash
+# On node 1:
+ssh ubuntu@<NODE1_IP>
+sudo apt-get update -qq
+sudo apt-get install -y nfs-kernel-server
+sudo mkdir -p /srv/nfs/canasta
+echo "/srv/nfs/canasta *(rw,sync,no_subtree_check,no_root_squash)" \
+  | sudo tee -a /etc/exports
+sudo exportfs -ra
+exit
+```
+
+In production you'd usually use a dedicated NFS host or managed NFS
+(EFS on AWS, Filestore on GCP, Azure Files on Azure) — running NFS on
+the same node as the K8s control plane is fine for testing but
+couples the storage's availability to that node's availability.
+
+Then install the NFS CSI driver and create a StorageClass:
+
+```bash
+# From your controller:
+canasta storage setup nfs \
+  --server <NODE1_PRIVATE> \
+  --share /srv/nfs/canasta \
+  --storage-class-name nfs
+
+kubectl get storageclass
+# Expected: nfs StorageClass listed
+```
+
+`canasta storage setup nfs` runs against the host you target with
+`--host` (defaulting to the local controller). It installs the
+`csi-driver-nfs` Helm chart on whatever K8s cluster is in the
+target's kubeconfig and creates a StorageClass pointing at the NFS
+server you specified.
+
+### Option B: AWS EFS
+
+For EKS or any other AWS-hosted cluster, EFS is the natural fit. It's
+managed, multi-AZ, and the EFS CSI driver is well-supported.
+
+1. Create an EFS filesystem in the same VPC as your EKS cluster.
+2. Add mount targets in each AZ where worker nodes run.
+3. Configure security groups to allow NFS (TCP 2049) from worker
+   security groups to the EFS mount target security group.
+4. Set up IRSA (IAM Roles for Service Accounts) so the EFS CSI driver
+   can manage access points. AWS documentation walks through this.
+
+Then:
+
+```bash
+canasta storage setup efs --filesystem-id fs-0123456789abcdef0
+```
+
+This installs the AWS EFS CSI driver and creates an `efs`
+StorageClass.
+
+### Option C: bring-your-own RWM storage
+
+If you already have RWM-capable storage on the cluster (CephFS,
+Longhorn-with-RWM, NetApp Trident, vendor-specific CSI drivers, etc.),
+you don't need `canasta storage setup` at all. Just verify with
+`kubectl get storageclass` that an RWM-capable class exists, and use
+its name when creating the instance below.
+
+## Step 3 — DNS
+
+Point your domain at the public IP of one of the cluster nodes. k3s
+includes Traefik as the default ingress controller, listening on
+ports 80 and 443 on every node, so the IP can be any node.
+
+```bash
+# Create an A record:
+#   wiki.example.com  →  <NODE1_IP>
+
+dig +short wiki.example.com
+# Expected: <NODE1_IP>
+```
+
+For wiki farms with subdomain routing, add a wildcard:
+`*.wiki.example.com → <NODE1_IP>`.
+
+On managed Kubernetes services, you'll typically have a load balancer
+in front of the ingress controller, and DNS points at the load
+balancer rather than at a node IP directly.
+
+## Step 4 — Create the instance
+
+```bash
+canasta create \
+  --id mywiki \
+  --wiki main \
+  --domain-name wiki.example.com \
+  --orchestrator kubernetes \
+  --storage-class nfs \
+  --access-mode ReadWriteMany
+```
+
+Both `--storage-class` and `--access-mode` are needed for multi-node
+multi-replica web. The two together tell the chart "use the NFS
+storage class for the four content PVCs, and declare them as
+ReadWriteMany so they can be mounted from multiple nodes
+simultaneously."
+
+If you omit `--access-mode`, the PVCs default to `ReadWriteOnce`. They
+will then physically work on most NFS implementations because the
+NFS CSI driver is lenient about access mode enforcement, but the
+chart's declared contract will be wrong, and the same setup will fail
+on stricter RWM backends like EFS or CephFS.
+
+After `canasta create` completes:
+
+```bash
+kubectl get pods -n canasta-mywiki
+# Expected: web, caddy, varnish, db, jobrunner — all Running
+
+kubectl get pvc -n canasta-mywiki
+# Expected: images, extensions, skins, public-assets bound on the nfs
+#           StorageClass with ACCESS MODES = RWX
+#           (db-data uses local-path by default — see Caveats)
+```
+
+## Step 5 — Scale the web tier
+
+Edit the instance's `values.yaml` and set `web.replicaCount`:
+
+```bash
+# Find the instance path:
+canasta list
+
+# Edit instance_path/values.yaml:
+#   web:
+#     replicaCount: 3
+#
+# Then restart so the helm upgrade picks up the change:
+canasta restart --id mywiki
+```
+
+There is no `canasta scale` command yet — the canonical way to change
+replica counts is to edit `values.yaml` and run `canasta restart`. The
+restart flow reads `web.replicaCount` from `values.yaml` and applies
+it via `helm upgrade`.
+
+```bash
+kubectl get pods -n canasta-mywiki -o wide | grep web
+# Expected: 3 web pods, ideally on multiple nodes
+```
+
+### Pod spread caveat
+
+The default Kubernetes scheduler will try to distribute pods across
+nodes based on resource availability, but **it does not guarantee
+spread**. With `replicaCount: 3` and two nodes, you may get two pods
+on one node and one on the other, or all three on the same node, or
+2-1, depending on what the scheduler thinks is optimal at the time.
+
+If you need stricter spread guarantees, you can manually force a
+re-schedule by cordoning the node where pods are clustered:
+
+```bash
+kubectl cordon <node-name>      # mark node unschedulable
+canasta restart --id mywiki     # forces rescheduling
+kubectl uncordon <node-name>    # re-allow scheduling
+```
+
+This is a known limitation. Adding pod anti-affinity or topology
+spread constraints to the chart would solve it properly and is
+tracked as a separate follow-up.
+
+## Caveats and known limitations
+
+Multi-node multi-replica web is **not** the same as full HA. Several
+single-points-of-failure remain by default:
+
+### Database
+
+The default deployment runs **one** MariaDB pod backed by a
+node-local PVC (`local-path` storage class on k3s). If the node
+hosting the DB pod fails, the DB pod cannot reschedule until that
+node recovers, and the entire wiki goes down regardless of how many
+web replicas you have.
+
+**For production HA, the recommended approach is to use an external
+database service** (RDS Multi-AZ, Aurora, CloudSQL, managed Galera,
+etc.) and point Canasta at it. External DB support is on the roadmap;
+see [issue #347 in
+Canasta-CLI](https://github.com/CanastaWiki/Canasta-CLI/issues/347)
+for the current status and the broader HA discussion.
+
+In the meantime, "multi-replica web with single-pod local-path DB" is
+useful for load distribution and partial fault tolerance (any node
+failure that isn't the DB node leaves the wiki running) but should
+not be confused with full HA.
+
+### Caddy
+
+Caddy is still single-replica in the default chart. The `caddy-data`
+PVC stores TLS certificates and is `ReadWriteOnce`, and multiple
+Caddy replicas would also independently provision Let's Encrypt
+certificates and hit ACME rate limits. Caddy clustering is a separate
+follow-up.
+
+### Elasticsearch / OpenSearch
+
+Both run as single-node by default with `discovery.type=single-node`
+hardcoded. If you need a clustered Elasticsearch, you currently have
+to configure it yourself outside the chart.
+
+### Pod scheduling
+
+As noted in Step 5, the chart does not yet declare pod anti-affinity
+or topology spread constraints. Multi-replica spread is best-effort,
+not guaranteed.
+
+## Troubleshooting
+
+**Pods on the worker node cannot resolve DNS or reach ClusterIP
+services.** This is the VXLAN/UDP problem on EC2 (and analogous
+issues on other clouds). Verify the security group allows all UDP
+between cluster nodes, not just TCP. The smoking-gun symptom is the
+web pod's `wait-for-db` init container hanging on DNS lookup of `db`.
+
+**PVCs stuck in `Pending`.** Run `kubectl describe pvc <name>` to see
+the actual binding error. Common causes:
+
+- StorageClass doesn't exist (check `kubectl get storageclass`).
+- StorageClass exists but doesn't support the requested access mode
+  (e.g. asking for `ReadWriteMany` against a class backed by EBS).
+- Provisioner is failing (CSI driver pod is not running or doesn't
+  have the right IAM permissions on EKS).
+
+**Web replicas pending after scale-up.** Likely an RWO PVC is already
+attached to a different node. Either set `--access-mode ReadWriteMany`
+when creating the instance, or accept that all replicas must land on
+the node holding the PVC.
+
+**Pods all on one node despite multi-node cluster.** No anti-affinity
+in the chart yet. Use the cordon workaround in Step 5, or wait for the
+anti-affinity follow-up.

--- a/docs/multi-node.md
+++ b/docs/multi-node.md
@@ -4,10 +4,6 @@ This guide walks through running Canasta on a multi-node Kubernetes
 cluster, with multiple web pods spread across nodes for load balancing
 and improved availability.
 
-For testing this end-to-end against a real cloud cluster, see
-[`MULTI_NODE_TEST_PLAN.md`](../../MULTI_NODE_TEST_PLAN.md) at the
-workspace root, which is the formal test plan we run before releases.
-
 ## When you need this
 
 You probably want a multi-node multi-replica deployment if any of these
@@ -346,9 +342,8 @@ canasta restart --id mywiki     # forces rescheduling
 kubectl uncordon <node-name>    # re-allow scheduling
 ```
 
-This is a known limitation. Adding pod anti-affinity or topology
-spread constraints to the chart would solve it properly and is
-tracked as a separate follow-up.
+If your workload depends on guaranteed pod spread for fault
+tolerance, the cordon workaround above is the current solution.
 
 ## Caveats and known limitations
 
@@ -363,25 +358,28 @@ hosting the DB pod fails, the DB pod cannot reschedule until that
 node recovers, and the entire wiki goes down regardless of how many
 web replicas you have.
 
-**For production HA, the recommended approach is to use an external
-database service** (RDS Multi-AZ, Aurora, CloudSQL, managed Galera,
-etc.) and point Canasta at it. External DB support is on the roadmap;
-see [issue #347 in
-Canasta-CLI](https://github.com/CanastaWiki/Canasta-CLI/issues/347)
-for the current status and the broader HA discussion.
+For production high availability, the recommended approach is to use
+an external database service (a managed MariaDB or MySQL such as RDS
+Multi-AZ, Aurora, Cloud SQL, or a self-managed Galera cluster) and
+point Canasta at it instead of running the bundled DB pod. The
+external database handles its own replication, failover, and backups,
+which removes the database tier as a single point of failure for the
+wiki.
 
-In the meantime, "multi-replica web with single-pod local-path DB" is
-useful for load distribution and partial fault tolerance (any node
-failure that isn't the DB node leaves the wiki running) but should
-not be confused with full HA.
+If you keep the bundled DB pod, "multi-replica web with single-pod
+local-path DB" is useful for load distribution and partial fault
+tolerance — any node failure that isn't the DB node leaves the wiki
+running — but should not be confused with full high availability.
 
 ### Caddy
 
-Caddy is still single-replica in the default chart. The `caddy-data`
-PVC stores TLS certificates and is `ReadWriteOnce`, and multiple
-Caddy replicas would also independently provision Let's Encrypt
-certificates and hit ACME rate limits. Caddy clustering is a separate
-follow-up.
+Caddy is single-replica in the default chart. The `caddy-data` PVC
+stores TLS certificates and is `ReadWriteOnce`, and multiple Caddy
+replicas would also independently provision Let's Encrypt
+certificates and hit ACME rate limits. If you need a highly available
+HTTPS termination layer, the supported approach is to put an external
+load balancer or ingress controller in front of Canasta and disable
+Canasta's own TLS handling with the `--skip-tls` flag at create time.
 
 ### Elasticsearch / OpenSearch
 
@@ -391,9 +389,11 @@ to configure it yourself outside the chart.
 
 ### Pod scheduling
 
-As noted in Step 5, the chart does not yet declare pod anti-affinity
-or topology spread constraints. Multi-replica spread is best-effort,
-not guaranteed.
+As noted in Step 5, the chart does not declare pod anti-affinity or
+topology spread constraints. Multi-replica spread is best-effort,
+based on the Kubernetes scheduler's default scoring (resource
+availability and balance). Use the cordon workaround above if you
+need to force pods onto specific nodes.
 
 ## Troubleshooting
 
@@ -417,6 +417,6 @@ attached to a different node. Either set `--access-mode ReadWriteMany`
 when creating the instance, or accept that all replicas must land on
 the node holding the PVC.
 
-**Pods all on one node despite multi-node cluster.** No anti-affinity
-in the chart yet. Use the cordon workaround in Step 5, or wait for the
-anti-affinity follow-up.
+**Pods all on one node despite multi-node cluster.** The Kubernetes
+scheduler doesn't guarantee spread without anti-affinity rules. Use
+the cordon workaround in Step 5 to force a re-schedule.

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -164,7 +164,10 @@ commands:
       - name: access_mode
         type: string
         orchestrator_only: kubernetes
-        description: "Access mode for content PVCs (ReadWriteOnce or ReadWriteMany). Use ReadWriteMany when also setting an RWM-capable storage class for multi-node multi-replica web pods."
+        description: >-
+          Access mode for content PVCs (ReadWriteOnce or
+          ReadWriteMany). Use ReadWriteMany with an RWM-capable
+          storage class for multi-node multi-replica web pods.
       - name: tls_email
         type: string
         orchestrator_only: kubernetes

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -161,6 +161,10 @@ commands:
         type: string
         orchestrator_only: kubernetes
         description: "Kubernetes storage class for shared volumes (e.g. nfs, efs)"
+      - name: access_mode
+        type: string
+        orchestrator_only: kubernetes
+        description: "Access mode for content PVCs (ReadWriteOnce or ReadWriteMany). Use ReadWriteMany when also setting an RWM-capable storage class for multi-node multi-replica web pods."
       - name: tls_email
         type: string
         orchestrator_only: kubernetes

--- a/playbooks/storage_setup_efs.yml
+++ b/playbooks/storage_setup_efs.yml
@@ -50,7 +50,15 @@
 - name: Report setup complete
   ansible.builtin.debug:
     msg:
-      - "EFS storage configured. StorageClass '{{ storage_class_name | default('efs') }}' is ready and set as the default for new Kubernetes instances."
-      - "To run a multi-replica web pod across nodes, also pass --access-mode ReadWriteMany when creating the instance:"
-      - "  canasta create -i myinstance --orchestrator kubernetes --storage-class {{ storage_class_name | default('efs') }} --access-mode ReadWriteMany ..."
+      - >-
+        EFS storage configured. StorageClass
+        '{{ storage_class_name | default('efs') }}' is ready and set
+        as the default for new Kubernetes instances.
+      - >-
+        To run a multi-replica web pod across nodes, also pass
+        --access-mode ReadWriteMany when creating the instance:
+      - >-
+        canasta create -i <id> --orchestrator kubernetes
+        --storage-class {{ storage_class_name | default('efs') }}
+        --access-mode ReadWriteMany ...
       - "See docs/multi-node.md for the full walkthrough."

--- a/playbooks/storage_setup_efs.yml
+++ b/playbooks/storage_setup_efs.yml
@@ -49,6 +49,8 @@
 
 - name: Report setup complete
   ansible.builtin.debug:
-    msg: >-
-      EFS storage configured. StorageClass '{{ storage_class_name | default('efs') }}'
-      is ready and set as the default for new Kubernetes instances.
+    msg:
+      - "EFS storage configured. StorageClass '{{ storage_class_name | default('efs') }}' is ready and set as the default for new Kubernetes instances."
+      - "To run a multi-replica web pod across nodes, also pass --access-mode ReadWriteMany when creating the instance:"
+      - "  canasta create -i myinstance --orchestrator kubernetes --storage-class {{ storage_class_name | default('efs') }} --access-mode ReadWriteMany ..."
+      - "See docs/multi-node.md for the full walkthrough."

--- a/playbooks/storage_setup_nfs.yml
+++ b/playbooks/storage_setup_nfs.yml
@@ -104,7 +104,15 @@
 - name: Report setup complete
   ansible.builtin.debug:
     msg:
-      - "NFS storage configured. StorageClass '{{ storage_class_name | default('nfs') }}' is ready and set as the default for new Kubernetes instances."
-      - "To run a multi-replica web pod across nodes, also pass --access-mode ReadWriteMany when creating the instance:"
-      - "  canasta create -i myinstance --orchestrator kubernetes --storage-class {{ storage_class_name | default('nfs') }} --access-mode ReadWriteMany ..."
+      - >-
+        NFS storage configured. StorageClass
+        '{{ storage_class_name | default('nfs') }}' is ready and set
+        as the default for new Kubernetes instances.
+      - >-
+        To run a multi-replica web pod across nodes, also pass
+        --access-mode ReadWriteMany when creating the instance:
+      - >-
+        canasta create -i <id> --orchestrator kubernetes
+        --storage-class {{ storage_class_name | default('nfs') }}
+        --access-mode ReadWriteMany ...
       - "See docs/multi-node.md for the full walkthrough."

--- a/playbooks/storage_setup_nfs.yml
+++ b/playbooks/storage_setup_nfs.yml
@@ -103,6 +103,8 @@
 
 - name: Report setup complete
   ansible.builtin.debug:
-    msg: >-
-      NFS storage configured. StorageClass '{{ storage_class_name | default('nfs') }}'
-      is ready and set as the default for new Kubernetes instances.
+    msg:
+      - "NFS storage configured. StorageClass '{{ storage_class_name | default('nfs') }}' is ready and set as the default for new Kubernetes instances."
+      - "To run a multi-replica web pod across nodes, also pass --access-mode ReadWriteMany when creating the instance:"
+      - "  canasta create -i myinstance --orchestrator kubernetes --storage-class {{ storage_class_name | default('nfs') }} --access-mode ReadWriteMany ..."
+      - "See docs/multi-node.md for the full walkthrough."

--- a/roles/orchestrator/files/helm/canasta/templates/pvc-extensions.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/pvc-extensions.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "canasta.labels" . | nindent 4 }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    - {{ .Values.persistence.extensions.accessMode }}
   {{- if .Values.persistence.extensions.storageClass }}
   storageClassName: {{ .Values.persistence.extensions.storageClass }}
   {{- end }}

--- a/roles/orchestrator/files/helm/canasta/templates/pvc-images.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/pvc-images.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "canasta.labels" . | nindent 4 }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    - {{ .Values.persistence.images.accessMode }}
   {{- if .Values.persistence.images.storageClass }}
   storageClassName: {{ .Values.persistence.images.storageClass }}
   {{- end }}

--- a/roles/orchestrator/files/helm/canasta/templates/pvc-public-assets.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/pvc-public-assets.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "canasta.labels" . | nindent 4 }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    - {{ .Values.persistence.publicAssets.accessMode }}
   {{- if .Values.persistence.publicAssets.storageClass }}
   storageClassName: {{ .Values.persistence.publicAssets.storageClass }}
   {{- end }}

--- a/roles/orchestrator/files/helm/canasta/templates/pvc-skins.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/pvc-skins.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "canasta.labels" . | nindent 4 }}
 spec:
   accessModes:
-    - ReadWriteOnce
+    - {{ .Values.persistence.skins.accessMode }}
   {{- if .Values.persistence.skins.storageClass }}
   storageClassName: {{ .Values.persistence.skins.storageClass }}
   {{- end }}

--- a/roles/orchestrator/files/helm/canasta/values.yaml
+++ b/roles/orchestrator/files/helm/canasta/values.yaml
@@ -98,21 +98,29 @@ ingress:
     issuer: letsencrypt-prod
 
 # Persistent volumes
-# For multi-node clusters, set storageClass to a ReadWriteMany provisioner
-# (e.g. nfs, efs). See 'canasta storage setup' for help configuring shared storage.
+# For multi-node multi-replica web pods, set storageClass to a
+# ReadWriteMany provisioner (e.g. nfs, efs) AND set accessMode to
+# ReadWriteMany. The default ReadWriteOnce is correct for single-node
+# clusters and for multi-replica deployments where all pods can be
+# scheduled to the same node. See docs/multi-node.md and
+# 'canasta storage setup' for help configuring shared storage.
 persistence:
   images:
     size: 10Gi
     storageClass: ""
+    accessMode: ReadWriteOnce
   extensions:
     size: 1Gi
     storageClass: ""
+    accessMode: ReadWriteOnce
   skins:
     size: 1Gi
     storageClass: ""
+    accessMode: ReadWriteOnce
   publicAssets:
     size: 1Gi
     storageClass: ""
+    accessMode: ReadWriteOnce
 
 # Secrets — names of K8s Secrets created by Ansible (not stored here)
 secrets:

--- a/roles/orchestrator/templates/k8s_values.yaml.j2
+++ b/roles/orchestrator/templates/k8s_values.yaml.j2
@@ -31,15 +31,35 @@ secrets:
 
 argocd:
   namespace: {{ argocd_namespace | default('argocd') }}
-{% if storage_class is defined and storage_class != '' %}
+{% if (storage_class is defined and storage_class != '') or (access_mode is defined and access_mode != '') %}
 
 persistence:
   images:
+{% if storage_class is defined and storage_class != '' %}
     storageClass: {{ storage_class }}
+{% endif %}
+{% if access_mode is defined and access_mode != '' %}
+    accessMode: {{ access_mode }}
+{% endif %}
   extensions:
+{% if storage_class is defined and storage_class != '' %}
     storageClass: {{ storage_class }}
+{% endif %}
+{% if access_mode is defined and access_mode != '' %}
+    accessMode: {{ access_mode }}
+{% endif %}
   skins:
+{% if storage_class is defined and storage_class != '' %}
     storageClass: {{ storage_class }}
+{% endif %}
+{% if access_mode is defined and access_mode != '' %}
+    accessMode: {{ access_mode }}
+{% endif %}
   publicAssets:
+{% if storage_class is defined and storage_class != '' %}
     storageClass: {{ storage_class }}
+{% endif %}
+{% if access_mode is defined and access_mode != '' %}
+    accessMode: {{ access_mode }}
+{% endif %}
 {% endif %}

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -88,6 +88,49 @@ class TestHelmChart:
                 % template_name
             )
 
+    def test_persistence_subkeys_have_access_mode_default(self):
+        """Each content PVC must have an accessMode default in values.yaml
+        so the chart renders without requiring users to set it (#55)."""
+        with open(os.path.join(HELM_CHART, "values.yaml")) as f:
+            values = yaml.safe_load(f)
+        assert "persistence" in values
+        for subkey in ("images", "extensions", "skins", "publicAssets"):
+            assert subkey in values["persistence"], (
+                "persistence.%s missing from values.yaml" % subkey
+            )
+            assert "accessMode" in values["persistence"][subkey], (
+                "persistence.%s.accessMode missing from values.yaml" % subkey
+            )
+            mode = values["persistence"][subkey]["accessMode"]
+            assert mode in ("ReadWriteOnce", "ReadWriteMany"), (
+                "persistence.%s.accessMode must be ReadWriteOnce or "
+                "ReadWriteMany, got %r" % (subkey, mode)
+            )
+
+    def test_content_pvcs_use_configurable_access_mode(self):
+        """The four content PVC templates must read accessMode from values.yaml
+        rather than hardcoding ReadWriteOnce, so multi-node multi-replica
+        web on RWM-capable storage is contractually correct (#55)."""
+        templates = os.path.join(HELM_CHART, "templates")
+        pvc_subkey_map = {
+            "pvc-images.yaml": "images",
+            "pvc-extensions.yaml": "extensions",
+            "pvc-skins.yaml": "skins",
+            "pvc-public-assets.yaml": "publicAssets",
+        }
+        for template_name, subkey in pvc_subkey_map.items():
+            with open(os.path.join(templates, template_name)) as f:
+                content = f.read()
+            expected = ".Values.persistence.%s.accessMode" % subkey
+            assert expected in content, (
+                "%s must read accessMode from %s" % (template_name, expected)
+            )
+            # Sanity: the old hardcoded "- ReadWriteOnce" line should be gone.
+            assert "- ReadWriteOnce" not in content, (
+                "%s still has hardcoded '- ReadWriteOnce' — should be templated"
+                % template_name
+            )
+
 
 class TestGitopsDispatchers:
     """Verify that each dispatched gitops command has both variants."""


### PR DESCRIPTION
Fixes #55.

## Bug

The four content PVCs (`images`, `extensions`, `skins`, `publicAssets`) hardcoded `accessModes: [ReadWriteOnce]` with no override path. This meant `web.replicaCount > 1` on a multi-node cluster only worked on NFS thanks to `csi-driver-nfs`'s lenient access-mode enforcement — the same setup would fail contractually on stricter RWM backends like EFS, CephFS, or Longhorn-with-RWM, even though the chart's own `values.yaml` comment said *"set storageClass to a ReadWriteMany provisioner"* as if that were sufficient.

The multi-node test we ran last week (see `MULTI_NODE_TEST_PLAN.md`) appeared to work because the NFS CSI driver allowed multiple nodes to mount the same RWO PV. That worked but was relying on driver-specific leniency, not on a correct contract.

## Fix

Per-PVC `accessMode` field on each persistence subkey in `values.yaml`, defaulting to `ReadWriteOnce`. The four PVC templates now read `.Values.persistence.<key>.accessMode` directly with no `default` filter — if the field is missing, the chart errors at render time, which is the right failure mode given K8s is still in development.

## Changes

**Chart (5 files)**

- `templates/pvc-images.yaml`, `pvc-extensions.yaml`, `pvc-skins.yaml`, `pvc-public-assets.yaml`: `- ReadWriteOnce` → `- {{ .Values.persistence.<key>.accessMode }}`.
- `values.yaml`: added `accessMode: ReadWriteOnce` default to each persistence subkey, plus an updated comment block pointing at `docs/multi-node.md`.

**Create flow (2 files)**

- `meta/command_definitions.yml`: new `--access-mode` parameter on `canasta create`, `orchestrator_only: kubernetes`.
- `roles/orchestrator/templates/k8s_values.yaml.j2`: extended the existing `storage_class` block to also emit `accessMode` per persistence subkey when `--access-mode` is given. Both flags are independently optional; with neither given, the template emits no `persistence:` section and the chart defaults apply (backward-compatible single-node default).

**Storage setup hints (2 files)**

- `playbooks/storage_setup_nfs.yml` and `storage_setup_efs.yml`: replaced the single-line "setup complete" debug with a multi-line message pointing users at `--access-mode ReadWriteMany` and `docs/multi-node.md`.

**Tests (1 file)**

- `tests/unit/test_kubernetes_structure.py`:
  - `test_persistence_subkeys_have_access_mode_default` — values.yaml has `accessMode` set to a valid value for each of the four content PVCs.
  - `test_content_pvcs_use_configurable_access_mode` — each PVC template references `.Values.persistence.<subkey>.accessMode` and no longer has a hardcoded `- ReadWriteOnce`.

**Documentation (1 file, new)**

- `docs/multi-node.md`: full user-facing walkthrough, written so it can become a section of the public Canasta user guide at https://canasta.wiki without further editing. Cluster-agnostic where possible, with EC2-specific bits clearly flagged. Covers:
  - When you need multi-node multi-replica (and when you don't)
  - What it actually buys you (load balancing, partial fault tolerance) vs what it doesn't (DB/Caddy/ES still SPOFs)
  - k3s self-managed setup with `--tls-san` and the UDP 8472 security group caveat from last week's debugging
  - Managed Kubernetes alternatives (EKS, GKE, AKS) — pointing at cloud-native primitives without re-documenting them
  - Shared storage via NFS, EFS, or BYO RWM provisioners
  - Instance creation with `--storage-class` and `--access-mode`
  - Scaling via the existing `values.yaml` hand-edit + `canasta restart` workflow
  - The cordon-to-force-spread workaround for the missing pod anti-affinity
  - "Caveats and known limitations" section honest about DB / Caddy / ES still being SPOFs, with the external-database recommendation described in prose (no internal links or issue references that would be out of place in public docs)
  - Troubleshooting (VXLAN/UDP, pending PVCs, pod scheduling)

## Commits in this PR

- `633ce0e` — Chart change, create flow, storage setup hints, unit tests, initial draft of `docs/multi-node.md`.
- `941f9a6` — Polish `docs/multi-node.md` for the public user guide. Drops references to internal files (`MULTI_NODE_TEST_PLAN.md`) and external issue trackers (Canasta-CLI #347), reframes "follow-up" / "tracked" language to describe current state and supported workarounds. No technical content changes.
- `4eaad52` — Wrap five long lines (one in `meta/command_definitions.yml`, two in each of the storage setup playbooks) that exceeded the project's 140-char yamllint limit. Folded block scalars for the multi-line debug messages, folded scalar for the access_mode parameter description. No functional changes.

## Out of scope (separate follow-ups)

- **Pod anti-affinity / topology spread** for guaranteed multi-node spread. Today the scheduler may pile multiple replicas on one node unless the user manually cordons; documented as a known limitation.
- **`canasta scale` / `canasta resources` convenience commands** for the `values.yaml`-edit workflow. The hand-edit pattern works but isn't ergonomic.
- **`defaultStorageClass` registry hint scoping bug** (it's controller-global, should be per-host or removed). Adjacent but separate.
- **`tests/integration/molecule/kubernetes/` cleanup** — that scenario still references kind even though the active K8s test infrastructure is k3s. Stale code worth removing.

## Test plan

- [x] `make test-unit` — 315 passed (up from 313)
- [x] `make validate` — passes
- [x] `make lint` — exit 0, zero yamllint annotations on the latest commit
- [x] `helm lint` on the chart — passes
- [x] `helm template` with `--set persistence.<key>.accessMode=ReadWriteMany` renders the four content PVCs as `ReadWriteMany`, leaves the DB StatefulSet at `ReadWriteOnce`
- [x] `helm template` with no overrides falls back to `ReadWriteOnce` for all four (backward-compatible default)
- [x] Direct Jinja render of `k8s_values.yaml.j2` with both `storage_class=nfs access_mode=ReadWriteMany` produces the correct nested YAML
- [x] Direct Jinja render with neither flag produces no `persistence:` section
- [x] CI passes (all 9 checks green on the latest commit)
- [ ] Full multi-node test rerun on EC2 per `MULTI_NODE_TEST_PLAN.md` to verify the chart change doesn't regress anything that was working before
