### PR TITLE
Fix values.yaml path in K8s integration test

### DIFF
--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -1098,7 +1098,7 @@ def test_k8s_lifecycle(inst):
     print("Testing config set → values.yaml propagation (#53)...")
     import yaml as _yaml  # for reading values.yaml
 
-    values_path = os.path.join(inst.work_dir, "values.yaml")
+    values_path = os.path.join(inst.instance_path(), "values.yaml")
 
     # First, hand-edit replicaCount into values.yaml to verify it
     # survives the config set round-trip. This is the #53 acceptance


### PR DESCRIPTION
The #53 integration test added in #82 used `inst.work_dir` (the temp directory) instead of `inst.instance_path()` (`work_dir/id`) to find `values.yaml`. The file lives in the instance subdirectory, not the parent.

Caused the K8s integration test to fail with:
```
ERROR: k8s-lifecycle: [Errno 2] No such file or directory: '/tmp/canasta-int-work-.../values.yaml'
```

One-line fix: `inst.work_dir` → `inst.instance_path()`.