### PR TITLE
Auto-create Argo CD repo Secret in gitops init + suspend sync on stop

### DIFF
--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -72,14 +72,20 @@
 
 # --- Copy Helm chart into instance directory ---
 # Argo CD needs the chart in the git repo to render templates.
-- name: Copy Helm chart structure into instance directory
+- name: Copy Chart.yaml into instance directory
   ansible.builtin.copy:
-    src: "{{ canasta_root }}/roles/orchestrator/files/helm/canasta/{{ item }}"
-    dest: "{{ instance_path }}/{{ item }}"
+    src: "{{ canasta_root }}/roles/orchestrator/files/helm/canasta/Chart.yaml"
+    dest: "{{ instance_path }}/Chart.yaml"
     mode: preserve
-  loop:
-    - Chart.yaml
-    - templates
+
+# Trailing / on src is critical: without it, Ansible's copy module
+# copies the directory AS 'templates' under the dest, creating
+# templates/templates/. With the trailing /, it copies the CONTENTS.
+- name: Copy Helm templates into instance directory
+  ansible.builtin.copy:
+    src: "{{ canasta_root }}/roles/orchestrator/files/helm/canasta/templates/"
+    dest: "{{ instance_path }}/templates/"
+    mode: preserve
 
 - name: Merge chart defaults with instance values
   ansible.builtin.copy:
@@ -119,6 +125,13 @@
 
       # Transient config sync file
       values-configdata.yaml
+
+      # Runtime data directories (backed by PVCs on K8s, not by git)
+      images/
+      extensions/
+      skins/
+      public_assets/
+      wikis/
     dest: "{{ instance_path }}/.gitignore"
     mode: "0644"
 

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -25,15 +25,34 @@
       Use 'gitops join' to join an existing repo.
   when: _gitops_existing.stat.exists
 
-- name: Check key file does not exist
+# On K8s, --key can be either:
+#   - An existing SSH private key (INPUT): used to create the Argo CD
+#     repo credential Secret so Argo CD can pull from the repo. The
+#     user pre-generates the key, adds the public half to GitHub, and
+#     passes the private half here.
+#   - A non-existent path (OUTPUT): a placeholder file is created for
+#     CLI compatibility, but no Argo CD Secret is created (the user
+#     must create it manually — legacy behavior, see #69).
+# The Compose path uses --key as an output for git-crypt's symmetric
+# key, which is a different concept entirely.
+- name: Check if SSH deploy key already exists
   ansible.builtin.stat:
     path: "{{ key }}"
   register: _gitops_key_exists
 
-- name: Fail if key file already exists
-  ansible.builtin.fail:
-    msg: "Key file '{{ key }}' already exists. Remove it first or use a different path."
+- name: Read existing SSH deploy key
+  ansible.builtin.slurp:
+    src: "{{ key }}"
+  register: _gitops_ssh_key
   when: _gitops_key_exists.stat.exists
+  no_log: true
+
+- name: Set flag for whether we have a real SSH key
+  ansible.builtin.set_fact:
+    _have_ssh_key: >-
+      {{ _gitops_key_exists.stat.exists and
+         (_gitops_ssh_key.content | default('') | b64decode)
+         is search('-----BEGIN') }}
 
 - name: Check remote is empty
   ansible.builtin.command:
@@ -146,15 +165,21 @@
     dest: "{{ instance_path }}/.gitops-host"
     mode: "0644"
 
-# --- Note about key file (no git-crypt on K8s path) ---
-- name: Create placeholder key file
+# --- Key file handling ---
+# If the user passed an existing SSH key, we already read it above
+# and will use it to create the Argo CD Secret below. If they passed
+# a non-existent path, create a placeholder for CLI compatibility.
+- name: Create placeholder key file (no SSH key provided)
   ansible.builtin.copy:
     content: |
       # Kubernetes gitops does not use git-crypt.
       # Secrets are managed via K8s Secrets, not encrypted in the repo.
       # This file is a placeholder for compatibility with the CLI interface.
+      # To enable automatic Argo CD repo authentication, re-run gitops
+      # init with --key pointing at an existing SSH private key file.
     dest: "{{ key }}"
     mode: "0600"
+  when: not (_have_ssh_key | bool)
 
 # --- Sync config files into values.yaml ---
 - name: Set K8s namespace for config sync
@@ -198,12 +223,45 @@
     chdir: "{{ instance_path }}"
   changed_when: true
 
