### PR TITLE
Fix www-data group permission issue in gitops pull + CI + doctor

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,7 +129,7 @@ jobs:
 
   integration-gitops:
     name: "Integration: GitOps"
-    if: github.event_name != 'pull_request'  # See #67
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -140,6 +140,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install -y git-crypt
+          sudo groupadd -f www-data
+          sudo usermod -aG www-data $(whoami)
           python -m venv .venv
           .venv/bin/pip install -r requirements.txt
           .venv/bin/pip install kubernetes
@@ -148,8 +150,8 @@ jobs:
           git config --global user.email "ci@canasta.wiki"
       - name: Run gitops tests
         run: >-
-          .venv/bin/python tests/integration/run_tests.py
-          gitops gitops-pull-diff
+          sg www-data -c '.venv/bin/python tests/integration/run_tests.py
+          gitops gitops-pull-diff'
         timeout-minutes: 15
 
   integration-k8s:

--- a/playbooks/doctor.yml
+++ b/playbooks/doctor.yml
@@ -35,6 +35,12 @@
   changed_when: false
   ignore_errors: true  # Checking if daemon running
 
+- name: Check www-data group membership
+  ansible.builtin.command:
+    cmd: id -nG
+  register: _doc_groups
+  changed_when: false
+
 # --- Required for Kubernetes ---
 - name: Check kubectl
   ansible.builtin.command:
@@ -132,6 +138,7 @@
       System:
         Memory:          {{ _doc_memory.stdout | default('unknown') | trim }}
         Disk (/ avail):  {{ _doc_disk.stdout | default('unknown') | trim }}
+        www-data group:  {{ ('www-data' in (_doc_groups.stdout | default('')).split()) | ternary('OK (member)', 'NOT A MEMBER — Canasta containers write files as www-data; add yourself with: sudo usermod -aG www-data ' + ansible_user | default('$USER')) }}
 
 - name: Fail if core dependencies missing
   ansible.builtin.fail:

--- a/roles/gitops/tasks/pull_compose.yml
+++ b/roles/gitops/tasks/pull_compose.yml
@@ -122,12 +122,6 @@
 - name: Render wikis.yaml from template
   when: _pull_wikis_template_stat.stat.exists
   block:
-    - name: Ensure config directory exists and is writable
-      ansible.builtin.file:
-        path: "{{ instance_path }}/config"
-        state: directory
-        mode: "0755"
-
     - name: Read wikis.yaml.template
       ansible.builtin.slurp:
         src: "{{ instance_path }}/wikis.yaml.template"


### PR DESCRIPTION
The `config/` directory in a Canasta instance is owned by `www-data:www-data` with mode 775 (created by the Docker web container). Writing rendered files to it (e.g., `config/wikis.yaml` during `gitops pull`) requires the host user to be in the `www-data` group.

## Fixes

1. **pull_compose.yml**: Remove the `ansible.builtin.file` chmod task that tried to fix permissions. The directory is writable via group membership — attempting to chmod a directory owned by another user fails with EPERM.

2. **CI workflow**: Add the runner to `www-data` group and use `sg www-data -c '...'` to activate the group for the gitops test step.

3. **doctor.yml**: Add www-data group membership check. Shows 'OK (member)' or tells the user how to fix it with `sudo usermod -aG www-data`.

Also includes:
- `docs/k8s-multi-env-gitops-design.md` — design doc for multi-environment K8s gitops (dev/staging/prod)
- `.DS_Store` added to `.gitignore`