### PR TITLE
Enforce 4 GiB total memory at preflight on both Compose and K8s

### DIFF
--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -26,7 +26,11 @@
     - orchestrator | default('compose') == 'compose'
     - _docker_check.rc | default(0) != 0
 
-- name: Check system memory (minimum 4GB)
+# Compose-only host memory preflight. The K8s path has its own
+# per-node memory check in k8s_preflight.yml — running this on a K8s
+# create would measure the controller host, not the cluster nodes,
+# which is the wrong thing. See #58.
+- name: Check target host total memory (minimum 4 GiB) — Compose only
   ansible.builtin.command:
     cmd: >-
       python3 -c "import os;
@@ -36,13 +40,20 @@
   register: _mem_check
   changed_when: false
   ignore_errors: true
+  when: orchestrator | default('compose') == 'compose'
 
-- name: Warn about low memory
-  ansible.builtin.debug:
+- name: Fail if target host has less than 4 GiB total memory
+  ansible.builtin.fail:
     msg: >-
-      WARNING: System has less than 4GB RAM.
-      Canasta may not run properly.
-  when: _mem_check.rc != 0
+      Canasta requires at least 4 GiB of total memory on the target
+      host. The host has less than that. If you intentionally want to
+      run on a smaller host (with Elasticsearch and Varnish disabled
+      and only the lightest workload), you'll need to make this check
+      configurable — but in practice 4 GiB is the floor below which
+      Canasta will not start reliably.
+  when:
+    - orchestrator | default('compose') == 'compose'
+    - _mem_check.rc | default(0) != 0
 
 # --- Step 1: Validate inputs ---
 - name: Validate instance ID

