### PR TITLE
Lower memory preflight threshold to 3500 MiB for cloud overhead

### DIFF
--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -30,27 +30,33 @@
 # per-node memory check in k8s_preflight.yml — running this on a K8s
 # create would measure the controller host, not the cluster nodes,
 # which is the wrong thing. See #58.
-- name: Check target host total memory (minimum 4 GiB) — Compose only
+#
+# Threshold is 3500 MiB rather than a round 4096 MiB because cloud
+# instances marketed as "4 GiB" actually expose ~3700-3900 MiB to the
+# kernel after BIOS/UEFI/hypervisor reserves. AWS c7i-flex.large
+# (4 GiB advertised) reports ~3826 MiB MemTotal, for example. The
+# 3500 MiB floor is comfortably above what 2 GiB instances report
+# (~1700-1900 MiB) and below what real 4 GiB cloud instances report.
+# See #65.
+- name: Check target host total memory (minimum 3500 MiB) — Compose only
   ansible.builtin.command:
     cmd: >-
       python3 -c "import os;
-      mem = os.sysconf('SC_PAGE_SIZE')
-      * os.sysconf('SC_PHYS_PAGES') // (1024**3);
-      exit(0 if mem >= 4 else 1)"
+      mem_mib = os.sysconf('SC_PAGE_SIZE')
+      * os.sysconf('SC_PHYS_PAGES') // (1024**2);
+      exit(0 if mem_mib >= 3500 else 1)"
   register: _mem_check
   changed_when: false
   ignore_errors: true
   when: orchestrator | default('compose') == 'compose'
 
-- name: Fail if target host has less than 4 GiB total memory
+- name: Fail if target host has less than 3500 MiB total memory
   ansible.builtin.fail:
     msg: >-
-      Canasta requires at least 4 GiB of total memory on the target
-      host. The host has less than that. If you intentionally want to
-      run on a smaller host (with Elasticsearch and Varnish disabled
-      and only the lightest workload), you'll need to make this check
-      configurable — but in practice 4 GiB is the floor below which
-      Canasta will not start reliably.
+      Canasta requires at least 3500 MiB of total memory on the target
+      host (in practice, a 4 GiB instance class or larger — cloud
+      instances marketed as 4 GiB report ~3700-3900 MiB after kernel
+      and firmware reserves). The host has less than that.
   when:
     - orchestrator | default('compose') == 'compose'
     - _mem_check.rc | default(0) != 0

--- a/roles/orchestrator/files/scripts/check_node_resources.py
+++ b/roles/orchestrator/files/scripts/check_node_resources.py
@@ -51,7 +51,9 @@ def parse_storage(value):
 def main():
     node_data = os.environ.get("NODE_DATA", "").strip()
     min_cpu = int(os.environ.get("MIN_CPU_MILLI", 600))
-    min_mem = int(os.environ.get("MIN_MEMORY_MI", 4096))
+    # 3500 MiB rather than a round 4096 because cloud instances
+    # marketed as "4 GiB" report ~3700-3900 MiB capacity. See #65.
+    min_mem = int(os.environ.get("MIN_MEMORY_MI", 3500))
     min_stor = int(os.environ.get("MIN_STORAGE_GI", 15))
 
     if not node_data:

--- a/roles/orchestrator/tasks/k8s_preflight.yml
+++ b/roles/orchestrator/tasks/k8s_preflight.yml
@@ -69,11 +69,16 @@
   vars:
     # Minimum requirements for a Canasta instance, expressed against
     # node capacity (not allocatable; not the sum of pod requests).
