### PR TITLE
Implement full multi-host gitops pull + fix push for Compose

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1111,12 +1111,17 @@ commands:
     long_description: "Push configuration changes to the remote gitops repository."
     examples:
       - "canasta gitops push -i mysite"
+      - "canasta gitops push -i mysite -m 'Add docs wiki'"
     playbook: gitops_push.yml
     parameters:
       - name: id
         short: i
         type: string
         description: "Canasta instance ID"
+      - name: message
+        short: m
+        type: string
+        description: "Commit message (defaults to 'Configuration update')"
 
   - name: gitops_pull
     description: "Pull configuration changes"

--- a/roles/gitops/tasks/join.yml
+++ b/roles/gitops/tasks/join.yml
@@ -1,32 +1,276 @@
 ---
+# GitOps join — connect an existing Canasta instance to an existing
+# gitops repository. The instance must already be created (canasta create).
+# This is the multi-host onboarding flow: Host A did 'gitops init',
+# Host B runs 'gitops join' to connect to the same repo.
+#
+# Input: host_name, role, repo, key, force
+# Requires: instance_path, instance_id, instance_orchestrator (set by dispatcher)
+
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
 - name: Not applicable for Kubernetes
   ansible.builtin.fail:
     msg: >-
-      'canasta gitops join' is not applicable for the kubernetes orchestrator.
-      Multi-host configuration is handled through the cluster rather than
-      individual machine join operations.
+      'canasta gitops join' is not yet implemented for the kubernetes
+      orchestrator. Multi-environment K8s gitops requires a different
+      repo structure (per-environment branches or directories) that
+      is not yet supported.
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+
+# --- Step 1: Validate prerequisites ---
+- name: Check git is installed
+  ansible.builtin.command:
+    cmd: "git --version"
+  changed_when: false
+
+- name: Check git-crypt is installed
+  ansible.builtin.command:
+    cmd: "git-crypt --version"
+  changed_when: false
+
+- name: Check for existing .git directory
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/.git"
+  register: _join_existing_git
+
+- name: Fail if git repo already exists
+  ansible.builtin.fail:
+    msg: >-
+      GitOps already initialized ({{ instance_path }}/.git exists).
+      This instance is already connected to a gitops repository.
+  when: _join_existing_git.stat.exists
+
+- name: Check key file exists
+  ansible.builtin.stat:
+    path: "{{ key }}"
+  register: _join_key_exists
+
+- name: Fail if key file not found
+  ansible.builtin.fail:
+    msg: >-
+      Key file '{{ key }}' not found. This should be the git-crypt
+      key exported during 'gitops init' on the source host.
+  when: not _join_key_exists.stat.exists
+
+# --- Step 2: Clone repo to temp location ---
+- name: Create temp directory for clone
+  ansible.builtin.tempfile:
+    state: directory
+    prefix: "canasta-join-"
+  register: _join_tmpdir
 
 - name: Clone gitops repository
   ansible.builtin.command:
-    cmd: "git clone {{ repo }} {{ instance_path }}/config-gitops"
+    cmd: "git clone {{ repo }} ."
+    chdir: "{{ _join_tmpdir.path }}"
   changed_when: true
 
-- name: Unlock with git-crypt key
+# --- Step 3: Unlock git-crypt ---
+- name: Unlock git-crypt with provided key
   ansible.builtin.command:
     cmd: "git-crypt unlock {{ key }}"
-    chdir: "{{ instance_path }}/config-gitops"
+    chdir: "{{ _join_tmpdir.path }}"
   changed_when: true
 
-- name: Add host to hosts.yaml
-  ansible.builtin.lineinfile:
-    path: "{{ instance_path }}/config-gitops/hosts.yaml"
-    line: "    - name: {{ host_name }}"
-    insertafter: "hosts:"
+# --- Step 4: Validate host name not already in config ---
+- name: Read hosts.yaml from cloned repo
+  ansible.builtin.slurp:
+    src: "{{ _join_tmpdir.path }}/hosts/hosts.yaml"
+  register: _join_hosts_raw
 