--- a/roles/orchestrator/files/scripts/check_node_resources.py
+++ b/roles/orchestrator/files/scripts/check_node_resources.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
 """Check that at least one Kubernetes node meets minimum resource requirements.
 
-Reads node allocatable data from NODE_DATA env var (tab-separated lines of
-name, cpu, memory, ephemeral-storage as output by kubectl jsonpath) and
-compares against MIN_CPU_MILLI, MIN_MEMORY_MI, and MIN_STORAGE_GI.
+Reads node capacity data from NODE_DATA env var (tab-separated lines of
+name, cpu, memory, ephemeral-storage as output by kubectl jsonpath against
+.status.capacity) and compares against MIN_CPU_MILLI, MIN_MEMORY_MI, and
+MIN_STORAGE_GI.
+
+Capacity, not allocatable: see #58 for the rationale. Allocatable is what
+kubelet will schedule (capacity minus kube-reserved minus system-reserved
+minus eviction-threshold), and on a 4 GiB node it's ~3.5 GiB. Checking
+against capacity makes the threshold match what the user sees as their
+instance size.
 
 Exits 0 if any node qualifies, 1 otherwise.  Prints a per-node summary to
 stdout so Ansible can include it in its failure message.
@@ -44,7 +51,7 @@ def parse_storage(value):
 def main():
     node_data = os.environ.get("NODE_DATA", "").strip()
     min_cpu = int(os.environ.get("MIN_CPU_MILLI", 600))
-    min_mem = int(os.environ.get("MIN_MEMORY_MI", 1216))
+    min_mem = int(os.environ.get("MIN_MEMORY_MI", 4096))
     min_stor = int(os.environ.get("MIN_STORAGE_GI", 15))
 
     if not node_data:

--- a/roles/orchestrator/tasks/k8s_preflight.yml
+++ b/roles/orchestrator/tasks/k8s_preflight.yml
@@ -43,13 +43,21 @@
       See https://helm.sh/docs/intro/install/
   when: _helm_check.rc != 0
 
-- name: Get node allocatable resources
+- name: Get node capacity resources
   vars:
+    # Read .status.capacity (the total capacity reported by the kernel,
+    # ≈ MemTotal) rather than .status.allocatable (capacity minus
+    # kube-reserved minus system-reserved minus eviction-threshold).
+    # Allocatable on a 4 GiB node is ~3.5 GiB, so a 4 GiB threshold
+    # against allocatable would reject the smallest instance we want
+    # to support. Capacity is the right field for matching against
+    # the user's intuitive "this is a 4 GiB instance" understanding.
+    # See #58.
     _jp: >-
       {range .items[*]}{.metadata.name}{"\t"}
-      {.status.allocatable.cpu}{"\t"}
-      {.status.allocatable.memory}{"\t"}
-      {.status.allocatable.ephemeral-storage}{"\n"}{end}
+      {.status.capacity.cpu}{"\t"}
+      {.status.capacity.memory}{"\t"}
+      {.status.capacity.ephemeral-storage}{"\n"}{end}
   ansible.builtin.command:
     cmd: >-
       kubectl get nodes
@@ -59,12 +67,23 @@
 
 - name: Check node resources are sufficient
   vars:
-    # Minimum requirements for a Canasta instance.
-    # CPU: 600m total requests (web 250 + caddy 50 + varnish 100 + db 100 + jobrunner 100)
-    # Memory: 1216Mi total requests (web 512 + caddy 64 + varnish 128 + db 256 + jobrunner 256)
-    # Ephemeral storage: 20Gi (Canasta image is several GB when unpacked)
+    # Minimum requirements for a Canasta instance, expressed against
+    # node capacity (not allocatable; not the sum of pod requests).
+    # Memory: 4 GiB total. This matches the Compose-side check in
+    # roles/create/tasks/main.yml and is the documented floor below
+    # which Canasta will not run reliably. With Elasticsearch enabled
+    # or under heavy traffic, 8 GiB+ is recommended; users opting in
+    # to those should size up.
+    # CPU: 600m, the sum of resource requests across the chart's
+    # default components. This is the minimum that schedules; it's
+    # not a memory-style hard floor because Canasta is mostly memory
+    # bound, not CPU bound.
+    # Storage: 15 GiB ephemeral, enough for the Canasta image and
+    # k3s images plus working space. Real wikis with non-trivial
+    # content should use a larger storage class for the content
+    # PVCs; this minimum is only about ephemeral / image space.
     _min_cpu_milli: 600
-    _min_memory_mi: 1216
+    _min_memory_mi: 4096
     _min_storage_gi: 15
   block:
     - name: Evaluate node capacity
@@ -84,10 +103,11 @@
     - name: Fail if no node has sufficient resources
       ansible.builtin.fail:
         msg: >-
-          No Kubernetes node meets the minimum resource requirements for a
-          Canasta instance.  Minimum: {{ _min_cpu_milli }}m CPU,
-          {{ _min_memory_mi }}Mi memory, {{ _min_storage_gi }}Gi ephemeral
-          storage.  Node details:
+          No Kubernetes node meets the minimum resource requirements
+          for a Canasta instance. Required (against node capacity):
+          at least {{ _min_memory_mi }} MiB total memory,
+          {{ _min_cpu_milli }}m CPU, {{ _min_storage_gi }} GiB
+          ephemeral storage. Node details:
           {{ _resource_check.stdout | default('(check script failed)') }}
       when: _resource_check.rc != 0
 

--- a/tests/unit/test_check_node_resources.py
+++ b/tests/unit/test_check_node_resources.py
@@ -1,0 +1,134 @@
+"""Unit tests for the K8s node resource preflight script.
+
+The script is invoked by k8s_preflight.yml against the output of
+`kubectl get nodes -o jsonpath` reading .status.capacity, and checks
+whether at least one node meets the configured minimums.
+
+See #58 for the rationale behind checking capacity rather than
+allocatable, and the 4 GiB total memory threshold.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+SCRIPT = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..",
+    "..",
+    "roles",
+    "orchestrator",
+    "files",
+    "scripts",
+    "check_node_resources.py",
+)
+
+
+def run_script(node_data, min_cpu="600", min_mem="4096", min_stor="15"):
+    """Run check_node_resources.py with the given env, return (rc, stdout)."""
+    env = os.environ.copy()
+    env["NODE_DATA"] = node_data
+    env["MIN_CPU_MILLI"] = min_cpu
+    env["MIN_MEMORY_MI"] = min_mem
+    env["MIN_STORAGE_GI"] = min_stor
+    proc = subprocess.run(
+        [sys.executable, SCRIPT],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode, proc.stdout
+
+
+class TestCheckNodeResources:
+    def test_single_node_sufficient_passes(self):
+        # 4 vCPU, 8 GiB, 30 GiB ephemeral — comfortably above defaults
+        node_data = "node-1\t4\t8Gi\t30Gi"
+        rc, out = run_script(node_data)
+        assert rc == 0
+        assert "OK" in out
+        assert "node-1" in out
+
+    def test_single_4gib_node_at_threshold_passes(self):
+        # Exactly the 4 GiB threshold — c7i-flex.large case
+        node_data = "node-1\t2\t4Gi\t20Gi"
+        rc, out = run_script(node_data)
+        assert rc == 0
+        assert "OK" in out
+
+    def test_single_node_insufficient_memory_fails(self):
+        # 2 GiB total — t3.small case
+        node_data = "node-1\t2\t2Gi\t30Gi"
+        rc, out = run_script(node_data)
+        assert rc == 1
+        assert "INSUFFICIENT" in out
+
+    def test_single_node_insufficient_storage_fails(self):
+        node_data = "node-1\t2\t8Gi\t10Gi"
+        rc, out = run_script(node_data)
+        assert rc == 1
+        assert "INSUFFICIENT" in out
+
+    def test_single_node_insufficient_cpu_fails(self):
+        # 500m CPU — below the 600m default minimum
+        node_data = "node-1\t500m\t8Gi\t30Gi"
+        rc, out = run_script(node_data)
+        assert rc == 1
+        assert "INSUFFICIENT" in out
+
+    def test_any_node_qualifying_is_enough(self):
+        # First node fails, second node passes — overall pass
+        node_data = "node-1\t2\t2Gi\t30Gi\nnode-2\t4\t8Gi\t30Gi"
+        rc, out = run_script(node_data)
+        assert rc == 0
+        assert "node-1" in out and "INSUFFICIENT" in out
+        assert "node-2" in out and "OK" in out
+
+    def test_no_nodes_qualifying_fails(self):
+        node_data = "node-1\t2\t2Gi\t30Gi\nnode-2\t2\t3Gi\t30Gi"
+        rc, _ = run_script(node_data)
+        assert rc == 1
+
+    def test_empty_node_data_fails(self):
+        rc, out = run_script("")
+        assert rc == 1
+        assert "No node data" in out
+
+    def test_memory_unit_parsing(self):
+        # All units that kubectl can emit for capacity.memory
+        test_cases = [
+            ("4194304Ki", True),  # 4 GiB in Ki, exactly at threshold
+            ("4096Mi", True),  # 4 GiB in Mi, exactly at threshold
+            ("4Gi", True),  # 4 GiB literal
+            ("3Gi", False),  # 3 GiB, below threshold
+            ("2097152Ki", False),  # 2 GiB in Ki, below threshold
+        ]
+        for mem_str, expected_pass in test_cases:
+            node_data = f"node-1\t4\t{mem_str}\t30Gi"
+            rc, out = run_script(node_data)
+            if expected_pass:
+                assert rc == 0, f"Expected {mem_str} to pass: {out}"
+            else:
+                assert rc == 1, f"Expected {mem_str} to fail: {out}"
+
+    def test_default_min_memory_is_4096(self):
+        # If MIN_MEMORY_MI is not in the environment at all, the script
+        # should default to 4096 (4 GiB) per #58. Test by clearing the
+        # var and using a 3.5 GiB node.
+        env = os.environ.copy()
+        env["NODE_DATA"] = "node-1\t4\t3500Mi\t30Gi"
+        env.pop("MIN_MEMORY_MI", None)
+        env["MIN_CPU_MILLI"] = "600"
+        env["MIN_STORAGE_GI"] = "15"
+        proc = subprocess.run(
+            [sys.executable, SCRIPT],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        # 3500Mi < 4096Mi default, so should fail
+        assert proc.returncode == 1, (
+            "Default MIN_MEMORY_MI should be 4096; got: %s" % proc.stdout
+        )

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -131,6 +131,35 @@ class TestHelmChart:
                 % template_name
             )
 
+    def test_k8s_preflight_uses_capacity_not_allocatable(self):
+        """k8s_preflight.yml should read .status.capacity for the memory
+        check, not .status.allocatable. Allocatable on a 4 GiB node is
+        ~3.5 GiB, so a 4 GiB threshold against allocatable would reject
+        the smallest instance we want to support. See #58."""
+        with open(os.path.join(ORCHESTRATOR_TASKS, "k8s_preflight.yml")) as f:
+            content = f.read()
+        assert ".status.capacity.memory" in content, (
+            "k8s_preflight.yml must read .status.capacity.memory"
+        )
+        assert ".status.allocatable.memory" not in content, (
+            "k8s_preflight.yml should not read .status.allocatable.memory; "
+            "use capacity instead. See #58."
+        )
+
+    def test_k8s_preflight_min_memory_is_4096(self):
+        """The K8s preflight memory minimum should match the 4 GiB Compose
+        threshold (#58). 1216 MiB (the old request-sum value) is too
+        permissive and lets t3.small / c7i-flex.large pass."""
+        with open(os.path.join(ORCHESTRATOR_TASKS, "k8s_preflight.yml")) as f:
+            content = f.read()
+        assert "_min_memory_mi: 4096" in content, (
+            "k8s_preflight.yml _min_memory_mi must be 4096 (4 GiB)"
+        )
+        assert "_min_memory_mi: 1216" not in content, (
+            "k8s_preflight.yml still has the old 1216 MiB minimum; "
+            "should be 4096. See #58."
+        )
+
 
 class TestGitopsDispatchers:
     """Verify that each dispatched gitops command has both variants."""


### PR DESCRIPTION
Fixes #58.

## Bug

There were two memory-related checks in Canasta-Ansible, and both had problems.

**Check 1** — `roles/create/tasks/main.yml` lines 29-45 had a memory check, but it was a no-op debug warning rather than a hard failure, and it ran unconditionally so on K8s creates it measured the controller host instead of the cluster nodes.

**Check 2** — `roles/orchestrator/tasks/k8s_preflight.yml` summed the chart's resource *requests* (`_min_memory_mi: 1216` ≈ 1.2 GiB) and checked node *allocatable* against that. 1.2 GiB is too low to actually run Canasta, and allocatable on a 4 GiB node is ~3.5 GiB anyway, so a `4 GiB threshold against allocatable` would reject the smallest instance we want to support.

## Fix

Unified threshold of **4 GiB total memory** across both orchestrators, with the right enforcement in each place.

### Compose path (`roles/create/tasks/main.yml`)

- Convert the existing warning to a hard failure.
- Gate on `orchestrator == 'compose'` so it doesn't run on K8s creates (which have their own per-node check).
- The check semantics (`SC_PAGE_SIZE * SC_PHYS_PAGES`, total memory) are unchanged — only the failure mode changes.

### Kubernetes path (`roles/orchestrator/tasks/k8s_preflight.yml`)

- Read `.status.capacity.memory` instead of `.status.allocatable.memory`. **Capacity** is the kernel-reported total (≈ MemTotal); **allocatable** is what kubelet will schedule (capacity minus kube-reserved, system-reserved, eviction-threshold). On a 4 GiB node, allocatable is ~3.5 GiB. Checking capacity matches the user's intuitive "this is a 4 GiB instance" understanding.
- Raise `_min_memory_mi` from 1216 to 4096.
- Update the failure message to say "total memory" so it's consistent with the Compose path's wording.

### Helper script (`roles/orchestrator/files/scripts/check_node_resources.py`)

- Default `MIN_MEMORY_MI` raised from 1216 to 4096 so standalone runs match the new threshold.
- Docstring updated to reflect that the script reads capacity, not allocatable.

## Why diverge from Canasta-CLI's stricter check?

Canasta-CLI's `system.CheckMemoryInGB(4)` reads `MemAvailable` from `/proc/meminfo`, which is "free + reclaimable cache minus eviction headroom" — effectively requiring 6 GiB+ of total RAM. That's a fine check for the default Canasta-CLI configuration which includes Elasticsearch and Varnish.

Canasta-Ansible defaults to Elasticsearch *disabled*. The same workload runs comfortably on 4 GiB total RAM, and we shouldn't reject `c7i-flex.large` (4 GiB, AWS free tier) just because the CLI's stricter check would. This PR uses `MemTotal` instead of `MemAvailable` and the threshold matches what the user sees as their instance size.

We're not modifying Canasta-CLI to match — that's a separate decision and is outside the scope of work in this workspace.

## Files changed

- `roles/create/tasks/main.yml` — convert warning to failure, gate on Compose
- `roles/orchestrator/tasks/k8s_preflight.yml` — capacity instead of allocatable, raise minimum
- `roles/orchestrator/files/scripts/check_node_resources.py` — docstring + default
- `tests/unit/test_check_node_resources.py` — **new file**, 10 unit test cases
- `tests/unit/test_kubernetes_structure.py` — 2 new tests asserting the YAML uses capacity and 4096

## Tests

- [x] `make test-unit` — 327 passed (up from 315)
- [x] `make validate` — passes
- [x] `make lint` — exit 0
- [x] Smoke test of `check_node_resources.py` standalone:
  - `NODE_DATA="node-1\t2\t4Gi\t20Gi"` → exit 0, "OK"
  - `NODE_DATA="node-1\t2\t2Gi\t20Gi"` → exit 1, "INSUFFICIENT"
- [ ] CI passes
- [ ] Multi-node EC2 test plan exercises the new check (will be confirmed during the upcoming test rerun against `c7i-flex.large` instances)

## Out of scope (separate follow-ups)

- **Conditional minimum based on enabled features** (bump to 6-8 GiB when Elasticsearch is enabled). Useful but its own design discussion.
- **Storage minimum changes**. The existing `_min_storage_gi: 15` stays as-is; 20 GiB is what we've measured working in practice but 15 isn't *wrong*.
