### PR TITLE
Add explanatory comments to all 102 ignore_errors: true statements

### DIFF
--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -14,7 +14,7 @@
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"
   register: _pre_check
-  ignore_errors: true
+  ignore_errors: true  # OK if instance doesn't exist yet
 
 - name: Fail early if instance already exists
   ansible.builtin.fail:
@@ -35,7 +35,7 @@
         - instance_path is defined
         - not (keep_config | default(false) | bool)
         - (orchestrator | default('compose')) == 'compose'
-      ignore_errors: true
+      ignore_errors: true  # Best-effort cleanup on failure
 
     - name: Clean up on failure (uninstall Helm release)
       ansible.builtin.command:
@@ -43,7 +43,7 @@
       when:
         - not (keep_config | default(false) | bool)
         - (orchestrator | default('compose')) in ['kubernetes', 'k8s']
-      ignore_errors: true
+      ignore_errors: true  # Best-effort cleanup on failure
 
     - name: Clean up on failure (delete K8s namespace)
       ansible.builtin.command:
@@ -51,7 +51,7 @@
       when:
         - not (keep_config | default(false) | bool)
         - (orchestrator | default('compose')) in ['kubernetes', 'k8s']
-      ignore_errors: true
+      ignore_errors: true  # Best-effort cleanup on failure
 
     - name: Clean up on failure (remove directory)
       ansible.builtin.file:
@@ -60,7 +60,7 @@
       when:
         - instance_path is defined
         - not (keep_config | default(false) | bool)
-      ignore_errors: true
+      ignore_errors: true  # Best-effort cleanup on failure
 
     - name: Deregister instance on failure
       canasta_registry:
@@ -70,7 +70,7 @@
       vars:
         ansible_connection: local
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
-      ignore_errors: true
+      ignore_errors: true  # OK if never registered
 
     - name: Report failure
       ansible.builtin.fail:

--- a/playbooks/doctor.yml
+++ b/playbooks/doctor.yml
@@ -12,28 +12,28 @@
     cmd: python3 --version
   register: _doc_python
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # Checking if installed
 
 - name: Check Docker
   ansible.builtin.command:
     cmd: docker --version
   register: _doc_docker
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # Checking if installed
 
 - name: Check Docker Compose
   ansible.builtin.command:
     cmd: docker compose version
   register: _doc_compose
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # Checking if installed
 
 - name: Check Docker daemon running
   ansible.builtin.command:
     cmd: docker info
   register: _doc_daemon
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # Checking if daemon running
 
 # --- Required for Kubernetes ---
 - name: Check kubectl
@@ -41,35 +41,35 @@
     cmd: kubectl version --client --output=yaml
   register: _doc_kubectl
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # Checking if installed
 
 - name: Check Helm
   ansible.builtin.command:
     cmd: helm version --short
   register: _doc_helm
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # Checking if installed
 
 - name: Check k3s
   ansible.builtin.command:
     cmd: k3s --version
   register: _doc_k3s
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # Checking if installed
 
 - name: Check Argo CD
   ansible.builtin.command:
     cmd: kubectl get deployment argocd-server -n argocd
   register: _doc_argocd
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # Checking if installed
 
 - name: Check cluster reachable
   ansible.builtin.command:
     cmd: kubectl cluster-info
   register: _doc_cluster
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # Checking if cluster reachable
 
 # --- Required for GitOps ---
 - name: Check git
@@ -77,14 +77,14 @@
     cmd: git --version
   register: _doc_git
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # Checking if installed
 
 - name: Check git-crypt
   ansible.builtin.command:
     cmd: git-crypt --version
   register: _doc_gitcrypt
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # Checking if installed
 
 # --- System resources ---
 - name: Check system memory
@@ -96,14 +96,14 @@
       print(str(mem) + ' GB')"
   register: _doc_memory
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if sysconf unavailable
 
 - name: Check disk space
   ansible.builtin.shell:
     cmd: "df -h / | awk 'NR==2{print $4}'"
   register: _doc_disk
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if df unavailable
 
 # --- Report ---
 - name: Display dependency report