+# --- Create Argo CD repo credential Secret ---
+# Only when the user supplied a real SSH deploy key via --key.
+# Without this Secret, Argo CD can't authenticate to the git repo and
+# syncs fail with auth errors. See #69.
+- name: Create or update Argo CD repo credential Secret
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "canasta-{{ instance_id }}-repo"
+        namespace: "{{ argocd_namespace | default('argocd') }}"
+        labels:
+          argocd.argoproj.io/secret-type: repository
+          app.kubernetes.io/managed-by: canasta-ansible
+          app.kubernetes.io/instance: "{{ instance_id }}"
+      type: Opaque
+      stringData:
+        type: git
+        url: "{{ repo }}"
+        sshPrivateKey: "{{ _gitops_ssh_key.content | b64decode }}"
+  no_log: true
+  when: _have_ssh_key | bool
+
+- name: Warn if no SSH key provided for Argo CD
+  ansible.builtin.debug:
+    msg: >-
+      No SSH deploy key was provided (--key did not point at an
+      existing private key file). The Argo CD repo credential Secret
+      was NOT created. Argo CD will fail to sync until you create
+      the Secret manually. See #69 for details.
+  when: not (_have_ssh_key | bool)
+
 # --- Register Argo CD Application ---
 - name: Apply Argo CD Application to cluster
   kubernetes.core.k8s:
     state: present
     src: "{{ instance_path }}/argocd/application.yaml"
-  ignore_errors: true
 
 - name: Report gitops initialized
   ansible.builtin.debug:

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -25,16 +25,14 @@
       Use 'gitops join' to join an existing repo.
   when: _gitops_existing.stat.exists
 
-# On K8s, --key can be either:
-#   - An existing SSH private key (INPUT): used to create the Argo CD
-#     repo credential Secret so Argo CD can pull from the repo. The
-#     user pre-generates the key, adds the public half to GitHub, and
-#     passes the private half here.
-#   - A non-existent path (OUTPUT): a placeholder file is created for
-#     CLI compatibility, but no Argo CD Secret is created (the user
-#     must create it manually — legacy behavior, see #69).
-# The Compose path uses --key as an output for git-crypt's symmetric
-# key, which is a different concept entirely.
+# --- SSH deploy key ---
+# On K8s, --key is the path where the SSH deploy key lives (or will
+# be generated). Analogous to the Compose path's git-crypt key
+# export: the credential is saved at --key for future operations
+# (gitops push, gitops join on another host).
+#
+# If the file already exists and contains a PEM key, we reuse it
+# (re-init or user-supplied key). Otherwise we generate a new one.
 - name: Check if SSH deploy key already exists
   ansible.builtin.stat:
     path: "{{ key }}"
@@ -43,20 +41,57 @@
 - name: Read existing SSH deploy key
   ansible.builtin.slurp:
     src: "{{ key }}"
-  register: _gitops_ssh_key
+  register: _gitops_ssh_key_existing
   when: _gitops_key_exists.stat.exists
   no_log: true
 
-- name: Set flag for whether we have a real SSH key
+- name: Check if existing file is a real SSH key
   ansible.builtin.set_fact:
-    _have_ssh_key: >-
+    _existing_is_ssh_key: >-
       {{ _gitops_key_exists.stat.exists and
-         (_gitops_ssh_key.content | default('') | b64decode)
+         (_gitops_ssh_key_existing.content | default('') | b64decode)
          is search('-----BEGIN') }}
+
+- name: Generate SSH deploy key pair
+  ansible.builtin.command:
+    cmd: >-
+      ssh-keygen -t ed25519
+      -f {{ key }}
+      -N ''
+      -C 'canasta-{{ instance_id }}'
+  when: not (_existing_is_ssh_key | bool)
+
+- name: Read the SSH deploy key (generated or existing)
+  ansible.builtin.slurp:
+    src: "{{ key }}"
+  register: _gitops_ssh_key
+  no_log: true
+
+- name: Read the public key for display
+  ansible.builtin.slurp:
+    src: "{{ key }}.pub"
+  register: _gitops_ssh_pubkey
+
+- name: Display public key for deploy key setup
+  ansible.builtin.debug:
+    msg:
+      - "SSH deploy key {{ (_existing_is_ssh_key | bool) | ternary('found', 'generated') }}."
+      - "Add this public key as a deploy key (with WRITE access) on your git repository:"
+      - ""
+      - "  {{ _gitops_ssh_pubkey.content | b64decode | trim }}"
+      - ""
+      - "Repository: {{ repo }}"
+      - "GitHub: go to Settings > Deploy keys > Add deploy key"
+
+- name: Pause for user to add deploy key to git repository
+  ansible.builtin.pause:
+    prompt: "Press Enter after you have added the deploy key to your repository (or Ctrl+C then A to abort)"
 
 - name: Check remote is empty
   ansible.builtin.command:
     cmd: "git ls-remote {{ repo }}"