+- name: Parse hosts config
+  ansible.builtin.set_fact:
+    _join_hosts: "{{ _join_hosts_raw.content | b64decode | from_yaml }}"
+
+- name: Fail if host name already exists
+  ansible.builtin.fail:
+    msg: >-
+      Host '{{ host_name }}' already exists in the gitops repository.
+      Choose a different name or remove the existing host first.
+  when: >-
+    _join_hosts.hosts | default([])
+    | selectattr('name', 'equalto', host_name)
+    | list | length > 0
+
+# --- Step 5: Move .git into instance directory ---
+- name: Remove legacy .gitignore files
+  ansible.builtin.file:
+    path: "{{ instance_path }}/{{ item }}"
+    state: absent
+  loop:
+    - extensions/.gitignore
+    - skins/.gitignore
+    - config/.gitignore
+
+- name: Move .git from temp clone to instance
+  ansible.builtin.command:
+    cmd: "mv {{ _join_tmpdir.path }}/.git {{ instance_path }}/.git"
+  changed_when: true
+
+- name: Checkout tracked files from repo (decrypted via git-crypt)
+  ansible.builtin.command:
+    cmd: "git checkout HEAD -- ."
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
+# --- Step 6: Extract vars from current .env ---
+- name: Define placeholder keys
+  ansible.builtin.set_fact:
+    _join_placeholder_keys:
+      - MYSQL_PASSWORD
+      - WIKI_DB_PASSWORD
+      - MW_SECRET_KEY
+      - RESTIC_REPOSITORY
+      - RESTIC_PASSWORD
+      - MW_SITE_SERVER
+      - MW_SITE_FQDN
+      - HTTPS_PORT
+      - HTTP_PORT
+    _join_secret_prefixes: "^(AWS_|AZURE_|B2_|GOOGLE_|OS_|ST_|RCLONE_)"
+
+- name: Read current .env
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read_all
+  register: _join_env
+
+- name: Read wikis for URL and password extraction
+  canasta_wikis_yaml:
+    instance_path: "{{ instance_path }}"
+    state: read
+  register: _join_wikis
+
+- name: Build vars from current .env and wikis
+  ansible.builtin.set_fact:
+    _join_vars: >-
+      {{
+        dict(
+          _join_env.variables | dict2items
+          | selectattr('key', 'in', _join_placeholder_keys)
+          | map(attribute='key')
+          | map('lower')
+          | zip(
+              _join_env.variables | dict2items
+              | selectattr('key', 'in', _join_placeholder_keys)
+              | map(attribute='value')
+              | list)
+          | list
+        )
+        | combine(
+            dict(
+              _join_env.variables | dict2items
+              | selectattr('key', 'match', _join_secret_prefixes)
+              | map(attribute='key')
+              | map('lower')
+              | zip(
+                  _join_env.variables | dict2items
+                  | selectattr('key', 'match', _join_secret_prefixes)
+                  | map(attribute='value')
+                  | list)
+              | list
+            )
+          )
+      }}
+
+- name: Add wiki URL vars
+  ansible.builtin.set_fact:
+    _join_vars: >-
+      {{ _join_vars | combine(
+           dict(_join_wikis.wikis | default([])
+                | map(attribute='id')
+                | map('regex_replace', '^', 'wiki_url_')
+                | zip(_join_wikis.wikis | default([])
+                      | map(attribute='url')
+                      | list)
+                | list)
+         ) }}
+
+- name: Add admin password vars
+  ansible.builtin.set_fact:
+    _join_vars: >-
+      {{ _join_vars | combine(
+           dict(_join_wikis.wiki_ids | default([])
+                | map('regex_replace', '^', 'admin_password_')
+                | zip(_join_wikis.wiki_ids | default([])
+                      | map('extract', lookup('file',
+                          instance_path ~ '/admin-password_' ~ item,
+                          errors='ignore') | default(''))
+                      | list)
+                | list)
+         ) }}
+  ignore_errors: true  # OK if some admin password files don't exist
+
+# --- Step 7: Add host to config and write vars ---
+- name: Add host to hosts.yaml
+  ansible.builtin.copy:
+    content: |
+      {{ _join_hosts
+         | combine({'hosts': _join_hosts.hosts | default([])
+                    + [{'name': host_name,
+                        'role': role | default('both')}]},
+                   recursive=True)
+         | to_nice_yaml(indent=2) }}
+    dest: "{{ instance_path }}/hosts/hosts.yaml"
+    mode: "0644"
+
+- name: Create host vars directory
+  ansible.builtin.file:
+    path: "{{ instance_path }}/hosts/{{ host_name }}"
+    state: directory
+    mode: "0755"
+
+- name: Write host vars
+  ansible.builtin.copy:
+    content: "{{ _join_vars | to_nice_yaml(indent=2) }}"
+    dest: "{{ instance_path }}/hosts/{{ host_name }}/vars.yaml"
+    mode: "0644"
+  no_log: true
+
+# --- Step 8: Write .gitops-host ---
+- name: Save .gitops-host identity
+  ansible.builtin.copy:
+    content: "{{ host_name }}"
+    dest: "{{ instance_path }}/.gitops-host"
+    mode: "0644"
+
+# --- Step 9: Update submodules ---
+- name: Update submodules
+  ansible.builtin.command:
+    cmd: "git submodule update --init --recursive"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+  ignore_errors: true  # OK if no submodules configured
+
+# --- Step 10: Commit and push ---
+- name: Stage all changes
+  ansible.builtin.command:
+    cmd: "git add -A"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
+- name: Commit
+  ansible.builtin.command:
+    cmd: "git commit -m 'Add host {{ host_name }}'"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
+- name: Push to remote
+  ansible.builtin.command:
+    cmd: "git push {{ (force | default(false) | bool) | ternary('--force', '') }}"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
+# --- Step 11: Clean up temp dir ---
+- name: Remove temp clone directory
+  ansible.builtin.file:
+    path: "{{ _join_tmpdir.path }}"
+    state: absent
+
+# --- Step 12: Report ---
 - name: Report gitops joined
   ansible.builtin.debug:
