### PR TITLE
Add kubectl and helm to the canasta-ansible Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,17 @@ RUN mkdir -p /usr/local/lib/docker/cli-plugins \
          -o /usr/local/lib/docker/cli-plugins/docker-compose \
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 
+# Install kubectl (latest stable). dpkg --print-architecture maps to
+# amd64 / arm64, matching the directories under dl.k8s.io. See #62.
+RUN curl -fsSL \
+        "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/$(dpkg --print-architecture)/kubectl" \
+        -o /usr/local/bin/kubectl \
+    && chmod +x /usr/local/bin/kubectl
+
+# Install Helm (3.x via the official installer script).
+RUN curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
+        | bash
+
 # Copy application
 WORKDIR /opt/canasta-ansible
 COPY requirements.txt requirements.yml ./


### PR DESCRIPTION
Fixes #62.

The `canasta-docker` wrapper advertised full feature parity with `canasta-native` (including K8s) but the image shipped neither `kubectl` nor `helm`. Any K8s command run through `canasta-docker` failed immediately at the kubectl preflight check.

## Changes

- `Dockerfile`: two new `RUN` steps installing kubectl (latest stable from dl.k8s.io) and helm 3.x (via the official `get-helm-3` installer script). Both static binaries, no extra runtime deps. Roughly +100 MB to the image.

## Why this hadn't been caught

- Local dev uses `canasta-native` (which uses the host's kubectl).
- CI's 'Integration: Kubernetes' job installs k3s and runs the test suite directly via `canasta-native`, not through the docker wrapper. So the image's K8s capability had never actually been end-to-end exercised.
- Compose users (the majority of canasta-docker's audience today) don't need either tool, so they never hit it.

## Test plan

- [x] `docker build -t ghcr.io/canastawiki/canasta-ansible:latest .` succeeds locally
- [x] `docker run --rm ghcr.io/canastawiki/canasta-ansible:latest which kubectl` returns a path
- [x] `docker run --rm ghcr.io/canastawiki/canasta-ansible:latest which helm` returns a path
- [ ] CI passes
- [ ] Discovered during a real multi-node EC2 test for #56/#58 — once this lands, we'll re-run `canasta storage setup nfs` via canasta-docker against the live cluster to verify end to end

## Related

- #62 — this PR fixes it
- #62 also recommended adding a CI check that exercises at least one K8s command through the docker wrapper (so this bug class doesn't recur the next time the Dockerfile changes). That CI improvement is a separate follow-up worth filing if it's not already on the radar.