### PR TITLE
Fix canasta-docker kubeconfig for Docker Desktop + skip preflight when --install-k3s

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -116,6 +116,26 @@ with open(sys.argv[2], 'w') as f:
     fi
 fi
 
+# Sanitize kubeconfig for the container.
+# Docker Desktop on macOS exposes the K8s API server at 127.0.0.1:6443
+# from the host (via port forwarding from the VM). Inside a container,
+# 127.0.0.1 is the container's own loopback — the host is reachable at
+# kubernetes.docker.internal instead (which is also in the API server's
+# TLS certificate SANs, so no --insecure-skip-tls-verify needed).
+# Without this fix, every K8s command via canasta-docker against Docker
+# Desktop fails with "Cannot reach Kubernetes cluster." See #78.
+KUBE_CONFIG="$HOME/.kube/config"
+if [[ -f "$KUBE_CONFIG" ]] \
+    && grep -qE 'server:.*https://(127\.0\.0\.1|localhost)' "$KUBE_CONFIG" 2>/dev/null; then
+    CANASTA_KUBE_CONFIG="$CONFIG_DIR/.kube-config"
+    sed -e 's|server: https://127\.0\.0\.1|server: https://kubernetes.docker.internal|g' \
+        -e 's|server: https://localhost|server: https://kubernetes.docker.internal|g' \
+        "$KUBE_CONFIG" > "$CANASTA_KUBE_CONFIG" 2>/dev/null
+    if [[ -f "$CANASTA_KUBE_CONFIG" ]]; then
+        MOUNTS+=(-v "$CANASTA_KUBE_CONFIG":"$HOME/.kube/config":ro)
+    fi
+fi
+
 # Ensure the container has a passwd entry for the host UID so that
 # SSH and Ansible can resolve the current user (required for remote
 # host connections via -H).

--- a/roles/orchestrator/tasks/k8s_preflight.yml
+++ b/roles/orchestrator/tasks/k8s_preflight.yml
@@ -15,19 +15,26 @@
       See https://kubernetes.io/docs/tasks/tools/
   when: _kubectl_check.rc != 0
 
+# Skip the cluster-reachability check when --install-k3s is set —
+# the cluster doesn't exist yet and will be created after preflight.
+# Still check kubectl and helm are installed (above/below) so those
+# failures are caught early. See #77.
 - name: Check cluster is reachable
   ansible.builtin.command:
     cmd: kubectl cluster-info
   register: _cluster_check
   changed_when: false
   ignore_errors: true
+  when: not (install_k3s | default(false) | bool)
 
 - name: Fail if cluster not reachable
   ansible.builtin.fail:
     msg: >-
       Cannot reach Kubernetes cluster. Ensure kubectl is configured with a
       valid kubeconfig. Use --install-k3s to install a local cluster.
-  when: _cluster_check.rc != 0
+  when:
+    - not (install_k3s | default(false) | bool)
+    - _cluster_check.rc | default(0) != 0
 
 - name: Check helm is available
   ansible.builtin.command:
@@ -43,7 +50,11 @@
       See https://helm.sh/docs/intro/install/
   when: _helm_check.rc != 0
 
+# Skip the node resource check when --install-k3s is set — there are
+# no nodes yet. The check will effectively run on the first start
+# after k3s is installed. See #77.
 - name: Get node capacity resources
+  when: not (install_k3s | default(false) | bool)
   vars:
     # Read .status.capacity (the total capacity reported by the kernel,
     # ≈ MemTotal) rather than .status.allocatable (capacity minus
@@ -66,6 +77,7 @@
   changed_when: false
 
 - name: Check node resources are sufficient
+  when: not (install_k3s | default(false) | bool)
   vars:
     # Minimum requirements for a Canasta instance, expressed against
     # node capacity (not allocatable; not the sum of pod requests).


### PR DESCRIPTION
Fixes #77 and #78.

## #78 — kubeconfig localhost translation

Docker Desktop on macOS exposes the K8s API at `127.0.0.1:6443` from the host, but inside a container `127.0.0.1` is the container's own loopback. Every K8s command via canasta-docker against Docker Desktop failed with 'Cannot reach Kubernetes cluster.'

Fix: the wrapper now detects kubeconfigs with `127.0.0.1` or `localhost` server URLs, creates a sanitized copy with the URL replaced by `kubernetes.docker.internal` (which resolves inside Docker containers and is in the API server's TLS cert SANs), and mounts it over `~/.kube/config` inside the container. Same pattern as the credsStore fix in #74. The host's kubeconfig is NOT modified.

## #77 — skip preflight when --install-k3s

`canasta create --install-k3s` ran `kubectl cluster-info` and the node capacity check BEFORE `k8s_install_k3s.yml` installed k3s. If k3s wasn't already running, the preflight failed — even though `--install-k3s` was about to fix that.

Fix: gate the cluster-reachability check and the node resource check on `not (install_k3s | default(false) | bool)`. kubectl and helm install checks still run (host-level, not cluster-level).

## Files

- `canasta-docker` — kubeconfig localhost → kubernetes.docker.internal translation
- `roles/orchestrator/tasks/k8s_preflight.yml` — install_k3s gates on cluster and node checks

## Test plan

- [x] `make test-unit` — 328 passed
- [x] `make lint` — exit 0
- [ ] CI passes
- [ ] `canasta create --orchestrator kubernetes` via canasta-docker against Docker Desktop K8s succeeds without manually editing kubeconfig (test #78)
- [ ] `canasta create --orchestrator kubernetes --install-k3s` gets past preflight on a host with kubectl+helm but no k3s (test #77)