### PR TITLE
Revert securityContext on web deployment — breaks Apache port binding

### DIFF
--- a/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
@@ -114,11 +114,6 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - ALL
           startupProbe:
             tcpSocket:
               port: http


### PR DESCRIPTION
The securityContext added in #88 dropped ALL capabilities and disallowed privilege escalation. Apache needs `CAP_NET_BIND_SERVICE` to bind to port 80, and the Canasta image starts as root before dropping privileges. The web pod failed to start on CI's k3s:

```
timed out waiting for the condition
Waiting for deployment ... rollout to finish: 0 of 1 updated replicas are available...
```

This reverts only the securityContext addition. All other #88 fixes (path quoting, path traversal validation, temp file cleanup, probe timeouts, domains validation, pod name validation) are unaffected and working correctly.