### PR TITLE
Ensure config directory is writable before rendering wikis.yaml on pull

### DIFF
--- a/roles/gitops/tasks/pull_compose.yml
+++ b/roles/gitops/tasks/pull_compose.yml
@@ -122,6 +122,12 @@
 - name: Render wikis.yaml from template
   when: _pull_wikis_template_stat.stat.exists
   block:
+    - name: Ensure config directory exists and is writable
+      ansible.builtin.file:
+        path: "{{ instance_path }}/config"
+        state: directory
+        mode: "0755"
+
     - name: Read wikis.yaml.template
       ansible.builtin.slurp:
         src: "{{ instance_path }}/wikis.yaml.template"


### PR DESCRIPTION
The gitops pull-diff integration test failed with:

```
Destination .../config not writable
```

pull_compose.yml renders `config/wikis.yaml` from the template, but the `config/` directory may not be writable after `git pull` brings in tracked files. Fix: ensure the directory exists with mode 0755 before writing.

One file, 6 lines added.