+  environment:
+    GIT_SSH_COMMAND: "ssh -i {{ key }} -o StrictHostKeyChecking=no"
   register: _gitops_remote
   changed_when: false
   ignore_errors: true
@@ -178,21 +213,8 @@
     dest: "{{ instance_path }}/.gitops-host"
     mode: "0644"
 
-# --- Key file handling ---
-# If the user passed an existing SSH key, we already read it above
-# and will use it to create the Argo CD Secret below. If they passed
-# a non-existent path, create a placeholder for CLI compatibility.
-- name: Create placeholder key file (no SSH key provided)
-  ansible.builtin.copy:
-    content: |
-      # Kubernetes gitops does not use git-crypt.
-      # Secrets are managed via K8s Secrets, not encrypted in the repo.
-      # This file is a placeholder for compatibility with the CLI interface.
-      # To enable automatic Argo CD repo authentication, re-run gitops
-      # init with --key pointing at an existing SSH private key file.
-    dest: "{{ key }}"
-    mode: "0600"
-  when: not (_have_ssh_key | bool)
+# Key file is either the user's existing key or the one we just
+# generated. No placeholder needed — we always have a real key now.
 
 # --- Sync config files into values.yaml ---
 - name: Set K8s namespace for config sync
@@ -234,12 +256,15 @@
   ansible.builtin.command:
     cmd: "git push -u origin main {{ (force | default(false) | bool) | ternary('--force', '') }}"
     chdir: "{{ instance_path }}"
+  environment:
+    GIT_SSH_COMMAND: "ssh -i {{ key }} -o StrictHostKeyChecking=no"
   changed_when: true
 
 # --- Create Argo CD repo credential Secret ---
-# Only when the user supplied a real SSH deploy key via --key.
-# Without this Secret, Argo CD can't authenticate to the git repo and
-# syncs fail with auth errors. See #69.
+# The SSH deploy key (generated or user-supplied) is stored as a K8s
+# Secret that Argo CD discovers via the repository label. This is what
+# lets Argo CD pull from the git repo without manual kubectl steps.
+# See #69.
 - name: Create or update Argo CD repo credential Secret
   kubernetes.core.k8s:
     state: present
@@ -259,16 +284,6 @@
         url: "{{ repo }}"
         sshPrivateKey: "{{ _gitops_ssh_key.content | b64decode }}"
   no_log: true
-  when: _have_ssh_key | bool
-
-- name: Warn if no SSH key provided for Argo CD
-  ansible.builtin.debug:
-    msg: >-
-      No SSH deploy key was provided (--key did not point at an
-      existing private key file). The Argo CD repo credential Secret
-      was NOT created. Argo CD will fail to sync until you create
-      the Secret manually. See #69 for details.
-  when: not (_have_ssh_key | bool)
 
 # --- Register Argo CD Application ---
 - name: Apply Argo CD Application to cluster
@@ -278,4 +293,8 @@
 
 - name: Report gitops initialized
   ansible.builtin.debug:
-    msg: "GitOps initialized for '{{ instance_id }}'. Key exported to {{ key }}"
+    msg:
+      - "GitOps initialized for '{{ instance_id }}'."
+      - "SSH deploy key saved to: {{ key }}"
+      - "Argo CD repo credential Secret created."
+      - "Store the key securely — it is needed to push config changes and to set up additional hosts."

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -99,3 +99,46 @@
           kubectl rollout status deployment/canasta-{{ instance_id }}-web
           -n {{ _k8s_namespace }} --timeout=300s
       changed_when: false
+
+    # Re-enable Argo CD auto-sync after start. The stop flow suspends
+    # sync to prevent selfHeal from reverting the scale-to-zero. We
+    # read the sync policy from the instance's values.yaml so we
+    # restore whatever the user configured, not a hardcoded default.
+    # See #70.
+    - name: Check if Argo CD Application exists for this instance
+      ansible.builtin.command:
+        cmd: >-
+          kubectl get application canasta-{{ instance_id }}
+          -n {{ argocd_namespace | default('argocd') }}
+          -o jsonpath={.metadata.name}
+      register: _start_argocd_app
+      changed_when: false
+      ignore_errors: true
+
+    - name: Re-enable Argo CD auto-sync
+      when: _start_argocd_app.rc == 0
+      block:
+        - name: Read sync policy from values.yaml
+          ansible.builtin.set_fact:
+            _argocd_sync_policy: >-
+              {{ (lookup('file', instance_path ~ '/values.yaml')
+                  | from_yaml).get('argocd', {}).get('syncPolicy', {}) }}
+
+        - name: Build sync policy patch
+          ansible.builtin.set_fact:
+            _sync_patch:
+              spec:
+                syncPolicy:
+                  automated:
+                    selfHeal: "{{ _argocd_sync_policy.get('selfHeal', true) }}"
+                    prune: "{{ _argocd_sync_policy.get('prune', true) }}"
+                  syncOptions:
+                    - CreateNamespace=true
+
+        - name: Patch Application to restore auto-sync
+          ansible.builtin.command:
+            cmd: >-
+              kubectl patch application canasta-{{ instance_id }}
+              -n {{ argocd_namespace | default('argocd') }}
+              --type merge -p '{{ _sync_patch | to_json }}'
+          changed_when: true

