### PR TITLE
canasta-docker: strip credsStore from Docker config.json for container use

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -83,6 +83,39 @@ MOUNTS=(
     --user "$(id -u):$(id -g)"
 )
 
+# Sanitize Docker config.json for the container.
+# macOS Docker Desktop's config.json typically contains
+# "credsStore": "desktop" which references docker-credential-desktop,
+# a macOS-specific binary that doesn't exist inside the Linux
+# container. When Docker CLI inside the container tries to pull an
+# image (e.g., during 'docker compose up'), it fails with
+# "docker-credential-desktop: executable file not found in $PATH"
+# even for public images. The fix: mount a sanitized copy with
+# credsStore stripped. The $HOME mount brings the original config.json
+# into the container, but a more specific file mount overrides it.
+DOCKER_CONFIG_HOST="$HOME/.docker/config.json"
+if [[ -f "$DOCKER_CONFIG_HOST" ]] && grep -q '"credsStore"' "$DOCKER_CONFIG_HOST" 2>/dev/null; then
+    CANASTA_DOCKER_CONFIG="$CONFIG_DIR/.docker-config.json"
+    if command -v python3 &>/dev/null; then
+        python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    c = json.load(f)
+c.pop('credsStore', None)
+c.pop('credStore', None)
+with open(sys.argv[2], 'w') as f:
+    json.dump(c, f, indent=2)
+" "$DOCKER_CONFIG_HOST" "$CANASTA_DOCKER_CONFIG" 2>/dev/null
+    else
+        # Fallback: sed-based strip (handles the common single-line case)
+        sed 's/"credsStore"[[:space:]]*:[[:space:]]*"[^"]*"[[:space:]]*,\?//' \
+            "$DOCKER_CONFIG_HOST" > "$CANASTA_DOCKER_CONFIG" 2>/dev/null
+    fi
+    if [[ -f "$CANASTA_DOCKER_CONFIG" ]]; then
+        MOUNTS+=(-v "$CANASTA_DOCKER_CONFIG":"$HOME/.docker/config.json":ro)
+    fi
+fi
+
 # Ensure the container has a passwd entry for the host UID so that
 # SSH and Ansible can resolve the current user (required for remote
 # host connections via -H).


### PR DESCRIPTION
Fixes #73.

The canasta-docker wrapper mounts `$HOME` into the container, bringing `~/.docker/config.json` along. On macOS Docker Desktop, that file contains `"credsStore": "desktop"` — a macOS-specific credential helper binary that doesn't exist in the Linux container. `docker compose up` (Compose instances) fails trying to pull images:

```
error getting credentials - err: exec: "docker-credential-desktop":
executable file not found in $PATH
```

## Fix

Before launching the container, check if the host's config.json contains `credsStore`. If so, create a sanitized copy at `$CONFIG_DIR/.docker-config.json` with `credsStore` stripped, and mount it over `$HOME/.docker/config.json` inside the container. The more-specific file mount overrides the broader `$HOME` directory mount.

Uses python3 (preferred, clean JSON round-trip) or sed (fallback) for the JSON manipulation.

## Why K8s wasn't affected

K8s image pulls happen on the cluster nodes (their own containerd config), not on the controller. Only Compose instances run `docker compose up` via the mounted Docker socket on the controller, triggering the credential helper lookup.

## Test plan

- [ ] `canasta create --id test --wiki main --domain-name localhost` on macOS Docker Desktop succeeds (previously failed with credsStore error)
- [ ] K8s workflow still works (no regression)
- [ ] Host's `~/.docker/config.json` is NOT modified (the sanitized copy is a separate file)