-    # Memory: 4 GiB total. This matches the Compose-side check in
-    # roles/create/tasks/main.yml and is the documented floor below
-    # which Canasta will not run reliably. With Elasticsearch enabled
-    # or under heavy traffic, 8 GiB+ is recommended; users opting in
-    # to those should size up.
+    # Memory: 3500 MiB. This matches the Compose-side check in
+    # roles/create/tasks/main.yml. The threshold is intentionally
+    # below a round 4096 MiB because cloud instances marketed as
+    # "4 GiB" actually expose ~3700-3900 MiB to the kernel after
+    # BIOS/UEFI/hypervisor reserves. AWS c7i-flex.large (4 GiB
+    # advertised) reports ~3826 MiB capacity, for example. 3500 MiB
+    # is comfortably above what 2 GiB instances report (~1700-1900)
+    # and below what real 4 GiB cloud instances report. See #65.
+    # With Elasticsearch enabled or under heavy traffic, 8 GiB+ is
+    # recommended; users opting in to those should size up.
     # CPU: 600m, the sum of resource requests across the chart's
     # default components. This is the minimum that schedules; it's
     # not a memory-style hard floor because Canasta is mostly memory
@@ -83,7 +88,7 @@
     # content should use a larger storage class for the content
     # PVCs; this minimum is only about ephemeral / image space.
     _min_cpu_milli: 600
-    _min_memory_mi: 4096
+    _min_memory_mi: 3500
     _min_storage_gi: 15
   block:
     - name: Evaluate node capacity
@@ -105,7 +110,8 @@
         msg: >-
           No Kubernetes node meets the minimum resource requirements
           for a Canasta instance. Required (against node capacity):
-          at least {{ _min_memory_mi }} MiB total memory,
+          at least {{ _min_memory_mi }} MiB total memory (in
+          practice, a 4 GiB instance class or larger),
           {{ _min_cpu_milli }}m CPU, {{ _min_storage_gi }} GiB
           ephemeral storage. Node details:
           {{ _resource_check.stdout | default('(check script failed)') }}

--- a/tests/unit/test_check_node_resources.py
+++ b/tests/unit/test_check_node_resources.py
@@ -26,7 +26,7 @@ SCRIPT = os.path.join(
 )
 
 
-def run_script(node_data, min_cpu="600", min_mem="4096", min_stor="15"):
+def run_script(node_data, min_cpu="600", min_mem="3500", min_stor="15"):
     """Run check_node_resources.py with the given env, return (rc, stdout)."""
     env = os.environ.copy()
     env["NODE_DATA"] = node_data
@@ -51,16 +51,25 @@ class TestCheckNodeResources:
         assert "OK" in out
         assert "node-1" in out
 
-    def test_single_4gib_node_at_threshold_passes(self):
-        # Exactly the 4 GiB threshold — c7i-flex.large case
-        node_data = "node-1\t2\t4Gi\t20Gi"
+    def test_real_4gib_cloud_instance_passes(self):
+        # AWS c7i-flex.large reports ~3826 MiB capacity (advertised 4 GiB).
+        # The threshold must accommodate this reality. See #65.
+        node_data = "node-1\t2\t3826Mi\t20Gi"
         rc, out = run_script(node_data)
         assert rc == 0
         assert "OK" in out
 
     def test_single_node_insufficient_memory_fails(self):
-        # 2 GiB total — t3.small case
+        # 2 GiB total — t3.small case (~1900 MiB capacity in practice)
         node_data = "node-1\t2\t2Gi\t30Gi"
+        rc, out = run_script(node_data)
+        assert rc == 1
+        assert "INSUFFICIENT" in out
+
+    def test_real_2gib_cloud_instance_fails(self):
+        # AWS t3.small reports ~1900 MiB capacity (advertised 2 GiB).
+        # Must still be rejected by the new threshold.
+        node_data = "node-1\t2\t1900Mi\t30Gi"
         rc, out = run_script(node_data)
         assert rc == 1
         assert "INSUFFICIENT" in out
@@ -97,13 +106,17 @@ class TestCheckNodeResources:
         assert "No node data" in out
 
     def test_memory_unit_parsing(self):