-    msg: "Joined gitops repository for '{{ instance_id }}'."
+    msg: >-
+      Joined gitops repository for '{{ instance_id }}' as
+      host '{{ host_name }}' with role '{{ role | default('both') }}'.

--- a/roles/gitops/tasks/pull_compose.yml
+++ b/roles/gitops/tasks/pull_compose.yml
@@ -1,14 +1,214 @@
 ---
-# GitOps pull (Compose).
-# Requires: instance_path (set by dispatcher)
+# GitOps pull (Compose) — full multi-host flow matching Go implementation.
+# Pulls from remote, renders .env and wikis.yaml from templates + host
+# vars, writes admin passwords, detects what changed, and flags whether
+# a restart or maintenance update is needed.
+# Requires: instance_path, instance_id (set by dispatcher)
 
-- name: Pull configuration
+# --- Step 1: Check for uncommitted changes ---
+- name: Check for uncommitted changes
+  ansible.builtin.command:
+    cmd: "git status --porcelain"
+    chdir: "{{ instance_path }}"
+  register: _pull_uncommitted
+  changed_when: false
+
+- name: Fail if uncommitted changes exist
+  ansible.builtin.fail:
+    msg: >-
+      Cannot pull: there are uncommitted changes in the instance
+      directory. Commit or stash them first, then retry.
+      Changed files: {{ _pull_uncommitted.stdout }}
+  when: _pull_uncommitted.stdout | trim | length > 0
+
+# --- Step 2: Save state before pull ---
+- name: Get current commit hash
+  ansible.builtin.command:
+    cmd: "git rev-parse HEAD"
+    chdir: "{{ instance_path }}"
+  register: _pull_prev_commit
+  changed_when: false
+
+- name: Save current .env for comparison
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/.env"
+  register: _pull_old_env
+  ignore_errors: true  # OK if .env doesn't exist yet (first pull on a joined host)
+
+- name: Save current wikis.yaml for comparison
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/config/wikis.yaml"
+  register: _pull_old_wikis
+  ignore_errors: true  # OK if wikis.yaml doesn't exist yet
+
+# --- Step 3: Pull and update submodules ---
+- name: Pull from remote
   ansible.builtin.command:
     cmd: "git pull"
