### PR TITLE
Fix debug msg list rendering in storage setup and gitops init

### DIFF
--- a/playbooks/storage_setup_efs.yml
+++ b/playbooks/storage_setup_efs.yml
@@ -49,16 +49,9 @@
 
 - name: Report setup complete
   ansible.builtin.debug:
-    msg:
-      - >-
-        EFS storage configured. StorageClass
-        '{{ storage_class_name | default('efs') }}' is ready and set
-        as the default for new Kubernetes instances.
-      - >-
-        To run a multi-replica web pod across nodes, also pass
-        --access-mode ReadWriteMany when creating the instance:
-      - >-
-        canasta create -i <id> --orchestrator kubernetes
-        --storage-class {{ storage_class_name | default('efs') }}
-        --access-mode ReadWriteMany ...
-      - "See docs/multi-node.md for the full walkthrough."
+    msg: >-
+      EFS storage configured. StorageClass
+      '{{ storage_class_name | default('efs') }}' is ready.
+      To run a multi-replica web pod across nodes, also pass
+      --access-mode ReadWriteMany when creating the instance.
+      See docs/multi-node.md for the full walkthrough.

--- a/playbooks/storage_setup_nfs.yml
+++ b/playbooks/storage_setup_nfs.yml
@@ -103,16 +103,9 @@
 
 - name: Report setup complete
   ansible.builtin.debug:
-    msg:
-      - >-
-        NFS storage configured. StorageClass
-        '{{ storage_class_name | default('nfs') }}' is ready and set
-        as the default for new Kubernetes instances.
-      - >-
-        To run a multi-replica web pod across nodes, also pass
-        --access-mode ReadWriteMany when creating the instance:
-      - >-
-        canasta create -i <id> --orchestrator kubernetes
-        --storage-class {{ storage_class_name | default('nfs') }}
-        --access-mode ReadWriteMany ...
-      - "See docs/multi-node.md for the full walkthrough."
+    msg: >-
+      NFS storage configured. StorageClass
+      '{{ storage_class_name | default('nfs') }}' is ready.
+      To run a multi-replica web pod across nodes, also pass
+      --access-mode ReadWriteMany when creating the instance.
+      See docs/multi-node.md for the full walkthrough.

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -74,14 +74,12 @@
 
 - name: Display public key for deploy key setup
   ansible.builtin.debug:
-    msg:
-      - "SSH deploy key {{ (_existing_is_ssh_key | bool) | ternary('found', 'generated') }}."
-      - "Add this public key as a deploy key (with WRITE access) on your git repository:"
-      - ""
-      - "  {{ _gitops_ssh_pubkey.content | b64decode | trim }}"
-      - ""
-      - "Repository: {{ repo }}"
-      - "GitHub: go to Settings > Deploy keys > Add deploy key"
+    msg: >-
+      SSH deploy key {{ (_existing_is_ssh_key | bool) | ternary('found', 'generated') }}.
+      Add this public key as a deploy key (with WRITE access) on your git repository.
+      Repository: {{ repo }}
+      GitHub: go to Settings > Deploy keys > Add deploy key.
+      Public key: {{ _gitops_ssh_pubkey.content | b64decode | trim }}
 
 - name: Pause for user to add deploy key to git repository
   ansible.builtin.pause:
@@ -293,8 +291,9 @@
 
 - name: Report gitops initialized
   ansible.builtin.debug:
-    msg:
-      - "GitOps initialized for '{{ instance_id }}'."
-      - "SSH deploy key saved to: {{ key }}"
-      - "Argo CD repo credential Secret created."
-      - "Store the key securely — it is needed to push config changes and to set up additional hosts."
+    msg: >-
+      GitOps initialized for '{{ instance_id }}'.
+      SSH deploy key saved to: {{ key }}.
+      Argo CD repo credential Secret created.
+      Store the key securely — it is needed to push config changes
+      and to set up additional hosts.


### PR DESCRIPTION
Fixes #75.

Ansible's `debug` module with `msg:` as a YAML list renders the output as a Python list literal (`['item1', 'item2', ...]`) rather than one item per line. This made the user-facing output of `canasta storage setup nfs/efs` and `canasta gitops init` on K8s unreadable.

Fix: switch from YAML lists to single folded scalars (`msg: >-`) for all affected debug messages.

## Files

- `playbooks/storage_setup_nfs.yml` — consolidated 4-item list to single line
- `playbooks/storage_setup_efs.yml` — same
- `roles/gitops/tasks/init_kubernetes.yml` — two debug tasks (public key display, init complete report)

## Test plan

- [x] `make test-unit` — 328 passed
- [x] `make lint` — exit 0
- [ ] CI passes