-        # All units that kubectl can emit for capacity.memory
+        # All units that kubectl can emit for capacity.memory.
+        # Threshold is 3500 MiB (#65) so values are picked relative to that.
         test_cases = [
-            ("4194304Ki", True),  # 4 GiB in Ki, exactly at threshold
-            ("4096Mi", True),  # 4 GiB in Mi, exactly at threshold
+            ("4194304Ki", True),  # 4 GiB in Ki, comfortably above threshold
+            ("4096Mi", True),  # 4 GiB in Mi
             ("4Gi", True),  # 4 GiB literal
-            ("3Gi", False),  # 3 GiB, below threshold
-            ("2097152Ki", False),  # 2 GiB in Ki, below threshold
+            ("3826Mi", True),  # c7i-flex.large reality
+            ("3500Mi", True),  # exactly at threshold
+            ("3499Mi", False),  # 1 MiB below threshold
+            ("3Gi", False),  # 3 GiB literal, below threshold
+            ("2097152Ki", False),  # 2 GiB in Ki, well below threshold
         ]
         for mem_str, expected_pass in test_cases:
             node_data = f"node-1\t4\t{mem_str}\t30Gi"
@@ -113,12 +126,12 @@ class TestCheckNodeResources:
             else:
                 assert rc == 1, f"Expected {mem_str} to fail: {out}"
 
-    def test_default_min_memory_is_4096(self):
+    def test_default_min_memory_is_3500(self):
         # If MIN_MEMORY_MI is not in the environment at all, the script
-        # should default to 4096 (4 GiB) per #58. Test by clearing the
-        # var and using a 3.5 GiB node.
+        # should default to 3500 MiB (#65). Test by clearing the var and
+        # using a node just below that.
         env = os.environ.copy()
-        env["NODE_DATA"] = "node-1\t4\t3500Mi\t30Gi"
+        env["NODE_DATA"] = "node-1\t4\t3499Mi\t30Gi"
         env.pop("MIN_MEMORY_MI", None)
         env["MIN_CPU_MILLI"] = "600"
         env["MIN_STORAGE_GI"] = "15"
@@ -128,7 +141,20 @@ class TestCheckNodeResources:
             capture_output=True,
             text=True,
         )
-        # 3500Mi < 4096Mi default, so should fail
+        # 3499Mi < 3500Mi default, so should fail
         assert proc.returncode == 1, (
-            "Default MIN_MEMORY_MI should be 4096; got: %s" % proc.stdout
+            "Default MIN_MEMORY_MI should be 3500; got: %s" % proc.stdout
+        )
+
+        # And just at the threshold should pass
+        env["NODE_DATA"] = "node-1\t4\t3500Mi\t30Gi"
+        proc = subprocess.run(
+            [sys.executable, SCRIPT],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode == 0, (
+            "3500Mi should exactly meet the default threshold; got: %s"
+            % proc.stdout
         )

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -146,18 +146,24 @@ class TestHelmChart:
             "use capacity instead. See #58."
         )
 
-    def test_k8s_preflight_min_memory_is_4096(self):
-        """The K8s preflight memory minimum should match the 4 GiB Compose
-        threshold (#58). 1216 MiB (the old request-sum value) is too
-        permissive and lets t3.small / c7i-flex.large pass."""
+    def test_k8s_preflight_min_memory_is_3500(self):
+        """The K8s preflight memory minimum should match the Compose
+        threshold and accommodate cloud-instance kernel overhead (#65).
+        4096 MiB rejects real 4 GiB cloud instances (which report
+        ~3826 MiB capacity); 3500 is the working threshold."""
         with open(os.path.join(ORCHESTRATOR_TASKS, "k8s_preflight.yml")) as f:
             content = f.read()