--- a/playbooks/host_add.yml
+++ b/playbooks/host_add.yml
@@ -23,7 +23,7 @@
   ansible.builtin.slurp:
     src: "{{ _config_dir }}/hosts.yml"
   register: _existing_hosts
-  ignore_errors: true
+  ignore_errors: true  # OK if file doesn't exist yet
   delegate_to: localhost
   vars:
     ansible_connection: local

--- a/playbooks/host_list.yml
+++ b/playbooks/host_list.yml
@@ -8,7 +8,7 @@
   ansible.builtin.slurp:
     src: "{{ _config_dir }}/hosts.yml"
   register: _existing_hosts
-  ignore_errors: true
+  ignore_errors: true  # OK if file doesn't exist
   delegate_to: localhost
   vars:
     ansible_connection: local

--- a/playbooks/host_remove.yml
+++ b/playbooks/host_remove.yml
@@ -8,7 +8,7 @@
   ansible.builtin.slurp:
     src: "{{ _config_dir }}/hosts.yml"
   register: _existing_hosts
-  ignore_errors: true
+  ignore_errors: true  # OK if file doesn't exist
   delegate_to: localhost
   vars:
     ansible_connection: local

--- a/playbooks/list.yml
+++ b/playbooks/list.yml
@@ -59,7 +59,7 @@
       loop_control:
         label: "{{ item.key }}"
       changed_when: false
-      ignore_errors: true
+      ignore_errors: true  # OK if host unreachable or dir gone
 
     - name: Build directory existence map
       ansible.builtin.set_fact:
@@ -82,7 +82,7 @@
       loop_control:
         label: "{{ item.key }}"
       changed_when: false
-      ignore_errors: true
+      ignore_errors: true  # OK if wikis.yaml missing
       when: (_dir_exists | default({}))[item.key] | default(false)
 
     - name: Parse wikis from YAML output
@@ -114,7 +114,7 @@
       loop_control:
         label: "{{ item.key }}"
       changed_when: false
-      ignore_errors: true
+      ignore_errors: true  # OK if containers not running
       when:
         - item.value.orchestrator | default('compose') == 'compose'
         - (_dir_exists | default({}))[item.key] | default(false)
@@ -131,7 +131,7 @@
       loop_control:
         label: "{{ item.key }}"
       changed_when: false
-      ignore_errors: true
+      ignore_errors: true  # OK if cluster unreachable
       when: >-
         item.value.orchestrator | default('compose')
         in ['kubernetes', 'k8s']

--- a/playbooks/remove.yml
+++ b/playbooks/remove.yml
@@ -24,7 +24,7 @@
   vars:
     exec_service: web
     exec_command: "rm -rf /mediawiki/images/{{ wiki | quote }}"
-  ignore_errors: true
+  ignore_errors: true  # OK if images dir doesn't exist
 
 # Clean up public assets (sitemaps etc.)
 - name: Remove wiki public assets
@@ -32,7 +32,7 @@
   vars:
     exec_service: web
     exec_command: "rm -rf /mediawiki/public_assets/{{ wiki | quote }}"
-  ignore_errors: true
+  ignore_errors: true  # OK if assets dir doesn't exist
 
 - name: Remove wiki from wikis.yaml
   canasta_wikis_yaml:
@@ -47,7 +47,7 @@
     exec_command: >-
       mariadb -u root -p{{ _remove_dbpass.value | default('mediawiki') | quote }}
       -e 'DROP DATABASE IF EXISTS {{ wiki | quote }}'
-  ignore_errors: true
+  ignore_errors: true  # OK if database doesn't exist
 
 - name: Remove per-wiki settings directory
   ansible.builtin.file:

--- a/playbooks/version.yml
+++ b/playbooks/version.yml
@@ -45,7 +45,7 @@
     chdir: "{{ playbook_dir }}"
   register: _git_commit
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if not a git checkout
   when: not _build_commit_file.stat.exists
   delegate_to: localhost
   vars:
@@ -58,7 +58,7 @@
     chdir: "{{ playbook_dir }}"
   register: _git_date
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if not a git checkout
   when: not _build_commit_file.stat.exists
   delegate_to: localhost
   vars:

--- a/roles/backup/tasks/create.yml
+++ b/roles/backup/tasks/create.yml
@@ -107,4 +107,4 @@
   vars:
     exec_service: web
     exec_command: "rm -rf /mediawiki/config/backup"
-  ignore_errors: true
+  ignore_errors: true  # OK if backup dir doesn't exist

--- a/roles/backup/tasks/restore.yml
+++ b/roles/backup/tasks/restore.yml
@@ -129,7 +129,7 @@
           ls /currentsnapshot/config/backup/
       register: _restore_db_files
       changed_when: false
-      ignore_errors: true
+      ignore_errors: true  # OK if no DB dumps in snapshot
 
     - name: Import each DB dump
       when: _restore_db_files is succeeded and _restore_db_files.stdout | trim | length > 0
@@ -226,7 +226,7 @@
   vars:
     exec_service: web
     exec_command: "rm -rf /mediawiki/config/backup"
-  ignore_errors: true
+  ignore_errors: true  # OK if backup dir doesn't exist
   when: instance_orchestrator | default('compose') == 'compose'
 
 - name: Restart instance after restore

--- a/roles/backup/tasks/schedule_list.yml
+++ b/roles/backup/tasks/schedule_list.yml
@@ -15,7 +15,7 @@
         cmd: "crontab -l"
       register: _cron_list
       changed_when: false
-      ignore_errors: true
+      ignore_errors: true  # OK if no crontab exists
 
     - name: Filter backup schedule
       ansible.builtin.set_fact:

--- a/roles/backup/tasks/schedule_remove.yml
+++ b/roles/backup/tasks/schedule_remove.yml
@@ -16,7 +16,7 @@
     name: "canasta-backup-{{ instance_id }}"
     namespace: "canasta-{{ instance_id }}"
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
-  ignore_errors: true
+  ignore_errors: true  # OK if CronJob doesn't exist
 
 - name: Report schedule removed
   ansible.builtin.debug:

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -14,7 +14,7 @@
     cmd: docker info
   register: _docker_check
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if Docker not installed
   when: orchestrator | default('compose') == 'compose'
 
 - name: Fail if Docker not available
@@ -46,7 +46,7 @@
       exit(0 if mem_mib >= 3500 else 1)"
   register: _mem_check
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if memory check unavailable
   when: orchestrator | default('compose') == 'compose'
 
 - name: Fail if target host has less than 3500 MiB total memory
@@ -73,7 +73,7 @@
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"
   register: _existing
-  ignore_errors: true
+  ignore_errors: true  # OK if instance doesn't exist yet
 
 - name: Fail if instance already exists
   ansible.builtin.fail:

--- a/roles/delete/tasks/main.yml
+++ b/roles/delete/tasks/main.yml
@@ -21,7 +21,7 @@
         ansible_connection: local
         ansible_python_interpreter: "{{ ansible_playbook_python }}"
       register: _delete_pwd_query
-      ignore_errors: true
+      ignore_errors: true  # OK if instance not in registry
 
     - name: Fail if no instance found for current directory
       ansible.builtin.fail:
@@ -43,7 +43,7 @@
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"
   register: _delete_query
-  ignore_errors: true
+  ignore_errors: true  # OK if instance not in registry
 
 - name: Set instance facts from registry
   ansible.builtin.set_fact:
@@ -73,7 +73,7 @@
         cmd: "kubectl version --client"
       register: _kubectl_check
       changed_when: false
-      ignore_errors: true
+      ignore_errors: true  # OK if kubectl not installed
 
     - name: Fail if no kubectl (Compose instance not in registry)
       ansible.builtin.fail:
@@ -85,7 +85,7 @@
         cmd: "helm status canasta-{{ id }} -n canasta-{{ id }}"
       register: _helm_status
       changed_when: false
-      ignore_errors: true
+      ignore_errors: true  # OK if no Helm release exists
 
     - name: Check for Kubernetes namespace
       kubernetes.core.k8s_info:
@@ -93,7 +93,7 @@
         kind: Namespace
         name: "canasta-{{ id }}"
       register: _ns_check
-      ignore_errors: true
+      ignore_errors: true  # OK if namespace doesn't exist
 
     - name: Set Kubernetes facts for unregistered instance
       ansible.builtin.set_fact:
@@ -218,7 +218,7 @@
     chdir: "{{ instance_path }}"
   when: instance_orchestrator | default('compose') == 'compose'
   changed_when: true
-  ignore_errors: true
+  ignore_errors: true  # OK if containers already removed
 
 - name: Clean up container-owned files (Kubernetes)
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
@@ -227,14 +227,14 @@
       ansible.builtin.include_role:
         name: orchestrator
         tasks_from: check_running.yml
-      ignore_errors: true
+      ignore_errors: true  # OK if pods not running
 
     - name: Remove files inside K8s pod
       ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
       vars:
         exec_service: web
         exec_command: "find /mediawiki/images /mediawiki/config /mediawiki/public_assets -mindepth 1 -delete 2>/dev/null || true"
-      ignore_errors: true
+      ignore_errors: true  # OK if dirs already empty or missing
       when: _container_running | default(false) | bool
 
 # Remove backup schedule from crontab
@@ -242,7 +242,7 @@
   ansible.builtin.cron:
     name: "canasta-backup-{{ instance_id }}"
     state: absent
-  ignore_errors: true
+  ignore_errors: true  # OK if no crontab entry exists
 
 - name: Remove Argo CD Application if present
   kubernetes.core.k8s:
@@ -251,14 +251,14 @@
     kind: Application
     name: "canasta-{{ instance_id }}"
     namespace: "{{ argocd_namespace | default('argocd') }}"
-  ignore_errors: true
+  ignore_errors: true  # OK if Argo CD not installed
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
 
 - name: Destroy containers and volumes
   ansible.builtin.include_role:
     name: orchestrator
     tasks_from: destroy.yml
-  ignore_errors: true
+  ignore_errors: true  # OK if already destroyed
 
 - name: Remove instance directory contents
   ansible.builtin.command:
@@ -266,7 +266,7 @@
     chdir: "/"
   changed_when: true
   when: instance_path | default('') | length > 0
-  ignore_errors: true
+  ignore_errors: true  # OK if some files can't be removed
   register: _rmdir_contents
 
 - name: Remove empty instance directory
@@ -275,7 +275,7 @@
     chdir: "/"
   changed_when: true
   when: instance_path | default('') | length > 0
-  ignore_errors: true
+  ignore_errors: true  # OK if dir is cwd or already gone
   register: _rmdir
 
 - name: Warn if directory could not be removed

--- a/roles/devmode/tasks/enable.yml
+++ b/roles/devmode/tasks/enable.yml
@@ -74,7 +74,7 @@
       ansible.builtin.command:
         cmd: "docker start canasta-dev-extract && docker exec canasta-dev-extract /create-symlinks.sh"
       changed_when: true
-      ignore_errors: true
+      ignore_errors: true  # OK if script missing in image
 
     - name: Extract code from container
       ansible.builtin.shell:

--- a/roles/gitops/tasks/_convert_submodule.yml
+++ b/roles/gitops/tasks/_convert_submodule.yml
@@ -9,7 +9,7 @@
     chdir: "{{ _repo_path }}"
   register: _sub_url
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if not a git repo
 
 - name: Convert to submodule
   when: _sub_url.rc == 0 and _sub_url.stdout | trim | length > 0

--- a/roles/gitops/tasks/diff_compose.yml
+++ b/roles/gitops/tasks/diff_compose.yml
@@ -17,7 +17,7 @@
     chdir: "{{ instance_path }}"
   register: _gdiff_local
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if no upstream configured
 
 # Remote changes (on remote but not pulled)
 - name: Get remote changes
@@ -26,7 +26,7 @@
     chdir: "{{ instance_path }}"
   register: _gdiff_remote
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if no upstream configured
 
 # Submodule changes
 - name: Check submodule status
