### PR TITLE
Code quality fixes from comprehensive review

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -459,12 +459,32 @@ def resolve_command_name(args):
     return cmd
 
 
+def _cleanup_stale_vars_files():
+    """Remove canasta-vars-*.json temp files older than 1 hour.
+
+    These accumulate because os.execvp replaces the process before
+    any cleanup can run. Each canasta invocation cleans up files left
+    by previous invocations.
+    """
+    import glob
+    import time
+    cutoff = time.time() - 3600  # 1 hour
+    for f in glob.glob(os.path.join(tempfile.gettempdir(), "canasta-vars-*.json")):
+        try:
+            if os.path.getmtime(f) < cutoff:
+                os.unlink(f)
+        except OSError:
+            pass
+
+
 def build_ansible_args(ansible_playbook, command_name, args, data):
     """Build the ansible-playbook command line.
 
     Extra vars are passed via a temp JSON file (-e @file) to avoid
     Jinja2 injection and shell quoting issues.
     """
+    _cleanup_stale_vars_files()
+
     cmd_index = {c["name"]: c for c in data["commands"]}
     cmd_def = cmd_index.get(command_name, {})
     params = cmd_def.get("parameters", [])
@@ -507,7 +527,10 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
         else:
             extra_vars[name] = str(value)
 
