### PR TITLE
Fix push unpushed commits, pull.rebase, and SSH host key for registry-resolved hosts

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -581,14 +581,16 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
         if ssh_user:
             ansible_args.extend(["-u", ssh_user])
 
-        # Auto-accept new SSH host keys on first connection (matching
-        # ssh's 'StrictHostKeyChecking=accept-new'). Known hosts with
-        # changed keys are still rejected.
-        os.environ.setdefault(
-            "ANSIBLE_SSH_ARGS",
-            "-o StrictHostKeyChecking=accept-new "
-            "-o UserKnownHostsFile=~/.ssh/known_hosts",
-        )
+    # Auto-accept new SSH host keys on first connection (matching
+    # ssh's 'StrictHostKeyChecking=accept-new'). Applies to all
+    # commands, not just -H commands — when the host is resolved from
+    # the registry, the SSH connection still needs this. Known hosts
+    # with changed keys are still rejected.
+    os.environ.setdefault(
+        "ANSIBLE_SSH_ARGS",
+        "-o StrictHostKeyChecking=accept-new "
+        "-o UserKnownHostsFile=~/.ssh/known_hosts",
+    )
 
     return ansible_args
 

--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -92,6 +92,12 @@
     chdir: "{{ instance_path }}"
   changed_when: true
 
+- name: Configure git pull strategy
+  ansible.builtin.command:
+    cmd: "git config pull.rebase false"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
 # --- Step 7: Write .gitignore and .gitattributes ---
 - name: Write .gitignore
   ansible.builtin.copy:

--- a/roles/gitops/tasks/join.yml
+++ b/roles/gitops/tasks/join.yml
@@ -147,6 +147,12 @@
     chdir: "{{ instance_path }}"
   changed_when: true
 
+- name: Configure git pull strategy
+  ansible.builtin.command:
+    cmd: "git config pull.rebase false"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
 # --- Step 6: Extract vars from current .env ---
 - name: Define placeholder keys
   ansible.builtin.set_fact:

--- a/roles/gitops/tasks/push_compose.yml
+++ b/roles/gitops/tasks/push_compose.yml
@@ -35,7 +35,7 @@
       does not allow pushing. Only 'source' and 'both' roles can push.
   when: _push_role not in ['source', 'both']
 
-# --- Stage and push ---
+# --- Stage, commit, and push ---
 - name: Stage all changes
   ansible.builtin.command:
     cmd: "git add -A"
@@ -50,21 +50,28 @@
   changed_when: false
   ignore_errors: true  # rc=1 means there are changes
 
-- name: Commit and push
+- name: Commit staged changes
+  ansible.builtin.command:
+    cmd: >-
+      git commit -m "{{ message | default('Configuration update') }}"
+    chdir: "{{ instance_path }}"
+  changed_when: true
   when: _push_staged.rc != 0
-  block:
-    - name: Commit changes
-      ansible.builtin.command:
-        cmd: >-
-          git commit -m "{{ message | default('Configuration update') }}"
-        chdir: "{{ instance_path }}"
-      changed_when: true
 
-    - name: Push to remote
-      ansible.builtin.command:
-        cmd: "git push"
-        chdir: "{{ instance_path }}"
-      changed_when: true
+- name: Check for unpushed commits
+  ansible.builtin.command:
+    cmd: "git log origin/main..HEAD --oneline"
+    chdir: "{{ instance_path }}"
+  register: _push_unpushed
+  changed_when: false
+  ignore_errors: true  # OK if no upstream configured yet
+
+- name: Push to remote
+  ansible.builtin.command:
+    cmd: "git push"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+  when: _push_unpushed.stdout | default('') | trim | length > 0
 
 - name: Report result
   ansible.builtin.debug:


### PR DESCRIPTION
Three issues from multi-host gitops testing:

1. **push_compose.yml** only checked for staged changes. Now also checks `git log origin/main..HEAD` for unpushed commits.

2. **init and join** now set `git config pull.rebase false` so divergent branches merge cleanly.

3. **canasta.py** — `ANSIBLE_SSH_ARGS` with `StrictHostKeyChecking=accept-new` was only set when `-H` was passed. Commands that resolve the host from the registry (add, delete, gitops, etc.) didn't get it, causing 'Host key verification failed' on first connection. Now set unconditionally. This fixes the Remote Host Integration Tests CI failure.