### PR TITLE
Fix K8s preflight and k3s install for fresh hosts

### DIFF
--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -27,6 +27,28 @@
       delay: 5
       changed_when: false
 
+# k3s bundles kubectl as 'k3s kubectl' but many tools (Helm, Ansible
+# k8s modules) expect a standalone 'kubectl' binary on the PATH.
+- name: Create kubectl symlink
+  ansible.builtin.file:
+    src: /usr/local/bin/k3s
+    dest: /usr/local/bin/kubectl
+    state: link
+  become: true
+
+- name: Check if helm is installed
+  ansible.builtin.command:
+    cmd: helm version --short
+  register: _helm_installed
+  changed_when: false
+  ignore_errors: true
+
+- name: Install helm
+  ansible.builtin.shell:
+    cmd: "curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash"
+  changed_when: true
+  when: _helm_installed.rc != 0
+
 - name: Ensure kubeconfig directory exists
   ansible.builtin.file:
     path: "{{ ansible_env.HOME }}/.kube"

--- a/roles/orchestrator/tasks/k8s_preflight.yml
+++ b/roles/orchestrator/tasks/k8s_preflight.yml
@@ -7,18 +7,19 @@
   register: _kubectl_check
   changed_when: false
   ignore_errors: true  # OK if kubectl not installed
+  when: not (install_k3s | default(false) | bool)
 
 - name: Fail if kubectl not available
   ansible.builtin.fail:
     msg: >-
       kubectl is not installed. Install kubectl to manage Kubernetes instances.
       See https://kubernetes.io/docs/tasks/tools/
-  when: _kubectl_check.rc != 0
+  when:
+    - not (install_k3s | default(false) | bool)
+    - _kubectl_check.rc | default(0) != 0
 
 # Skip the cluster-reachability check when --install-k3s is set —
 # the cluster doesn't exist yet and will be created after preflight.
-# Still check kubectl and helm are installed (above/below) so those
-# failures are caught early.
 - name: Check cluster is reachable
   ansible.builtin.command:
     cmd: kubectl cluster-info
@@ -42,13 +43,16 @@
   register: _helm_check
   changed_when: false
   ignore_errors: true  # OK if Helm not installed
+  when: not (install_k3s | default(false) | bool)
 
 - name: Fail if helm not available
   ansible.builtin.fail:
     msg: >-
       Helm is not installed. Install Helm 3.10+ to manage Kubernetes instances.
       See https://helm.sh/docs/intro/install/
-  when: _helm_check.rc != 0
+  when:
+    - not (install_k3s | default(false) | bool)
+    - _helm_check.rc | default(0) != 0
 
 # Skip the node resource check when --install-k3s is set — there are
 # no nodes yet. The check will effectively run on the first start


### PR DESCRIPTION
## Summary

- Skip kubectl and helm preflight checks when `--install-k3s` is set (they'll be installed as part of the k3s setup)
- Add `kubectl` symlink after k3s install (k3s bundles it as `k3s kubectl` but Helm and Ansible k8s modules need standalone `kubectl`)
- Install Helm as part of k3s setup if not already present

Without this fix, `canasta create --orchestrator kubernetes --install-k3s` fails on a fresh host because the preflight requires kubectl/helm before they exist.

## Test plan

- [ ] `canasta create --orchestrator kubernetes --install-k3s` succeeds on a fresh host
- [ ] `kubectl` and `helm` are available after k3s install
- [ ] CI unit tests pass
