### PR TITLE
Make k3s kubeconfig readable after install

### DIFF
--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -49,6 +49,16 @@
   changed_when: true
   when: _helm_installed.rc != 0
 
+# k3s writes its kubeconfig to /etc/rancher/k3s/k3s.yaml with mode
+# 600 (root-only). The k3s binary (used via the kubectl symlink)
+# reads this file by default. Make it readable so non-root users
+# can use kubectl without sudo.
+- name: Make k3s kubeconfig readable
+  ansible.builtin.file:
+    path: /etc/rancher/k3s/k3s.yaml
+    mode: "0644"
+  become: true
+
 - name: Ensure kubeconfig directory exists
   ansible.builtin.file:
     path: "{{ ansible_env.HOME }}/.kube"

--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -3,6 +3,12 @@
 # Input: install_k3s (bool)
 # Idempotent — checks if k3s is already running.
 
+# gather_facts is false globally — collect ansible_env.HOME for
+# kubeconfig path.
+- name: Gather minimal facts for HOME directory
+  ansible.builtin.setup:
+    filter: ansible_env
+
 - name: Check if k3s is already running
   ansible.builtin.command:
     cmd: k3s kubectl cluster-info


### PR DESCRIPTION
## Summary

- `chmod 644 /etc/rancher/k3s/k3s.yaml` after k3s install so the kubectl symlink (which points to the k3s binary) can read it as a non-root user

Without this, `canasta create --install-k3s` installs k3s successfully but then fails on the next kubectl command with "permission denied" on the kubeconfig.

## Test plan

- [ ] `canasta create --orchestrator kubernetes --install-k3s` succeeds end-to-end on a fresh host
- [ ] CI unit tests pass