-    # Write vars to temp file (bypasses Jinja2 interpolation)
+    # Write vars to temp file (bypasses Jinja2 interpolation).
+    # delete=False because ansible-playbook needs to read it after
+    # execvp replaces this process. Stale files are cleaned up by
+    # _cleanup_stale_vars_files() at the start of each invocation.
     vars_file = tempfile.NamedTemporaryFile(
         mode="w", suffix=".json", prefix="canasta-vars-",
         delete=False,

--- a/roles/backup/tasks/restore.yml
+++ b/roles/backup/tasks/restore.yml
@@ -104,17 +104,17 @@
         cmd: >-
           kubectl exec -n {{ _k8s_namespace }} restic-restore --
           tar cf - -C /currentsnapshot/config . 2>/dev/null |
-          tar xf - -C {{ instance_path }}/config/
+          tar xf - -C "{{ instance_path }}/config/"
       changed_when: true
-      ignore_errors: true
+      ignore_errors: true  # OK if config dir is empty in the snapshot
 
     - name: Copy restored .env to host
       ansible.builtin.shell:
         cmd: >-
           kubectl cp {{ _k8s_namespace }}/restic-restore:/currentsnapshot/.env
-          {{ instance_path }}/.env
+          "{{ instance_path }}/.env"
       changed_when: true
-      ignore_errors: true
+      ignore_errors: true  # OK if .env is missing from snapshot
 
     - name: Get DB pod name
       ansible.builtin.include_tasks: >-
@@ -172,9 +172,8 @@
   ansible.builtin.shell:
     cmd: |
       docker run --rm \
-        -v canasta-backup-{{ instance_path | basename
-        }}:/currentsnapshot:ro \
-        -v {{ instance_path }}:/install \
+        -v "canasta-backup-{{ instance_path | basename }}:/currentsnapshot:ro" \
+        -v "{{ instance_path }}:/install" \
         alpine sh -c "
         for d in config extensions images skins public_assets; do
           if [ -d /currentsnapshot/\$d ]; then

--- a/roles/common/library/canasta_wikis_yaml.py
+++ b/roles/common/library/canasta_wikis_yaml.py
@@ -52,8 +52,16 @@ RESERVED_WIKI_IDS = ["settings", "images", "w", "wiki", "wikis"]
 
 
 def wikis_yaml_path(instance_path):
-    """Return the path to wikis.yaml."""
-    return os.path.join(instance_path, "config", "wikis.yaml")
+    """Return the path to wikis.yaml, validated against path traversal."""
+    path = os.path.join(instance_path, "config", "wikis.yaml")
+    real_path = os.path.realpath(path)
+    real_base = os.path.realpath(instance_path)
+    if not real_path.startswith(real_base + os.sep) and real_path != real_base:
+        raise ValueError(
+            "wikis.yaml path '%s' escapes instance directory '%s'"
+            % (real_path, real_base)
+        )
+    return path
 
 
 def validate_wiki_id(wiki_id):

--- a/roles/extensions_skins/library/canasta_settings_yaml.py
+++ b/roles/extensions_skins/library/canasta_settings_yaml.py
@@ -54,10 +54,19 @@ HEADER = "# Canasta will add and remove lines from this file as extensions and s
 
 
 def config_path(instance_path, wiki=None):
-    """Return the path to settings.yaml (global or per-wiki)."""
+    """Return the path to settings.yaml (global or per-wiki), validated against path traversal."""
     if wiki:
-        return os.path.join(instance_path, "config", "settings", "wikis", wiki, "settings.yaml")
-    return os.path.join(instance_path, "config", "settings", "global", "settings.yaml")
+        path = os.path.join(instance_path, "config", "settings", "wikis", wiki, "settings.yaml")
+    else:
+        path = os.path.join(instance_path, "config", "settings", "global", "settings.yaml")
+    real_path = os.path.realpath(path)
+    real_base = os.path.realpath(instance_path)
+    if not real_path.startswith(real_base + os.sep):
+        raise ValueError(
+            "settings.yaml path '%s' escapes instance directory '%s'"
+            % (real_path, real_base)
+        )
+    return path
 
 
 def validate_name(name):

--- a/roles/mediawiki/tasks/install_single_wiki.yml
+++ b/roles/mediawiki/tasks/install_single_wiki.yml
@@ -69,6 +69,15 @@
         instance_orchestrator | default('compose')
         in ['kubernetes', 'k8s']
 
+    - name: Fail if no running web pod found
+      ansible.builtin.fail:
+        msg: >-
+          No running web pod found in namespace canasta-{{ instance_id }}.
+          Check that the instance is started and the web pod is Ready.
+      when:
+        - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+        - _k8s_pod.stdout | default('') | trim == ''
+
     - name: Build K8s extract command
       ansible.builtin.set_fact:
         _extract_cmd: >-

--- a/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
@@ -1,3 +1,6 @@
+{{- if not .Values.domains }}
+  {{- fail "At least one domain must be configured in values.yaml (domains: [example.com])" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -111,21 +114,29 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           startupProbe:
             tcpSocket:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 3
+            timeoutSeconds: 5
             failureThreshold: 30
           readinessProbe:
             tcpSocket:
               port: http
             periodSeconds: 5
+            timeoutSeconds: 5
           livenessProbe:
             tcpSocket:
               port: http
             initialDelaySeconds: 60
             periodSeconds: 30
+            timeoutSeconds: 5
             failureThreshold: 5
       volumes:
         - name: web-configmap


### PR DESCRIPTION
Covers findings from a comprehensive code quality review of the entire codebase.

## Critical fixes

- **Path quoting in restore.yml** — `instance_path` was unquoted in shell commands (`docker run -v`, `kubectl cp`, `tar -C`). Paths with spaces or special characters would break.
- **Path traversal validation** in `canasta_wikis_yaml.py` and `canasta_settings_yaml.py` — added `os.path.realpath()` check that computed paths stay within the instance directory.
- **Temp file cleanup** in `canasta.py` — `canasta-vars-*.json` files accumulated in `/tmp` because `os.execvp` prevents normal cleanup. Each invocation now cleans files older than 1 hour.

## High fixes

- **Pod validation** in `install_single_wiki.yml` — fail with a clear error if no running web pod is found, instead of passing empty string to `kubectl exec`.
- **SecurityContext** on web deployment — drop all capabilities, disallow privilege escalation.
- **Probe timeouts** — added `timeoutSeconds: 5` to all web deployment probes (default of 1s may be too short for MediaWiki).
- **Domains validation** — deployment-web.yaml fails at render time if the domains list is empty.

## Medium fixes

- **ignore_errors comments** in restore.yml — explained why config/env copy failures are acceptable.

## Test plan

- [x] `make test-unit` — 328 passed
- [x] `make lint` — exit 0
- [x] `helm lint` — passes
- [ ] CI passes