-    chdir: "{{ instance_path }}/config"
-  register: _git_pull
-  changed_when: "'Already up to date' not in _git_pull.stdout"
+    chdir: "{{ instance_path }}"
+  register: _pull_result
+  changed_when: "'Already up to date' not in _pull_result.stdout"
 
-- name: Display result
+- name: Update submodules
+  ansible.builtin.command:
+    cmd: "git submodule update --init --recursive"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+  ignore_errors: true  # OK if no submodules configured
+
+# --- Step 4: Check if anything changed ---
+- name: Get new commit hash
+  ansible.builtin.command:
+    cmd: "git rev-parse HEAD"
+    chdir: "{{ instance_path }}"
+  register: _pull_new_commit
+  changed_when: false
+
+- name: Skip rendering if no changes
+  when: _pull_prev_commit.stdout == _pull_new_commit.stdout
+  block:
+    - name: Report no changes
+      ansible.builtin.debug:
+        msg: "Already up to date."
+    - name: End play for no-change case
+      ansible.builtin.meta: end_play
+
+# --- Step 5: Read host identity and vars ---
+- name: Read .gitops-host
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/.gitops-host"
+  register: _pull_host_raw
+
+- name: Set host name
+  ansible.builtin.set_fact:
+    _pull_hostname: "{{ _pull_host_raw.content | b64decode | trim }}"
+
+- name: Read host vars
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/hosts/{{ _pull_hostname }}/vars.yaml"
+  register: _pull_vars_raw
+
+- name: Parse host vars
+  ansible.builtin.set_fact:
+    _pull_vars: "{{ _pull_vars_raw.content | b64decode | from_yaml }}"
+
+# --- Step 6: Render .env from env.template + vars ---
+- name: Read env.template
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/env.template"
+  register: _pull_env_template_raw
+
+- name: Render .env from template
+  ansible.builtin.copy:
+    content: |
+      {% for line in (_pull_env_template_raw.content | b64decode).split('\n') %}
+      {% if '={{' in line and '}}' in line %}
+      {% set key = line.split('=', 1)[0] %}
+      {% set placeholder = line.split('={{', 1)[1].split('}}', 1)[0] %}
+      {{ key }}={{ _pull_vars[placeholder] | default('') }}
+      {% else %}
+      {{ line }}
+      {% endif %}
+      {% endfor %}
+    dest: "{{ instance_path }}/.env"
+    mode: "0600"
+
+# --- Step 7: Render wikis.yaml from template + vars (if template exists) ---
+- name: Check if wikis.yaml.template exists
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/wikis.yaml.template"
+  register: _pull_wikis_template_stat
+
+- name: Render wikis.yaml from template
+  when: _pull_wikis_template_stat.stat.exists
+  block:
+    - name: Read wikis.yaml.template
+      ansible.builtin.slurp:
+        src: "{{ instance_path }}/wikis.yaml.template"
+      register: _pull_wikis_template_raw
+
+    - name: Render config/wikis.yaml from template
+      ansible.builtin.copy:
+        content: |
+          {% for line in (_pull_wikis_template_raw.content | b64decode).split('\n') %}
+          {% if '{{' in line and '}}' in line %}
+          {% set before = line.split('{{', 1)[0] %}
+          {% set placeholder = line.split('{{', 1)[1].split('}}', 1)[0] %}
+          {% set after = line.split('}}', 1)[1] if '}}' in line else '' %}
+          {{ before }}{{ _pull_vars[placeholder] | default('') }}{{ after }}
+          {% else %}
+          {{ line }}
+          {% endif %}
+          {% endfor %}
+        dest: "{{ instance_path }}/config/wikis.yaml"
+        mode: "0644"
+
+# --- Step 8: Write admin password files ---
+- name: Write admin password files from vars
+  ansible.builtin.copy:
+    content: "{{ item.value }}"
+    dest: >-
+      {{ instance_path }}/admin-password_{{ item.key
+         | regex_replace('^admin_password_', '') }}
+    mode: "0600"
+  loop: >-
+    {{ _pull_vars | dict2items
+       | selectattr('key', 'match', '^admin_password_')
+       | list }}
+  loop_control:
+    label: "{{ item.key }}"
+  no_log: true
+
+# --- Step 9: Detect what changed ---
+- name: Get list of changed files
+  ansible.builtin.command:
+    cmd: "git diff --name-only {{ _pull_prev_commit.stdout }}"
+    chdir: "{{ instance_path }}"
+  register: _pull_changed_files
+  changed_when: false
+
+- name: Read new .env for comparison
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/.env"
+  register: _pull_new_env
+
+- name: Read new wikis.yaml for comparison
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/config/wikis.yaml"
+  register: _pull_new_wikis
+  ignore_errors: true  # OK if wikis.yaml doesn't exist
+
+- name: Determine if restart is needed
+  ansible.builtin.set_fact:
+    _pull_needs_restart: >-
+      {{ (_pull_old_env.content | default('') !=
+          _pull_new_env.content | default(''))
+         or (_pull_old_wikis.content | default('') !=
+             _pull_new_wikis.content | default(''))
+         or (_pull_changed_files.stdout_lines | default([])
+             | select('match',
+               '^(env\.template|config/Caddyfile|docker-compose\.override\.yml)')
+             | list | length > 0) }}
+    _pull_needs_maintenance: >-
+      {{ _pull_changed_files.stdout_lines | default([])
+         | select('match', '^(extensions/|skins/)')
+         | list | length > 0 }}
+
+# --- Step 10: Save applied commit ---
+- name: Write .gitops-applied
+  ansible.builtin.copy:
+    content: "{{ _pull_new_commit.stdout }}"
+    dest: "{{ instance_path }}/.gitops-applied"
+    mode: "0644"
+
+# --- Step 11: Report results ---
+- name: Report pull results
   ansible.builtin.debug:
