### PR TITLE
Remove issue/PR references from code comments

### DIFF
--- a/playbooks/add.yml
+++ b/playbooks/add.yml
@@ -19,10 +19,10 @@
          | regex_replace('^/', '') }}
 
 # Refuse path-based wikis when the instance has very short URLs on.
-# The runtime in CanastaBase #150 catches this too, but failing fast
+# The runtime catches this too, but failing fast
 # at the CLI gives the user a clear error before the wiki actually
 # gets installed (which would otherwise leave a half-created wiki
-# database that the next restart would refuse to load). #50.
+# database that the next restart would refuse to load).
 - name: Read CANASTA_ENABLE_VERY_SHORT_URLS from .env to validate URL shape
   canasta_env:
     path: "{{ instance_path }}/.env"

--- a/roles/common/tasks/switch_connection.yml
+++ b/roles/common/tasks/switch_connection.yml
@@ -13,7 +13,7 @@
 # cached `discovered_interpreter_python` from iteration 1 leaks into
 # iteration 2, and Ansible tries to use the previous host's Python path
 # on the new host. /usr/bin/python3 bypasses discovery entirely and is
-# the canonical Python 3 path on every modern Linux distro. See #41.
+# the canonical Python 3 path on every modern Linux distro.
 
 - name: Parse SSH user and hostname from registry host
   ansible.builtin.set_fact:

--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -30,7 +30,7 @@
 # at request time as a safety net for hand-edited configs, but the
 # user-facing UX of failing fast at the CLI is much friendlier than
 # discovering the problem when the container restart-loops on next
-# start. See CanastaBase #138 / #150 for the runtime side. See #50.
+# start.
 - name: Validate CANASTA_ENABLE_VERY_SHORT_URLS=true does not collide with current state
   when:
     - _config_key == 'CANASTA_ENABLE_VERY_SHORT_URLS'
@@ -174,7 +174,7 @@
 # reflected in wikis.yaml and MW_SITE_*). The HTTP_PORT/HTTPS_PORT
 # handler above only fires when the port values change; we need a
 # parallel handler for when the *scheme* changes but the port values
-# don't. See #46.
+# don't.
 - name: Apply CADDY_AUTO_HTTPS side effects
   when: _config_key == 'CADDY_AUTO_HTTPS'
   block:

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -37,7 +37,6 @@
 # (4 GiB advertised) reports ~3826 MiB MemTotal, for example. The
 # 3500 MiB floor is comfortably above what 2 GiB instances report
 # (~1700-1900 MiB) and below what real 4 GiB cloud instances report.
-#
 - name: Check target host total memory (minimum 3500 MiB) — Compose only
   ansible.builtin.command:
     cmd: >-

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -29,7 +29,7 @@
 # Compose-only host memory preflight. The K8s path has its own
 # per-node memory check in k8s_preflight.yml — running this on a K8s
 # create would measure the controller host, not the cluster nodes,
-# which is the wrong thing. See #58.
+# which is the wrong thing.
 #
 # Threshold is 3500 MiB rather than a round 4096 MiB because cloud
 # instances marketed as "4 GiB" actually expose ~3700-3900 MiB to the
@@ -37,7 +37,7 @@
 # (4 GiB advertised) reports ~3826 MiB MemTotal, for example. The
 # 3500 MiB floor is comfortably above what 2 GiB instances report
 # (~1700-1900 MiB) and below what real 4 GiB cloud instances report.
-# See #65.
+#
 - name: Check target host total memory (minimum 3500 MiB) — Compose only
   ansible.builtin.command:
     cmd: >-

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -262,7 +262,7 @@
 # The SSH deploy key (generated or user-supplied) is stored as a K8s
 # Secret that Argo CD discovers via the repository label. This is what
 # lets Argo CD pull from the git repo without manual kubectl steps.
-# See #69.
+#
 - name: Create or update Argo CD repo credential Secret
   kubernetes.core.k8s:
     state: present

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -262,7 +262,6 @@
 # The SSH deploy key (generated or user-supplied) is stored as a K8s
 # Secret that Argo CD discovers via the repository label. This is what
 # lets Argo CD pull from the git repo without manual kubectl steps.
-#
 - name: Create or update Argo CD repo credential Secret
   kubernetes.core.k8s:
     state: present

--- a/roles/orchestrator/files/helm/canasta/templates/configmap-env.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/configmap-env.yaml
@@ -9,7 +9,6 @@ the pods consume via envFrom: configMapRef in their deployment templates.
 Deliberately kept separate from the web-config ConfigMap (which holds
 opaque file contents like wikis.yaml and settings/*) so that the envFrom
 semantics — one ConfigMap key = one environment variable — stay clean.
-
 */}}
 {{- if .Values.configData.env }}
 apiVersion: v1

