### PR TITLE
Fix registry storing delegate host instead of target host

### DIFF
--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -521,12 +521,19 @@
     install_wiki_db_password: "{{ _wikidbpass }}"
 
 # --- Step 13: Register instance ---
+# Capture host identity BEFORE delegate_to: localhost, because
+# delegation overrides ansible_host/ansible_user with the delegate's
+# values (localhost), not the play target's.
+- name: Build registry host string
+  ansible.builtin.set_fact:
+    _registry_host: "{{ (ansible_user | default('') + '@') if (ansible_user | default('')) else '' }}{{ ansible_host | default(inventory_hostname) }}"
+
 - name: Register instance in controller config
   canasta_registry:
     id: "{{ id }}"
     path: "{{ instance_path }}"
     orchestrator: "{{ orchestrator | default('compose') }}"
-    host: "{{ (ansible_user | default('') + '@') if (ansible_user | default('')) else '' }}{{ ansible_host | default(inventory_hostname) }}"
+    host: "{{ _registry_host }}"
     managed_cluster: false
     build_from: "{{ build_from | default(omit) }}"
     state: present


### PR DESCRIPTION
## Summary

- Fix registry storing `testuser@localhost` instead of `testuser@<actual-host>` for remote instances
- Root cause: `delegate_to: localhost` overrides `ansible_host` with the delegate's value
- Fix: capture host string in `set_fact` before the delegated registry task

Fixes #106

## Test plan

- [ ] Remote Host Integration Tests pass in CI (tests 2-5 were all failing)
- [ ] Manual: `canasta -H user@host create` stores correct host in conf.json
- [ ] Manual: subsequent `canasta add -i <id>` resolves host from registry correctly
