### PR TITLE
Set Ansible temp directories to /tmp when running as a non-root user

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -84,6 +84,18 @@ MOUNTS=(
     --user "$(id -u):$(id -g)"
 )
 
+# Set Ansible temp directories to /tmp when running as a non-root user in
+# rootless Docker. On rootless Docker, the UID/GID mapping causes directory
+# ownership to appear as root:root to the container process even though
+# the directory is owned by the host user. This causes Ansible to fail when
+# trying to create $HOME/.ansible/tmp. Using /tmp avoids the issue.
+if [[ "$(id -u)" != "0" ]]; then
+    MOUNTS+=(
+        -e "ANSIBLE_LOCAL_TEMP=/tmp/ansible-local"
+        -e "ANSIBLE_REMOTE_TEMP=/tmp/ansible-remote"
+    )
+fi
+
 # Sanitize Docker config.json for the container.
 # macOS Docker Desktop's config.json typically contains
 # "credsStore": "desktop" which references docker-credential-desktop,


### PR DESCRIPTION
On rootless Docker, the UID/GID mapping causes directory ownership to appear as root:root to the container process even
though the directory is owned by the host user. This causes Ansible to fail when trying to create
$HOME/.ansible/tmp. Using /tmp avoids the issue.

Fixes #97