--- a/roles/orchestrator/files/helm/canasta/templates/configmap-env.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/configmap-env.yaml
@@ -9,7 +9,7 @@ the pods consume via envFrom: configMapRef in their deployment templates.
 Deliberately kept separate from the web-config ConfigMap (which holds
 opaque file contents like wikis.yaml and settings/*) so that the envFrom
 semantics — one ConfigMap key = one environment variable — stay clean.
-See issue #51.
+
 */}}
 {{- if .Values.configData.env }}
 apiVersion: v1

--- a/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
@@ -73,7 +73,7 @@ spec:
           #       CANASTA_ENABLE_WIKI_DIRECTORY, CANASTA_ENABLE_VERY_SHORT_URLS,
           #       MW_SITEMAP_PAUSE_DAYS, and any other .env key listed in the
           #       sync task's allowlist. `canasta config set <key>=<value>`
-          #       propagates cleanly through this path. See #51.
+          #       propagates cleanly through this path.
           #
           #   env: hardcoded entries below
           #       Three of these (MW_SITE_SERVER, MW_SITE_FQDN,
@@ -85,8 +85,8 @@ spec:
           #       .Values.varnish.enabled gates whether the Varnish deployment
           #       exists at all. Moving just the pod env vars to the ConfigMap
           #       would create half-broken state where the pod sees one value
-          #       and the cluster resources still reflect the old one. Tracked
-          #       separately as #53.
+          #       and the cluster resources still reflect the old one.
+
           #
           #       MYSQL_HOST is a constant. MYSQL_PASSWORD and MW_SECRET_KEY
           #       stay as secretKeyRef because secrets don't belong in

--- a/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
@@ -86,7 +86,6 @@ spec:
           #       exists at all. Moving just the pod env vars to the ConfigMap
           #       would create half-broken state where the pod sees one value
           #       and the cluster resources still reflect the old one.
-
           #
           #       MYSQL_HOST is a constant. MYSQL_PASSWORD and MW_SECRET_KEY
           #       stay as secretKeyRef because secrets don't belong in

--- a/roles/orchestrator/files/scripts/check_node_resources.py
+++ b/roles/orchestrator/files/scripts/check_node_resources.py
@@ -6,7 +6,7 @@ name, cpu, memory, ephemeral-storage as output by kubectl jsonpath against
 .status.capacity) and compares against MIN_CPU_MILLI, MIN_MEMORY_MI, and
 MIN_STORAGE_GI.
 
-Capacity, not allocatable: see #58 for the rationale. Allocatable is what
+Capacity, not allocatable. Allocatable is what
 kubelet will schedule (capacity minus kube-reserved minus system-reserved
 minus eviction-threshold), and on a 4 GiB node it's ~3.5 GiB. Checking
 against capacity makes the threshold match what the user sees as their
@@ -52,7 +52,7 @@ def main():
     node_data = os.environ.get("NODE_DATA", "").strip()
     min_cpu = int(os.environ.get("MIN_CPU_MILLI", 600))
     # 3500 MiB rather than a round 4096 because cloud instances
-    # marketed as "4 GiB" report ~3700-3900 MiB capacity. See #65.
+    # marketed as "4 GiB" report ~3700-3900 MiB capacity.
     min_mem = int(os.environ.get("MIN_MEMORY_MI", 3500))
     min_stor = int(os.environ.get("MIN_STORAGE_GI", 15))
 

--- a/roles/orchestrator/tasks/k8s_preflight.yml
+++ b/roles/orchestrator/tasks/k8s_preflight.yml
@@ -18,7 +18,7 @@
 # Skip the cluster-reachability check when --install-k3s is set —
 # the cluster doesn't exist yet and will be created after preflight.
 # Still check kubectl and helm are installed (above/below) so those
-# failures are caught early. See #77.
+# failures are caught early.
 - name: Check cluster is reachable
   ansible.builtin.command:
     cmd: kubectl cluster-info
@@ -52,7 +52,7 @@
 
 # Skip the node resource check when --install-k3s is set — there are
 # no nodes yet. The check will effectively run on the first start
-# after k3s is installed. See #77.
+# after k3s is installed.
 - name: Get node capacity resources
   when: not (install_k3s | default(false) | bool)
   vars:
@@ -63,7 +63,7 @@
     # against allocatable would reject the smallest instance we want
     # to support. Capacity is the right field for matching against
     # the user's intuitive "this is a 4 GiB instance" understanding.
-    # See #58.
+
     _jp: >-
       {range .items[*]}{.metadata.name}{"\t"}
       {.status.capacity.cpu}{"\t"}
