### PR TITLE
docs/multi-node.md: clarify that web.replicaCount must be added, not edited

### DIFF
--- a/docs/multi-node.md
+++ b/docs/multi-node.md
@@ -308,16 +308,26 @@ kubectl get pvc -n canasta-mywiki
 
 ## Step 5 — Scale the web tier
 
-Edit the instance's `values.yaml` and set `web.replicaCount`:
+The generated `values.yaml` does not include a `web:` section by
+default — it inherits `web.replicaCount: 1` from the chart defaults.
+To scale up, you need to **add** the section:
 
 ```bash
 # Find the instance path:
 canasta list
 
-# Edit instance_path/values.yaml:
+# Add a web: section to instance_path/values.yaml. For example,
+# insert before the "domains:" line:
+#
 #   web:
 #     replicaCount: 3
 #
+# Or via sed:
+sed -i '' '/^domains:/i\
+web:\
+  replicaCount: 3\
+' <instance_path>/values.yaml
+
 # Then restart so the helm upgrade picks up the change:
 canasta restart --id mywiki
 ```


### PR DESCRIPTION
The generated values.yaml does not include a `web:` section — it inherits `replicaCount: 1` from the chart defaults. The previous wording said 'edit values.yaml and set web.replicaCount' which implied the field already existed.

Updated to explain that the section must be added, with a concrete `sed` command.

Discovered during the multi-node EC2 test when the `sed` substitution silently did nothing because the field wasn't there.