### PR TITLE
Propagate config set to values.yaml for K8s-mapped knobs

### DIFF
--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -267,7 +267,7 @@
     name: orchestrator
     tasks_from: ensure_observability_credentials.yml
 
-# --- Kubernetes values.yaml propagation (#53) ---
+# --- Kubernetes values.yaml propagation ---
 # On K8s, certain env keys are sourced from values.yaml fields that
 # double-duty as cluster-level configuration (Ingress hostnames,
 # deployment gates, etc.). When these keys change via config set, we
@@ -275,7 +275,7 @@
 # reaches the cluster on the next helm upgrade (which the restart
 # that config set triggers will do). Without this, the value lands
 # in .env on the controller but the running pods and K8s resources
-# never see it. See #53.
+# never see it.
 #
 # Mapping table:
 #   MW_SITE_FQDN         → domains: [<value>]

--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -266,3 +266,55 @@
   ansible.builtin.include_role:
     name: orchestrator
     tasks_from: ensure_observability_credentials.yml
+
+# --- Kubernetes values.yaml propagation (#53) ---
+# On K8s, certain env keys are sourced from values.yaml fields that
+# double-duty as cluster-level configuration (Ingress hostnames,
+# deployment gates, etc.). When these keys change via config set, we
+# must also update the corresponding values.yaml field so the change
+# reaches the cluster on the next helm upgrade (which the restart
+# that config set triggers will do). Without this, the value lands
+# in .env on the controller but the running pods and K8s resources
+# never see it. See #53.
+#
+# Mapping table:
+#   MW_SITE_FQDN         → domains: [<value>]
+#   CANASTA_ENABLE_VARNISH → varnish.enabled: <bool>
+#   CANASTA_ENABLE_ELASTICSEARCH → elasticsearch.enabled: <bool>
+- name: Propagate config key to K8s values.yaml
+  when:
+    - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+    - _config_key in ['MW_SITE_FQDN', 'CANASTA_ENABLE_VARNISH', 'CANASTA_ENABLE_ELASTICSEARCH']
+  block:
+    - name: Read current values.yaml
+      ansible.builtin.slurp:
+        src: "{{ instance_path }}/values.yaml"
+      register: _k8s_values_raw
+
+    - name: Parse current values
+      ansible.builtin.set_fact:
+        _k8s_values: "{{ _k8s_values_raw.content | b64decode | from_yaml }}"
+
+    - name: Build values.yaml override for MW_SITE_FQDN
+      ansible.builtin.set_fact:
+        _k8s_override: "{{ {'domains': [_config_value | regex_replace(':[0-9]+$', '')]} }}"
+      when: _config_key == 'MW_SITE_FQDN'
+
+    - name: Build values.yaml override for CANASTA_ENABLE_VARNISH
+      ansible.builtin.set_fact:
+        _k8s_override: "{{ {'varnish': {'enabled': _config_value | lower == 'true'}} }}"
+      when: _config_key == 'CANASTA_ENABLE_VARNISH'
+
+    - name: Build values.yaml override for CANASTA_ENABLE_ELASTICSEARCH
+      ansible.builtin.set_fact:
+        _k8s_override: "{{ {'elasticsearch': {'enabled': _config_value | lower == 'true'}} }}"
+      when: _config_key == 'CANASTA_ENABLE_ELASTICSEARCH'
+
+    - name: Write updated values.yaml
+      ansible.builtin.copy:
+        content: >-
+          {{ _k8s_values
+             | combine(_k8s_override, recursive=True)
+             | to_nice_yaml(indent=2) }}
+        dest: "{{ instance_path }}/values.yaml"
+        mode: "0644"

--- a/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
@@ -65,32 +65,12 @@ spec:
             - name: http
               containerPort: 80
               protocol: TCP
-          # The env vars the pod receives come from two places:
-          #
-          #   envFrom: canasta-<id>-env ConfigMap
-          #       Populated by k8s_sync_config.yml from the instance's .env
-          #       file on each restart. Covers the PHP_* knobs,
-          #       CANASTA_ENABLE_WIKI_DIRECTORY, CANASTA_ENABLE_VERY_SHORT_URLS,
-          #       MW_SITEMAP_PAUSE_DAYS, and any other .env key listed in the
-          #       sync task's allowlist. `canasta config set <key>=<value>`
-          #       propagates cleanly through this path. See #51.
-          #
-          #   env: hardcoded entries below
-          #       Three of these (MW_SITE_SERVER, MW_SITE_FQDN,
-          #       CANASTA_ENABLE_VARNISH) intentionally stay here instead of
-          #       moving to the ConfigMap above. They are sourced from
-          #       values.yaml fields (.Values.domains, .Values.varnish.enabled)
-          #       that double-duty as K8s-level configuration:
-          #       .Values.domains drives Ingress hostnames and TLS hosts;
-          #       .Values.varnish.enabled gates whether the Varnish deployment
-          #       exists at all. Moving just the pod env vars to the ConfigMap
-          #       would create half-broken state where the pod sees one value
-          #       and the cluster resources still reflect the old one. Tracked
-          #       separately as #53.
-          #
-          #       MYSQL_HOST is a constant. MYSQL_PASSWORD and MW_SECRET_KEY
-          #       stay as secretKeyRef because secrets don't belong in
-          #       ConfigMaps.
+          # Runtime knobs from .env come via the envFrom ConfigMap.
+          # MW_SITE_SERVER, MW_SITE_FQDN, and CANASTA_ENABLE_VARNISH
+          # stay as hardcoded env: entries because they're sourced from
+          # values.yaml fields that also drive K8s resources (Ingress
+          # hostnames, Varnish deployment gate). config set updates
+          # both .env and values.yaml for these keys.
           envFrom:
             - configMapRef:
                 name: {{ include "canasta.fullname" . }}-env

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -1091,6 +1091,50 @@ def test_k8s_lifecycle(inst):
         "Expected PHP_UPLOAD_MAX_FILESIZE=77M in pod, got: %r" % result.stdout
     )
 
