### PR TITLE
Document instance-size and storage requirements for multi-node setup

### DIFF
--- a/docs/multi-node.md
+++ b/docs/multi-node.md
@@ -71,7 +71,14 @@ analogous concepts exist but the commands differ.
 ```bash
 # Launch 2 EC2 instances:
 #   - AMI: Ubuntu 22.04 or 24.04 (amd64)
-#   - Type: t3.small or larger
+#   - Type: needs at least 4 GiB of total RAM. Working choices for
+#     a small wiki without Elasticsearch include c7i-flex.large
+#     (4 GiB), t3.medium (4 GiB), t3.large (8 GiB), and
+#     c7i-flex.xlarge (8 GiB). For wikis with Elasticsearch enabled
+#     or with significant traffic, use 8 GiB or larger.
+#   - Storage: 20 GB gp3 EBS root volume or larger. The default
+#     8 GB Ubuntu AMI is too small once the Canasta image, k3s
+#     images, and PVC working space are accounted for.
 #   - Key pair: your SSH key
 #   - Security group rules:
 #     1. SSH (22/TCP) from your controller's IP


### PR DESCRIPTION
Fixes #59.

Documents the actual instance-size and storage requirements for multi-node EC2 setup in `docs/multi-node.md`. This update was meant to land as part of #56 but the commit ended up orphaned when the PR was merged before the docs polish was finished.

## Changes

- Replace `Type: t3.small or larger` (which is wrong — t3.small can't run Canasta) with concrete working choices: `c7i-flex.large`, `t3.medium` (4 GiB), `t3.large`, `c7i-flex.xlarge` (8 GiB).
- Add the previously-missing storage requirement (20 GB gp3 EBS root, with explanation).
- Note that the 4 GiB instances are sufficient for small wikis without Elasticsearch, and 8 GiB+ is recommended for Elasticsearch or significant traffic.

## Test plan

- [x] Documentation only — no code changes
- [x] Lines wrapped within the project's yamllint limits (no .yml/.yaml files modified)
- [ ] CI passes