### PR TITLE
canasta-native: resolve symlinks so it works from /usr/local/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ Run `canasta doctor` to verify all dependencies on a target host.
 Only Docker is required. No Python, no Ansible.
 
 ```bash
-sudo curl -o /usr/local/bin/canasta \
+sudo curl -o /usr/local/bin/canasta-docker \
   https://raw.githubusercontent.com/CanastaWiki/Canasta-Ansible/main/canasta-docker
-sudo chmod +x /usr/local/bin/canasta
+sudo chmod +x /usr/local/bin/canasta-docker
+sudo ln -sf /usr/local/bin/canasta-docker /usr/local/bin/canasta
 ```
 
 The wrapper automatically pulls the `canasta-ansible` image on first
@@ -75,7 +76,19 @@ cd /opt/canasta-ansible
 sudo python3 -m venv .venv
 sudo .venv/bin/pip install -r requirements.txt
 sudo .venv/bin/ansible-galaxy collection install -r requirements.yml
-sudo ln -sf /opt/canasta-ansible/canasta-native /usr/local/bin/canasta
+sudo ln -sf /opt/canasta-ansible/canasta-native /usr/local/bin/canasta-native
+sudo ln -sf /usr/local/bin/canasta-native /usr/local/bin/canasta
+```
+
+### Both wrappers available
+
+Whichever option you chose, both wrappers can coexist at
+`/usr/local/bin`. If you installed via Docker, you can also set up
+native as a backup (or vice versa). Switch the default at any time:
+
+```bash
+sudo ln -sf /usr/local/bin/canasta-docker /usr/local/bin/canasta   # use Docker
+sudo ln -sf /usr/local/bin/canasta-native /usr/local/bin/canasta   # use native
 ```
 
 ### Remote hosts (both options)

--- a/canasta-docker
+++ b/canasta-docker
@@ -5,9 +5,10 @@
 # Only Docker is required on the host. No Python, no Ansible.
 #
 # Install:
-#   curl -o /usr/local/bin/canasta \
+#   sudo curl -o /usr/local/bin/canasta-docker \
 #     https://raw.githubusercontent.com/CanastaWiki/Canasta-Ansible/main/canasta-docker
-#   chmod +x /usr/local/bin/canasta
+#   sudo chmod +x /usr/local/bin/canasta-docker
+#   sudo ln -sf /usr/local/bin/canasta-docker /usr/local/bin/canasta
 #
 # Usage is identical to the native install:
 #   canasta create -i mysite -w main

--- a/canasta-native
+++ b/canasta-native
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 # Thin wrapper that invokes the Python CLI.
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#
+# Resolves symlinks so this script can be symlinked from /usr/local/bin
+# and still find canasta.py and .venv relative to the actual repo checkout.
+#
+# Install layout:
+#   /usr/local/bin/canasta-native  → symlink to <repo>/canasta-native
+#   /usr/local/bin/canasta-docker  → symlink to <repo>/canasta-docker (or copy)
+#   /usr/local/bin/canasta         → symlink to whichever is preferred
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
+
 if [[ -x "${SCRIPT_DIR}/.venv/bin/python" ]]; then
     exec "${SCRIPT_DIR}/.venv/bin/python" "${SCRIPT_DIR}/canasta.py" "$@"
 else


### PR DESCRIPTION
Fixes #63.

`canasta-native` uses `SCRIPT_DIR` to find `canasta.py` and `.venv` relative to itself. Previously it used a simple `dirname` of `BASH_SOURCE[0]`, which returns the symlink's directory, not the target's. A symlink at `/usr/local/bin/canasta-native` → `<repo>/canasta-native` would set `SCRIPT_DIR` to `/usr/local/bin` and fail to find `canasta.py`.

## Fix

Standard symlink-resolution loop (portable across macOS and Linux — `readlink -f` is not available on macOS) that follows the chain until it reaches the actual file, then computes `SCRIPT_DIR` from there.

## Install layout

Both wrappers can now be symlinked from `/usr/local/bin`:

```
/usr/local/bin/canasta-native → <repo>/canasta-native
/usr/local/bin/canasta-docker → <repo>/canasta-docker (or copy — it's standalone)
/usr/local/bin/canasta        → whichever is preferred
```

Switching the default:
```bash
sudo ln -sf /usr/local/bin/canasta-docker /usr/local/bin/canasta
sudo ln -sf /usr/local/bin/canasta-native /usr/local/bin/canasta
```

## Verified

```bash
$ ln -sf ~/xdebug/Canasta-Ansible/canasta-native /tmp/test-native-link
$ /tmp/test-native-link version
Canasta CLI v4.0.0 (native, commit 9db6040, built 2026-04-12 08:03:49)
```

Previously this failed with `can't open file '/tmp/canasta.py'`.