+    # #53: verify that config set propagates values.yaml-backed knobs
+    # on K8s. Previously, setting CANASTA_ENABLE_VARNISH via config set
+    # updated .env but not values.yaml, so the Helm chart and the
+    # running pod never saw the change.
+    print("Testing config set → values.yaml propagation (#53)...")
+    import yaml as _yaml  # for reading values.yaml
+
+    values_path = os.path.join(inst.work_dir, "values.yaml")
+
+    # First, hand-edit replicaCount into values.yaml to verify it
+    # survives the config set round-trip. This is the #53 acceptance
+    # criterion: unrelated hand-edits must not be clobbered.
+    with open(values_path) as f:
+        values = _yaml.safe_load(f)
+    values.setdefault("web", {})["replicaCount"] = 7
+    with open(values_path, "w") as f:
+        _yaml.dump(values, f, default_flow_style=False)
+
+    # Set a values.yaml-backed knob via config set
+    inst.run_ok(
+        "config", "set", "-i", inst.id,
+        "CANASTA_ENABLE_VARNISH=false", "--no-restart",
+    )
+
+    # Read values.yaml back and verify both:
+    # 1. varnish.enabled is now false
+    # 2. web.replicaCount is still 7 (not clobbered)
+    with open(values_path) as f:
+        values_after = _yaml.safe_load(f)
+    assert values_after.get("varnish", {}).get("enabled") is False, (
+        "Expected varnish.enabled=false in values.yaml after config set, "
+        "got: %s" % values_after.get("varnish", {}).get("enabled")
+    )
+    assert values_after.get("web", {}).get("replicaCount") == 7, (
+        "Hand-edited web.replicaCount=7 was clobbered by config set! "
+        "Got: %s" % values_after.get("web", {}).get("replicaCount")
+    )
+
+    # Revert varnish
+    inst.run_ok(
+        "config", "set", "-i", inst.id,
+        "CANASTA_ENABLE_VARNISH=true", "--no-restart",
+    )
+
     print("Deleting instance...")
     inst.run_ok("delete", "-i", inst.id, "--yes")
 


### PR DESCRIPTION
Fixes #53.

## Bug

On K8s instances, `canasta config set MW_SITE_FQDN=new.example.com` (and `CANASTA_ENABLE_VARNISH`, `CANASTA_ENABLE_ELASTICSEARCH`) updated `.env` on the controller but never touched `values.yaml`. Since these keys are sourced from `values.yaml` fields (`.Values.domains`, `.Values.varnish.enabled`, `.Values.elasticsearch.enabled`), the running cluster never saw the change — the Ingress kept routing the old hostname, the Varnish deployment kept running, etc.

## Fix

A K8s-gated block at the end of `_side_effects.yml` that, for the three mapped keys, reads `values.yaml`, merges the new value via Ansible's `combine(recursive=True)`, and writes it back. The merge preserves everything else in `values.yaml` (resource limits, replica counts, storage classes, etc.).

| `config set` key | Mutates `values.yaml` field |
|---|---|
| `MW_SITE_FQDN=<host>` | `domains: [<host>]` |
| `CANASTA_ENABLE_VARNISH=true\|false` | `varnish: {enabled: <bool>}` |
| `CANASTA_ENABLE_ELASTICSEARCH=true\|false` | `elasticsearch: {enabled: <bool>}` |

The merge uses `from_yaml | combine | to_nice_yaml`, which round-trips through PyYAML. This loses YAML comments but preserves all data. In practice the generated `values.yaml` files don't have user-added comments (the Jinja template and gitops merge steps both strip them already).

## Integration test

Extended `test_k8s_lifecycle` to verify:

1. Hand-edits `web.replicaCount` to 7 in `values.yaml`
2. Runs `config set CANASTA_ENABLE_VARNISH=false`
3. Reads `values.yaml` back and asserts both:
   - `varnish.enabled` is `False` (the change propagated)
   - `web.replicaCount` is still `7` (the hand-edit survived)

## Local verification

Simulated the merge against a real generated `values.yaml` from a Docker Desktop K8s instance:

```
varnish.enabled: False     ← changed
web.replicaCount: 7        ← hand-edit preserved
domains: ['localhost']     ← untouched
instance.id: test53        ← untouched
```

## Test plan

- [x] `make test-unit` — 328 passed
- [x] `make lint` — exit 0
- [x] Local merge simulation verified
- [ ] CI passes
- [ ] CI K8s integration test exercises the new `config set → values.yaml` path
