### PR TITLE
Handle controller-to-remote key transfer in gitops init and join

### DIFF
--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -25,11 +25,16 @@
     msg: "GitOps already initialized ({{ instance_path }}/.git exists). Use 'gitops join' to join an existing repo."
   when: _existing_git.stat.exists
 
-# --- Step 3: Check key file won't overwrite ---
-- name: Check key file does not exist
+# --- Step 3: Check key file won't overwrite on the CONTROLLER ---
+# --key is a controller-local path, not a remote path.
+- name: Check key file does not exist on controller
   ansible.builtin.stat:
     path: "{{ key }}"
   register: _key_exists
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Fail if key file already exists
   ansible.builtin.fail:
@@ -90,11 +95,25 @@
     chdir: "{{ instance_path }}"
   changed_when: true
 
-- name: Export git-crypt key
+# Export to a temp path on the remote host, then fetch to the
+# controller at the --key path. The controller-to-target model
+# means --key is a LOCAL path on the controller, not on the remote.
+- name: Export git-crypt key on remote host
   ansible.builtin.command:
-    cmd: "git-crypt export-key {{ key }}"
+    cmd: "git-crypt export-key /tmp/canasta-gitcrypt-key"
     chdir: "{{ instance_path }}"
   changed_when: true
+
+- name: Fetch git-crypt key to controller
+  ansible.builtin.fetch:
+    src: "/tmp/canasta-gitcrypt-key"
+    dest: "{{ key }}"
+    flat: true
+
+- name: Remove temp key from remote host
+  ansible.builtin.file:
+    path: "/tmp/canasta-gitcrypt-key"
+    state: absent
 
 # --- Step 9: Create env.template and wikis.yaml.template ---
 # env.template replaces secret/host-specific values with {{placeholder}} syntax.

--- a/roles/gitops/tasks/join.yml
+++ b/roles/gitops/tasks/join.yml
@@ -42,16 +42,22 @@
       This instance is already connected to a gitops repository.
   when: _join_existing_git.stat.exists
 
-- name: Check key file exists
+# --key is a controller-local path. Check it on the controller,
+# then copy it to the remote host for git-crypt unlock.
+- name: Check key file exists on controller
   ansible.builtin.stat:
     path: "{{ key }}"
   register: _join_key_exists
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
 
 - name: Fail if key file not found
   ansible.builtin.fail:
     msg: >-
-      Key file '{{ key }}' not found. This should be the git-crypt
-      key exported during 'gitops init' on the source host.
+      Key file '{{ key }}' not found on the controller. This should
+      be the git-crypt key exported during 'gitops init'.
   when: not _join_key_exists.stat.exists
 
 # --- Step 2: Clone repo to temp location ---
@@ -67,12 +73,23 @@
     chdir: "{{ _join_tmpdir.path }}"
   changed_when: true
 
-# --- Step 3: Unlock git-crypt ---
+# --- Step 3: Copy key to remote and unlock git-crypt ---
+- name: Copy git-crypt key from controller to remote
+  ansible.builtin.copy:
+    src: "{{ key }}"
+    dest: "/tmp/canasta-gitcrypt-key"
+    mode: "0600"
+
 - name: Unlock git-crypt with provided key
   ansible.builtin.command:
-    cmd: "git-crypt unlock {{ key }}"
+    cmd: "git-crypt unlock /tmp/canasta-gitcrypt-key"
     chdir: "{{ _join_tmpdir.path }}"
   changed_when: true
+
+- name: Remove temp key from remote
+  ansible.builtin.file:
+    path: "/tmp/canasta-gitcrypt-key"
+    state: absent
 
 # --- Step 4: Validate host name not already in config ---
 - name: Read hosts.yaml from cloned repo


### PR DESCRIPTION
The `--key` parameter is a path on the **controller** (the Mac/laptop running canasta), not on the remote host. With Canasta-Ansible's controller-to-target architecture, the git-crypt key needs to cross the SSH hop.

**init**: exports key on remote to a temp path, uses `ansible.builtin.fetch` to copy it back to the controller at `--key`, then cleans up the temp file.

**join**: checks the key on the controller (`delegate_to: localhost`), uses `ansible.builtin.copy` to push it to the remote, unlocks git-crypt, then cleans up.

Previously, `--key` was treated as a remote path, which failed with 'No such file or directory' because `/Users/cicalese/...` doesn't exist on the VPS.