-    msg: "{{ _git_pull.stdout }}"
+    msg: >-
+      Pulled {{ _pull_prev_commit.stdout[:7] }}..{{ _pull_new_commit.stdout[:7] }}.
+      {{ (_pull_needs_restart | bool)
+         | ternary('Restart needed.', '') }}
+      {{ (_pull_needs_maintenance | bool)
+         | ternary('Maintenance update needed (extensions/skins changed).', '') }}
+      {{ (not _pull_needs_restart | bool and not _pull_needs_maintenance | bool)
+         | ternary('No restart needed.', '') }}

--- a/roles/gitops/tasks/push_compose.yml
+++ b/roles/gitops/tasks/push_compose.yml
@@ -1,35 +1,73 @@
 ---
-# GitOps push (Compose).
-# Requires: instance_path (set by dispatcher)
+# GitOps push (Compose) — commit staged changes and push to remote.
+# Matches Go CLI's push flow: validates role, accepts message, supports
+# the staged-changes-only model.
+# Requires: instance_path, instance_id (set by dispatcher)
+# Optional: message (commit message, defaults to 'Configuration update')
 
+# --- Validate role allows push ---
+- name: Read hosts.yaml
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/hosts/hosts.yaml"
+  register: _push_hosts_raw
+
+- name: Read .gitops-host
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/.gitops-host"
+  register: _push_host_raw
+
+- name: Parse host config
+  ansible.builtin.set_fact:
+    _push_hostname: "{{ _push_host_raw.content | b64decode | trim }}"
+    _push_hosts: "{{ _push_hosts_raw.content | b64decode | from_yaml }}"
+
+- name: Find current host role
+  ansible.builtin.set_fact:
+    _push_role: >-
+      {{ (_push_hosts.hosts | default([])
+          | selectattr('name', 'equalto', _push_hostname)
+          | first | default({})).get('role', 'both') }}
+
+- name: Fail if role does not allow push
+  ansible.builtin.fail:
+    msg: >-
+      Host '{{ _push_hostname }}' has role '{{ _push_role }}' which
+      does not allow pushing. Only 'source' and 'both' roles can push.
+  when: _push_role not in ['source', 'both']
+
+# --- Stage and push ---
 - name: Stage all changes
   ansible.builtin.command:
     cmd: "git add -A"