-        assert "_min_memory_mi: 4096" in content, (
-            "k8s_preflight.yml _min_memory_mi must be 4096 (4 GiB)"
+        assert "_min_memory_mi: 3500" in content, (
+            "k8s_preflight.yml _min_memory_mi must be 3500 (the cloud-"
+            "overhead-aware floor for 4 GiB instances)"
+        )
+        assert "_min_memory_mi: 4096" not in content, (
+            "k8s_preflight.yml still has the old 4096 MiB minimum; "
+            "should be 3500. See #65."
         )
         assert "_min_memory_mi: 1216" not in content, (
-            "k8s_preflight.yml still has the old 1216 MiB minimum; "
-            "should be 4096. See #58."
+            "k8s_preflight.yml still has the original 1216 MiB minimum; "
+            "should be 3500. See #58 / #65."
         )
 
 


### PR DESCRIPTION
Fixes #65.

## Bug

#58 enforced a 4096 MiB total-memory threshold on the Compose and K8s preflight checks, intending to allow real 4 GiB cloud instances. We discovered during the multi-node EC2 test rerun that AWS `c7i-flex.large` (advertised as 4 GiB) actually reports **~3826 MiB** capacity to k3s due to BIOS/UEFI/hypervisor reserves and kernel overhead. The 4096 threshold rejected the very instance class #58 was supposed to enable:

```
Error: No Kubernetes node meets the minimum resource requirements for a Canasta instance.
Required (against node capacity): at least 4096 MiB total memory, 600m CPU, 15 GiB ephemeral storage.
Node details:
  ip-172-31-10-96: cpu=2000m mem=3826Mi storage=19.5Gi INSUFFICIENT
  ip-172-31-8-192: cpu=2000m mem=3826Mi storage=19.5Gi INSUFFICIENT
```

## Fix

Lower the threshold from **4096 MiB** to **3500 MiB** on both paths.

3500 MiB is:
- **Above** what 2 GiB cloud instances actually report (~1700-1900 MiB), so they still fail correctly.
- **Below** what every "4 GiB" cloud instance class reports (~3700-3900 MiB), so they pass.
- **Documented** in the error message as 'in practice, a 4 GiB instance class or larger' so users see both the technical floor and the practical guidance.

The Compose-side check also moves from integer-GiB comparison to MiB comparison so it can express a 3500 threshold. Previously it computed `mem >= 4` against integer-GiB division, which on a host where MemTotal was ~3.82 GiB would round down to 3 and fail.

## Verification

Smoke test of the helper script:

```
$ NODE_DATA="node-1\t2\t3826Mi\t19Gi" .venv/bin/python roles/orchestrator/files/scripts/check_node_resources.py
  node-1: cpu=2000m mem=3826Mi storage=19.0Gi OK   ← passes (c7i-flex.large reality)

$ NODE_DATA="node-1\t2\t1900Mi\t19Gi" .venv/bin/python roles/orchestrator/files/scripts/check_node_resources.py
  node-1: cpu=2000m mem=1900Mi storage=19.0Gi INSUFFICIENT   ← fails (t3.small reality)
```

## Files

- `roles/create/tasks/main.yml` — Compose check uses MiB units and threshold 3500
- `roles/orchestrator/tasks/k8s_preflight.yml` — `_min_memory_mi` lowered from 4096 to 3500, error message updated
- `roles/orchestrator/files/scripts/check_node_resources.py` — default `MIN_MEMORY_MI` lowered from 4096 to 3500
- `tests/unit/test_check_node_resources.py` — added `test_real_4gib_cloud_instance_passes` (3826 MiB), added `test_real_2gib_cloud_instance_fails` (1900 MiB), expanded memory unit parsing test cases, updated default-threshold test to 3500
- `tests/unit/test_kubernetes_structure.py` — renamed and updated the YAML structure assertion

## What we are NOT walking back

#58's deliberate choice to use `MemTotal` rather than Canasta-CLI's stricter `MemAvailable` check stays. Canasta-Ansible defaults to Elasticsearch disabled and is designed to run on smaller instances than Canasta-CLI assumes; sticking with `MemTotal` on a tighter threshold rather than `MemAvailable` on a looser one.

## Test plan

- [x] `make test-unit` — 328 passed
- [x] `make validate` — passes
- [x] `make lint` — exit 0
- [x] Smoke test of `check_node_resources.py` standalone (3826 MiB passes, 1900 MiB fails)
- [ ] CI passes
- [ ] Multi-node EC2 test rerun against `c7i-flex.large` actually proceeds past the preflight