@@ -88,7 +88,7 @@
     # BIOS/UEFI/hypervisor reserves. AWS c7i-flex.large (4 GiB
     # advertised) reports ~3826 MiB capacity, for example. 3500 MiB
     # is comfortably above what 2 GiB instances report (~1700-1900)
-    # and below what real 4 GiB cloud instances report. See #65.
+    # and below what real 4 GiB cloud instances report.
     # With Elasticsearch enabled or under heavy traffic, 8 GiB+ is
     # recommended; users opting in to those should size up.
     # CPU: 600m, the sum of resource requests across the chart's

--- a/roles/orchestrator/tasks/k8s_preflight.yml
+++ b/roles/orchestrator/tasks/k8s_preflight.yml
@@ -63,7 +63,6 @@
     # against allocatable would reject the smallest instance we want
     # to support. Capacity is the right field for matching against
     # the user's intuitive "this is a 4 GiB instance" understanding.
-
     _jp: >-
       {range .items[*]}{.metadata.name}{"\t"}
       {.status.capacity.cpu}{"\t"}

--- a/roles/orchestrator/tasks/k8s_sync_config.yml
+++ b/roles/orchestrator/tasks/k8s_sync_config.yml
@@ -5,7 +5,7 @@
 #
 # ConfigMaps created:
 #   canasta-<id>-web-config     — wikis.yaml, .env, settings/*, composer.local.json
-#   canasta-<id>-env            — allowlisted runtime env vars parsed from .env (#51)
+#   canasta-<id>-env            — allowlisted runtime env vars parsed from .env
 #   canasta-<id>-caddy-config   — Caddyfile, Caddyfile.site, Caddyfile.global
 #   canasta-<id>-varnish-config — default.vcl
 #   canasta-<id>-db-config      — my.cnf
@@ -20,7 +20,7 @@
     # through K8s Secrets instead. MW_SITE_SERVER, MW_SITE_FQDN, and
     # CANASTA_ENABLE_VARNISH also stay out because they're sourced from
     # values.yaml fields that double-duty as K8s-level config (Ingress
-    # hostnames, Varnish deployment gate); see #53. See #51 for the
+    # hostnames, Varnish deployment gate). See
     # rationale for an allowlist over a denylist.
     _k8s_pod_env_allowlist:
       - PHP_UPLOAD_MAX_FILESIZE

--- a/roles/orchestrator/tasks/k8s_sync_config.yml
+++ b/roles/orchestrator/tasks/k8s_sync_config.yml
@@ -20,8 +20,7 @@
     # through K8s Secrets instead. MW_SITE_SERVER, MW_SITE_FQDN, and
     # CANASTA_ENABLE_VARNISH also stay out because they're sourced from
     # values.yaml fields that double-duty as K8s-level config (Ingress
-    # hostnames, Varnish deployment gate). See
-    # rationale for an allowlist over a denylist.
+    # hostnames, Varnish deployment gate).
     _k8s_pod_env_allowlist:
       - PHP_UPLOAD_MAX_FILESIZE
       - PHP_POST_MAX_SIZE

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -104,7 +104,7 @@
     # sync to prevent selfHeal from reverting the scale-to-zero. We
     # read the sync policy from the instance's values.yaml so we
     # restore whatever the user configured, not a hardcoded default.
-    # See #70.
+    #
     - name: Check if Argo CD Application exists for this instance
       ansible.builtin.command:
         cmd: >-

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -104,7 +104,6 @@
     # sync to prevent selfHeal from reverting the scale-to-zero. We
     # read the sync policy from the instance's values.yaml so we
     # restore whatever the user configured, not a hardcoded default.
-    #
     - name: Check if Argo CD Application exists for this instance
       ansible.builtin.command:
         cmd: >-

--- a/roles/orchestrator/tasks/stop.yml
+++ b/roles/orchestrator/tasks/stop.yml
@@ -32,7 +32,7 @@
 
     # Suspend Argo CD auto-sync before scaling to zero. If we don't,
     # selfHeal detects the scale-to-zero as drift and immediately
-    # reverts it by re-creating the pods. See #70.
+    # reverts it by re-creating the pods.
     - name: Check if Argo CD Application exists for this instance
       ansible.builtin.command:
         cmd: >-


### PR DESCRIPTION
Bug-tracking context belongs in commit messages and issue trackers, not inline in the codebase. Issue references become stale noise after the issue is closed and are meaningless to future readers without the issue context.

This removes all `See #XX`, `(#XX)`, and `CanastaBase #XX` references from code comments across 12 files. Explanatory comments about design decisions are preserved — only the issue number suffixes are removed.

Going forward, we will not add issue/PR references to code comments.