@@ -35,7 +35,7 @@
     chdir: "{{ instance_path }}"
   register: _gdiff_submodules
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if no submodules configured
 
 - name: Display diff
   ansible.builtin.debug:

--- a/roles/gitops/tasks/diff_kubernetes.yml
+++ b/roles/gitops/tasks/diff_kubernetes.yml
@@ -17,7 +17,7 @@
     chdir: "{{ instance_path }}"
   register: _kdiff_local
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if no upstream configured
 
 - name: Get remote unpulled changes
   ansible.builtin.command:
@@ -25,7 +25,7 @@
     chdir: "{{ instance_path }}"
   register: _kdiff_remote
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if no upstream configured
 
 # --- Argo CD live diff ---
 - name: Render Helm template to temp file
@@ -36,7 +36,7 @@
       -f {{ instance_path }}/values.yaml
   register: _kdiff_rendered
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if Helm chart not available
 
 - name: Write rendered manifest
   ansible.builtin.copy:
@@ -50,7 +50,7 @@
     cmd: "kubectl diff -n canasta-{{ instance_id }} -f /tmp/canasta-diff-{{ instance_id }}.yaml"
   register: _kdiff_cluster
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # rc=1 means there are differences
   when: _kdiff_rendered is succeeded
 
 - name: Clean up temp manifest

--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -42,7 +42,7 @@
     cmd: "git ls-remote {{ repo }}"
   register: _remote_check
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if remote unreachable
   when: not (force | default(false) | bool)
 
 - name: Fail if remote is not empty

--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -92,7 +92,7 @@
     GIT_SSH_COMMAND: "ssh -i {{ key }} -o StrictHostKeyChecking=no"
   register: _gitops_remote
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if remote unreachable
 
 - name: Fail if remote is not empty
   ansible.builtin.fail:

--- a/roles/gitops/tasks/push_compose.yml
+++ b/roles/gitops/tasks/push_compose.yml
@@ -14,7 +14,7 @@
     chdir: "{{ instance_path }}/config"
   register: _git_staged
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # rc=1 means there are changes
 
 - name: Commit changes
   ansible.builtin.command:

--- a/roles/gitops/tasks/push_kubernetes.yml
+++ b/roles/gitops/tasks/push_kubernetes.yml
@@ -38,7 +38,7 @@
     chdir: "{{ instance_path }}"
   register: _git_staged
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # rc=1 means there are changes
 
 - name: Commit and push
   when: _git_staged.rc != 0

--- a/roles/gitops/tasks/status_compose.yml
+++ b/roles/gitops/tasks/status_compose.yml
@@ -7,13 +7,13 @@
   ansible.builtin.slurp:
     src: "{{ instance_path }}/.gitops-host"
   register: _gops_host_file
-  ignore_errors: true
+  ignore_errors: true  # OK if file doesn't exist
 
 - name: Read hosts.yaml
   ansible.builtin.slurp:
     src: "{{ instance_path }}/hosts/hosts.yaml"
   register: _gops_hosts_yaml
-  ignore_errors: true
+  ignore_errors: true  # OK if file doesn't exist
 
 - name: Get current commit
   ansible.builtin.command:
@@ -21,7 +21,7 @@
     chdir: "{{ instance_path }}"
   register: _gops_commit
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if no commits yet
 
 - name: Get last applied commit
   ansible.builtin.command:
@@ -29,7 +29,7 @@
     chdir: "{{ instance_path }}"
   register: _gops_applied
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if file doesn't exist
 
 - name: Get staged files
   ansible.builtin.command:
@@ -51,7 +51,7 @@
     chdir: "{{ instance_path }}"
   register: _gops_revcount
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if no upstream configured
 
 - name: Parse host info
   ansible.builtin.set_fact:
@@ -68,7 +68,7 @@
           | b64decode
           | from_yaml).hosts[0].pull_requests
          | default(false) }}
-  ignore_errors: true
+  ignore_errors: true  # OK if YAML structure unexpected
 
 - name: Parse ahead/behind
   ansible.builtin.set_fact:

--- a/roles/gitops/tasks/status_kubernetes.yml
+++ b/roles/gitops/tasks/status_kubernetes.yml
@@ -8,7 +8,7 @@
   ansible.builtin.slurp:
     src: "{{ instance_path }}/.gitops-host"
   register: _gops_host_file
-  ignore_errors: true
+  ignore_errors: true  # OK if file doesn't exist
 
 - name: Get current commit
   ansible.builtin.command:
@@ -16,7 +16,7 @@
     chdir: "{{ instance_path }}"
   register: _gops_commit
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if no commits yet
 
 - name: Get ahead/behind counts
   ansible.builtin.command:
@@ -24,7 +24,7 @@
     chdir: "{{ instance_path }}"
   register: _gops_revcount
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if no upstream configured
 
 - name: Parse git info
   ansible.builtin.set_fact:
@@ -40,7 +40,7 @@
     name: "canasta-{{ instance_id }}"
     namespace: "{{ argocd_namespace | default('argocd') }}"
   register: _argocd_app
-  ignore_errors: true
+  ignore_errors: true  # OK if Argo CD not installed
 
 - name: Set Argo CD resource shorthand
   ansible.builtin.set_fact:

--- a/roles/maintenance/tasks/update.yml
+++ b/roles/maintenance/tasks/update.yml
@@ -63,7 +63,7 @@
       --wiki={{ item | quote }}
     _maint_label: "rebuildData.php ({{ item }})"
   loop: "{{ _update_wikis }}"
-  ignore_errors: true
+  ignore_errors: true  # OK if SMW rebuild fails for a wiki
 
 - name: Report complete
   ansible.builtin.debug:

--- a/roles/orchestrator/tasks/check_running.yml
+++ b/roles/orchestrator/tasks/check_running.yml
@@ -26,7 +26,7 @@
     chdir: "{{ _check_chdir | default(omit) }}"
   register: _ps_result
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if container/pod not running
 
 - name: Set running status
   ansible.builtin.set_fact:

--- a/roles/orchestrator/tasks/destroy.yml
+++ b/roles/orchestrator/tasks/destroy.yml
@@ -10,13 +10,13 @@
         cmd: "docker compose down -v"
         chdir: "{{ instance_path }}"
       changed_when: true
-      ignore_errors: true
+      ignore_errors: true  # OK if containers already removed
 
     - name: Remove backup staging volume
       ansible.builtin.command:
         cmd: "docker volume rm {{ instance_path | basename }}-backup"
       changed_when: true
-      ignore_errors: true
+      ignore_errors: true  # OK if volume doesn't exist
 
 - name: Destroy (Kubernetes)
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']

--- a/roles/orchestrator/tasks/helm_status.yml
+++ b/roles/orchestrator/tasks/helm_status.yml
@@ -8,7 +8,7 @@
     name: "canasta-{{ instance_id }}"
     release_namespace: "{{ _k8s_namespace }}"
   register: _helm_info
-  ignore_errors: true
+  ignore_errors: true  # OK if release not installed
 
 - name: Set release status facts
   ansible.builtin.set_fact:

--- a/roles/orchestrator/tasks/helm_uninstall.yml
+++ b/roles/orchestrator/tasks/helm_uninstall.yml
@@ -8,7 +8,7 @@
     release_namespace: "{{ _k8s_namespace }}"
     state: absent
     wait: true
-  ignore_errors: true
+  ignore_errors: true  # OK if release already uninstalled
 
 - name: Delete Ansible-managed resources
   kubernetes.core.k8s:
@@ -24,7 +24,7 @@
     - { kind: ConfigMap, name: "canasta-{{ instance_id }}-caddy-config" }
     - { kind: ConfigMap, name: "canasta-{{ instance_id }}-varnish-config" }
     - { kind: ConfigMap, name: "canasta-{{ instance_id }}-db-config" }
-  ignore_errors: true
+  ignore_errors: true  # OK if resources already deleted
 
 - name: Delete namespace
   kubernetes.core.k8s:

--- a/roles/orchestrator/tasks/k8s_argocd_bootstrap.yml
+++ b/roles/orchestrator/tasks/k8s_argocd_bootstrap.yml
@@ -8,7 +8,7 @@
     cmd: "kubectl get deployment argocd-server -n {{ argocd_namespace | default('argocd') }}"
   register: _argocd_check
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if Argo CD not installed yet
 
 - name: Install Argo CD
   when: _argocd_check.rc != 0

--- a/roles/orchestrator/tasks/k8s_certmanager.yml
+++ b/roles/orchestrator/tasks/k8s_certmanager.yml
@@ -10,7 +10,7 @@
     name: cert-manager
     namespace: cert-manager
   register: _cm_check
-  ignore_errors: true
+  ignore_errors: true  # OK if cert-manager not installed
 
 - name: Install cert-manager
   when: _cm_check.resources | default([]) | length == 0
@@ -46,7 +46,7 @@
     kind: ClusterIssuer
     name: letsencrypt-prod
   register: _issuer_check
-  ignore_errors: true
+  ignore_errors: true  # OK if CRD not registered yet
 
 - name: Create Let's Encrypt ClusterIssuer
   kubernetes.core.k8s:

--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -8,7 +8,7 @@
     cmd: k3s kubectl cluster-info
   register: _k3s_running
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if k3s not installed yet
 
 - name: Install k3s
   when: _k3s_running.rc != 0

--- a/roles/orchestrator/tasks/k8s_kind_delete.yml
+++ b/roles/orchestrator/tasks/k8s_kind_delete.yml
@@ -10,4 +10,4 @@
   ansible.builtin.command:
     cmd: "kind delete cluster --name {{ _kind_cluster_name }}"
   changed_when: true
-  ignore_errors: true
+  ignore_errors: true  # OK if cluster already deleted

--- a/roles/orchestrator/tasks/k8s_preflight.yml
+++ b/roles/orchestrator/tasks/k8s_preflight.yml
@@ -6,7 +6,7 @@
     cmd: kubectl version --client --output=json
   register: _kubectl_check
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if kubectl not installed
 
 - name: Fail if kubectl not available
   ansible.builtin.fail:
@@ -24,7 +24,7 @@
     cmd: kubectl cluster-info
   register: _cluster_check
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if no cluster yet
   when: not (install_k3s | default(false) | bool)
 
 - name: Fail if cluster not reachable
@@ -41,7 +41,7 @@
     cmd: helm version --short
   register: _helm_check
   changed_when: false
-  ignore_errors: true
+  ignore_errors: true  # OK if Helm not installed
 
 - name: Fail if helm not available
   ansible.builtin.fail:
@@ -114,7 +114,7 @@
         MIN_STORAGE_GI: "{{ _min_storage_gi }}"
       register: _resource_check
       changed_when: false
-      ignore_errors: true
+      ignore_errors: true  # OK if nodes lack resources
 
     - name: Fail if no node has sufficient resources
       ansible.builtin.fail:

--- a/roles/orchestrator/tasks/k8s_run_backup.yml
+++ b/roles/orchestrator/tasks/k8s_run_backup.yml
@@ -153,4 +153,4 @@
     kind: Job
     name: "{{ _backup_job_name }}"
     namespace: "{{ _k8s_namespace }}"
-  ignore_errors: true
+  ignore_errors: true  # OK if job already cleaned up by TTL

--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -45,7 +45,7 @@
           -o jsonpath={.spec.replicas}
       register: _current_replicas
       changed_when: false
-      ignore_errors: true
+      ignore_errors: true  # OK if deployment doesn't exist yet
 
     - name: Apply values and upgrade Helm release
       ansible.builtin.include_tasks: helm_deploy.yml
@@ -84,7 +84,7 @@
               --replicas=1
               -n {{ _k8s_namespace }}
           changed_when: true
-          ignore_errors: true
+          ignore_errors: true  # OK if some deployments don't exist
 
     - name: Wait for DB readiness
       ansible.builtin.command:
@@ -112,7 +112,7 @@
           -o jsonpath={.metadata.name}
       register: _start_argocd_app
       changed_when: false
-      ignore_errors: true
+      ignore_errors: true  # OK if no Argo CD app exists
 
     - name: Re-enable Argo CD auto-sync
       when: _start_argocd_app.rc == 0

--- a/roles/orchestrator/tasks/stop.yml
+++ b/roles/orchestrator/tasks/stop.yml
@@ -41,7 +41,7 @@
           -o jsonpath={.metadata.name}
       register: _stop_argocd_app
       changed_when: false
-      ignore_errors: true
+      ignore_errors: true  # OK if no Argo CD app exists
 
     - name: Suspend Argo CD auto-sync
       ansible.builtin.command:

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -154,7 +154,7 @@
       vars:
         exec_service: web
         exec_command: "touch /var/www/mediawiki/w/LocalSettings.php"
-      ignore_errors: true
+      ignore_errors: true  # OK if container not ready yet
 
     - name: Report instance upgraded
       ansible.builtin.debug:

--- a/roles/upgrade/tasks/migrations/fix_vector_default_skin.yml
+++ b/roles/upgrade/tasks/migrations/fix_vector_default_skin.yml
@@ -14,7 +14,7 @@
         cmd: "grep -c 'wgDefaultSkin' {{ instance_path }}/config/settings/global/Vector.php"
       register: _has_default_skin
       changed_when: false
-      ignore_errors: true
+      ignore_errors: true  # OK if grep finds no matches
 
     - name: Append wgDefaultSkin line
       ansible.builtin.lineinfile:

--- a/roles/upgrade/tasks/migrations/migrate_directory_structure.yml
+++ b/roles/upgrade/tasks/migrations/migrate_directory_structure.yml
@@ -31,7 +31,7 @@
         label: "{{ item.path | basename }}"
       when: item.path | basename not in ['settings', 'logstash', 'backup']
       changed_when: true
-      ignore_errors: true
+      ignore_errors: true  # OK if dir already moved
 
 - name: Check for PHP files in config/settings/ (not in global/)
   ansible.builtin.find:

--- a/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
+++ b/roles/upgrade/tasks/migrations/mysql_to_mariadb.yml
@@ -18,7 +18,7 @@
         exec_service: db
         exec_command: "test -f /var/lib/mysql/.rocksdb && echo mysql8 || echo mariadb"
       register: _mysql_check
-      ignore_errors: true
+      ignore_errors: true  # OK if db container not running
 
     - name: Set MySQL 8 detection flag
       ansible.builtin.set_fact:
@@ -69,7 +69,7 @@
             cmd: "docker volume rm {{ instance_path | basename }}_mysql-data-volume"
             chdir: "{{ instance_path }}"
           changed_when: true
-          ignore_errors: true
+          ignore_errors: true  # OK if volume already removed
 
         - name: Start new MariaDB containers
           ansible.builtin.include_role:

--- a/roles/upgrade/tasks/migrations/remove_empty_composer_local.yml
+++ b/roles/upgrade/tasks/migrations/remove_empty_composer_local.yml
@@ -27,4 +27,4 @@
         _composer_data.extra['merge-plugin'] is defined and
         _composer_data.extra['merge-plugin'].include is defined and
         _composer_data.extra['merge-plugin'].include | length == 0
-  ignore_errors: true
+  ignore_errors: true  # OK if JSON structure unexpected


### PR DESCRIPTION
Every `ignore_errors: true` in the codebase now has an inline comment explaining why the error is acceptable. 42 files changed, comment-only — no logic changes.

Common patterns:
- Preflight checks: `OK if not installed yet`
- Optional file reads: `OK if file doesn't exist`
- Cleanup/delete: `OK if already removed`
- K8s resources: `OK if no Argo CD app exists`
- Git diff --quiet: `rc=1 means there are changes`
- Doctor checks: `Checking if installed`

## Test plan
- [x] `make test-unit` — 328 passed
- [x] `make lint` — exit 0
- [x] Zero uncommented `ignore_errors: true` remaining
- [ ] CI passes