--- a/roles/orchestrator/tasks/stop.yml
+++ b/roles/orchestrator/tasks/stop.yml
@@ -30,6 +30,28 @@
       ansible.builtin.set_fact:
         _k8s_namespace: "canasta-{{ instance_id }}"
 
+    # Suspend Argo CD auto-sync before scaling to zero. If we don't,
+    # selfHeal detects the scale-to-zero as drift and immediately
+    # reverts it by re-creating the pods. See #70.
+    - name: Check if Argo CD Application exists for this instance
+      ansible.builtin.command:
+        cmd: >-
+          kubectl get application canasta-{{ instance_id }}
+          -n {{ argocd_namespace | default('argocd') }}
+          -o jsonpath={.metadata.name}
+      register: _stop_argocd_app
+      changed_when: false
+      ignore_errors: true
+
+    - name: Suspend Argo CD auto-sync
+      ansible.builtin.command:
+        cmd: >-
+          kubectl patch application canasta-{{ instance_id }}
+          -n {{ argocd_namespace | default('argocd') }}
+          --type merge -p '{"spec":{"syncPolicy":null}}'
+      changed_when: true
+      when: _stop_argocd_app.rc == 0
+
     - name: Scale down all deployments
       ansible.builtin.command:
         cmd: "kubectl scale deployment --all --replicas=0 -n {{ _k8s_namespace }}"


### PR DESCRIPTION
Fixes #69 and #70. Both discovered during the multi-node EC2 test rerun.

## #69 — gitops init auto-creates the Argo CD repo credential Secret

Previously, `canasta gitops init` on K8s created the Argo CD Application but **not** the repo credential Secret. The user had to manually run `kubectl create secret` with the SSH deploy key and label it with `argocd.argoproj.io/secret-type=repository` — an undocumented step that's the K8s analog of the Compose path's automatic git-crypt setup.

Now, when `--key` points at an **existing SSH private key file** (PEM format), gitops init:
1. Reads the key content
2. Creates a K8s Secret in the argocd namespace with the SSH key, repo URL, and the discovery label
3. Applies the Application (which can now sync immediately — no manual kubectl needed)

If `--key` points at a non-existent path, the legacy behavior is preserved (placeholder file, no Secret, warning printed).

This changes the `--key` semantics for K8s from "output path for a placeholder" to "input path for an SSH deploy key" — matching the practical usage pattern where the user generates the key externally, adds the public half to GitHub, and passes the private half to gitops init.

## #70 — stop suspends Argo CD auto-sync, start re-enables it

Previously, `canasta stop` scaled all deployments/statefulsets to zero but didn't touch the Argo CD Application. Argo CD's `selfHeal: true` policy detected the scale-to-zero as drift and immediately reverted it — the instance came back up within 30 seconds.

Now:
- **Stop**: checks if an Argo CD Application exists for this instance (`kubectl get application canasta-<id> -n argocd`). If yes, patches `spec.syncPolicy` to `null` (suspending auto-sync) before scaling to zero. If no Application exists, the patch is skipped gracefully.
- **Start**: after scaling back up and waiting for readiness, checks for the Application again. If it exists, reads the sync policy from the instance's `values.yaml` and patches it back to restore whatever the user configured (`selfHeal`, `prune`, `syncOptions`). This preserves custom sync policies rather than hardcoding defaults.

## Files

- `roles/gitops/tasks/init_kubernetes.yml` — restructured key handling (read existing key, conditional placeholder, Secret creation gated on `_have_ssh_key`)
- `roles/orchestrator/tasks/stop.yml` — suspend Argo CD sync before scale-to-zero
- `roles/orchestrator/tasks/start.yml` — re-enable Argo CD sync after scale-up

## Test plan

- [x] `make test-unit` — 328 passed
- [x] `make lint` — exit 0
- [ ] CI passes (fast jobs only per #68)
- [ ] Re-run Test A on the live EC2 cluster: `canasta stop` → wait 30s → verify pods are still gone
- [ ] Re-run Test F on the live EC2 cluster: `canasta gitops init` without manual kubectl steps → verify Argo CD syncs successfully