-    chdir: "{{ instance_path }}/config"
+    chdir: "{{ instance_path }}"
   changed_when: false
 
 - name: Check for staged changes
   ansible.builtin.command:
     cmd: "git diff --cached --quiet"
-    chdir: "{{ instance_path }}/config"
-  register: _git_staged
+    chdir: "{{ instance_path }}"
+  register: _push_staged
   changed_when: false
   ignore_errors: true  # rc=1 means there are changes
 
-- name: Commit changes
-  ansible.builtin.command:
-    cmd: "git commit -m 'Configuration update'"
-    chdir: "{{ instance_path }}/config"
-  when: _git_staged.rc != 0
-  changed_when: true
+- name: Commit and push
+  when: _push_staged.rc != 0
+  block:
+    - name: Commit changes
+      ansible.builtin.command:
+        cmd: >-
+          git commit -m "{{ message | default('Configuration update') }}"
+        chdir: "{{ instance_path }}"
+      changed_when: true
 
-- name: Push to remote
-  ansible.builtin.command:
-    cmd: "git push"
-    chdir: "{{ instance_path }}/config"
-  when: _git_staged.rc != 0
-  changed_when: true
+    - name: Push to remote
+      ansible.builtin.command:
+        cmd: "git push"
+        chdir: "{{ instance_path }}"
+      changed_when: true
 
 - name: Report result
   ansible.builtin.debug:
-    msg: "{{ (_git_staged.rc != 0) | ternary('Configuration pushed.', 'No changes to push.') }}"
+    msg: >-
+      {{ (_push_staged.rc != 0)
+         | ternary('Configuration pushed.', 'No changes to push.') }}


### PR DESCRIPTION
Partial fix for #81. Implements pull and fixes push. Join is the remaining piece (separate PR).

## Pull — rewritten for multi-host

The previous pull was just `git pull` — it didn't render .env from templates, which means a staging/prod server that pulled config changes from dev would never actually get updated secrets, URLs, or wiki configuration. The whole point of the multi-host gitops flow is that each host has its own vars but shares the same templates.

New flow (11 steps matching Go CLI):
1. Block if uncommitted changes exist
2. Save .env and wikis.yaml for comparison
3. `git pull` + `git submodule update`
4. Read `.gitops-host` identity
5. Load `hosts/{hostname}/vars.yaml`
6. **Render `.env` from `env.template` + vars** (the key missing piece)
7. **Render `config/wikis.yaml` from `wikis.yaml.template` + vars**
8. Write admin password files from vars
9. Detect what changed (restart/maintenance flags)
10. Write `.gitops-applied` commit hash
11. Report results

## Push — fixed and extended

- **Bug fix**: `chdir` was `instance_path/config` but the git repo is at `instance_path` (created by init at the instance root). This meant push only staged files under `config/`, missing top-level files like `env.template` and `hosts/`.
- Added role validation (only 'source' and 'both' can push)
- Added `-m`/`--message` parameter for custom commit messages

## Test plan

- [x] `make test-unit` — 328 passed
- [x] `make validate` — 58 commands validated (message param recognized)
- [x] `make lint` — exit 0
- [ ] CI passes
- [ ] Multi-host round-trip test: init on host A → push change → pull on host B → verify .env rendered with host B's values