### PR TITLE
CI: only run integration test jobs on push to main

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Manual trigger for re-running the full suite (including the
+  # integration jobs that are normally gated to push-to-main only).
+  # Useful when reviewing a PR that touches integration-relevant
+  # code. See #67.
+  workflow_dispatch:
 
 jobs:
   unit:
@@ -71,6 +76,9 @@ jobs:
 
   integration-core:
     name: "Integration: Core Lifecycle"
+    # Skip on PRs (run only on push to main and manual workflow_dispatch).
+    # See #67.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -95,6 +103,7 @@ jobs:
 
   integration-features:
     name: "Integration: Features"
+    if: github.event_name != 'pull_request'  # See #67
     runs-on: ubuntu-latest
     timeout-minutes: 35
     steps:
@@ -120,6 +129,7 @@ jobs:
 
   integration-gitops:
     name: "Integration: GitOps"
+    if: github.event_name != 'pull_request'  # See #67
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -144,6 +154,7 @@ jobs:
 
   integration-k8s:
     name: "Integration: Kubernetes"
+    if: github.event_name != 'pull_request'  # See #67
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -182,6 +193,7 @@ jobs:
 
   remote-integration:
     name: Remote Host Integration Tests
+    if: github.event_name != 'pull_request'  # See #67
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
Fixes #67.

## Change

The five integration jobs (Core Lifecycle, Features, GitOps, Kubernetes, Remote Host) each spin up real Canasta instances or k3s clusters and take 15-20 minutes wall clock. They were running on every PR even when the diff couldn't possibly affect integration behavior. This change gates them to push-to-main and manual `workflow_dispatch` triggers.

12-line addition to `.github/workflows/tests.yml`:

- Add `workflow_dispatch:` to the `on:` block so the full suite can be re-run manually on a PR via the Actions tab when integration-relevant code is touched.
- Add `if: github.event_name != 'pull_request'` to each of the five integration jobs.

## Effect

| | Before | After |
|---|---|---|
| Per-PR check time | ~15-20 min | ~2 min |
| Jobs that run on PRs | 9 | 4 (Unit Tests, Lint, Helm Chart Lint, Docker Smoke Test) |
| Integration coverage on `main` | full suite on merge | full suite on merge (unchanged) |
| Manual escape hatch | none | `workflow_dispatch` (one-click on Actions tab) |

## What still runs on PRs

- `unit` (Unit Tests + coverage) — fast, catches most regressions per minute of CI
- `lint` (yamllint + validate_definitions.py)
- `helm-lint` (Helm Chart Lint + template render)
- `docker-smoke` (build image + version/list/doctor/help smoke)

All four finish in under 2 minutes.

## Trade-offs

- **Pro**: PR feedback ~10x faster. Reviewers stop ignoring CI status because it's no longer a 20-minute wait.
- **Pro**: Less compute, less log noise.
- **Con**: Integration regressions can land on `main` and need a fix-forward. We've been doing follow-up PRs all day anyway, so the incremental cost is small. The manual workflow_dispatch trigger is the escape hatch for PRs that genuinely need integration verification before merge.

## Test plan

- [x] `make test-unit` — 327 passed
- [x] `make lint` — exit 0
- [x] Workflow YAML structure verified (each integration job has its `if` guard, fast jobs are unchanged)
- [ ] CI passes (only the fast jobs should run on this PR — and the new `workflow_dispatch` trigger should appear on the Actions tab)

## Out of scope

- Label-based 'force integration on this PR' mechanism. Worth considering if `workflow_dispatch` isn't ergonomic enough.
- Per-changed-file selection (only run K8s tests if K8s files changed). Possible but more complex; not needed for the immediate pain.