### PR TITLE
Fix K8s commands for remote hosts: chart copy, file lookups, template path

### DIFF
--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -120,12 +120,18 @@
     dest: "{{ instance_path }}/templates/"
     mode: preserve
 
+# lookup('file') runs on the controller — use slurp for remote files.
+- name: Read instance values.yaml from remote
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/values.yaml"
+  register: _gitops_instance_values
+
 - name: Merge chart defaults with instance values
   ansible.builtin.copy:
     content: |
       {{ lookup('file', canasta_root ~ '/roles/orchestrator/files/helm/canasta/values.yaml')
          | from_yaml
-         | combine(lookup('file', instance_path ~ '/values.yaml') | from_yaml, recursive=True)
+         | combine(_gitops_instance_values.content | b64decode | from_yaml, recursive=True)
          | to_nice_yaml(indent=2) }}
     dest: "{{ instance_path }}/values.yaml"
     mode: "0644"
@@ -222,11 +228,21 @@
 - name: Sync config files
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_sync_config.yml"
 
+- name: Read values.yaml from remote for configData merge
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/values.yaml"
+  register: _gitops_values_for_merge
+
+- name: Read values-configdata.yaml from remote
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/values-configdata.yaml"
+  register: _gitops_configdata_for_merge
+
 - name: Merge configData into values.yaml for git
   ansible.builtin.copy:
     content: >-
-      {{ lookup('file', instance_path ~ '/values.yaml') | from_yaml
-         | combine(lookup('file', instance_path ~ '/values-configdata.yaml') | from_yaml, recursive=True)
+      {{ _gitops_values_for_merge.content | b64decode | from_yaml
+         | combine(_gitops_configdata_for_merge.content | b64decode | from_yaml, recursive=True)
          | to_nice_yaml(indent=2) }}
     dest: "{{ instance_path }}/values.yaml"
     mode: "0644"

--- a/roles/gitops/tasks/push_kubernetes.yml
+++ b/roles/gitops/tasks/push_kubernetes.yml
@@ -17,11 +17,21 @@
 - name: Sync config files
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_sync_config.yml"
 
+- name: Read values.yaml from remote
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/values.yaml"
+  register: _push_values
+
+- name: Read values-configdata.yaml from remote
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/values-configdata.yaml"
+  register: _push_configdata
+
 - name: Merge configData into values.yaml for git
   ansible.builtin.copy:
     content: >-
-      {{ lookup('file', instance_path ~ '/values.yaml') | from_yaml
-         | combine(lookup('file', instance_path ~ '/values-configdata.yaml') | from_yaml, recursive=True)
+      {{ _push_values.content | b64decode | from_yaml
+         | combine(_push_configdata.content | b64decode | from_yaml, recursive=True)
          | to_nice_yaml(indent=2) }}
     dest: "{{ instance_path }}/values.yaml"
     mode: "0644"

--- a/roles/orchestrator/tasks/helm_deploy.yml
+++ b/roles/orchestrator/tasks/helm_deploy.yml
@@ -3,6 +3,14 @@
 # Input: instance_id, instance_path, _k8s_namespace
 # Optional: helm_wait (bool, default true), helm_reset_values (bool, default true)
 
+# Copy the Helm chart to the remote host. The chart lives in the
+# controller's repo at canasta_root, but helm runs on the target.
+- name: Copy Helm chart to instance directory
+  ansible.builtin.copy:
+    src: "{{ canasta_root }}/roles/orchestrator/files/helm/canasta/"
+    dest: "{{ instance_path }}/_chart/"
+    mode: preserve
+
 - name: Check for configData values file
   ansible.builtin.stat:
     path: "{{ instance_path }}/values-configdata.yaml"
@@ -12,7 +20,7 @@
   ansible.builtin.command:
     cmd: >-
       helm upgrade --install canasta-{{ instance_id }}
-      {{ canasta_root }}/roles/orchestrator/files/helm/canasta
+      {{ instance_path }}/_chart
       --namespace {{ _k8s_namespace }} --create-namespace
       -f {{ instance_path }}/values.yaml
       {{ (_configdata_file.stat.exists | default(false))

--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -55,6 +55,21 @@
   changed_when: true
   when: _helm_installed.rc != 0
 
+# Ansible k8s modules require the Python kubernetes library.
+- name: Check if Python kubernetes library is available
+  ansible.builtin.command:
+    cmd: "python3 -c 'import kubernetes'"
+  register: _k8s_python
+  changed_when: false
+  ignore_errors: true
+
+- name: Install Python kubernetes library
+  ansible.builtin.apt:
+    name: python3-kubernetes
+    state: present
+  become: true
+  when: _k8s_python.rc != 0
+
 # k3s writes its kubeconfig to /etc/rancher/k3s/k3s.yaml with mode
 # 600 (root-only). The k3s binary (used via the kubectl symlink)
 # reads this file by default. Make it readable so non-root users

--- a/roles/orchestrator/tasks/rewrite_caddy.yml
+++ b/roles/orchestrator/tasks/rewrite_caddy.yml
@@ -42,7 +42,7 @@
 
 - name: Write Caddyfile from template
   ansible.builtin.template:
-    src: "{{ role_path }}/templates/Caddyfile.j2"
+    src: "{{ canasta_root }}/roles/orchestrator/templates/Caddyfile.j2"
     dest: "{{ instance_path }}/config/Caddyfile"
     mode: "0644"
     # The Canasta web container's run-all.sh rsyncs $MW_ORIGIN_FILES


### PR DESCRIPTION
## Summary

Fixes for running K8s commands on remote hosts (controller ≠ target). These were discovered during a single-host K8s gitops test on dev.acknowledge.wiki:

- **Install Python kubernetes library** during k3s setup (Ansible k8s modules require it)
- **Copy Helm chart to remote host** before deploy (helm runs on the target, not the controller)
- **Fix `lookup('file')` calls** in K8s gitops init and push (lookup runs on the controller but instance files are on the remote — replaced with `slurp`)
- **Fix Caddyfile template path** in rewrite_caddy.yml (`role_path` resolved to the gitops role instead of orchestrator when included cross-role — use `canasta_root` instead)

## Test plan

- [x] K8s gitops test: create → init → push → sync all working on remote host
- [ ] CI unit tests pass
- [ ] CI integration tests pass
