### PR TITLE
Handle unreachable hosts in delete, improve create error message

### DIFF
--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -77,7 +77,11 @@
 
 - name: Fail if instance already exists
   ansible.builtin.fail:
-    msg: "Instance '{{ id }}' already exists at {{ _existing.instance.path }}"
+    msg: >-
+      Instance '{{ id }}' already exists in the registry
+      (path: {{ _existing.instance.path }},
+      host: {{ _existing.instance.host | default('localhost') }}).
+      Run 'canasta delete --id {{ id }} --yes' to remove it first.
   when: _existing is succeeded
 
 # --- Step 2: Determine base image ---

--- a/roles/delete/tasks/main.yml
+++ b/roles/delete/tasks/main.yml
@@ -65,6 +65,54 @@
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/switch_connection.yml"
   when: _delete_query is succeeded
 
+# If the remote host is unreachable (VM destroyed, IP changed),
+# deregister from the controller and exit gracefully rather than
+# failing with "Host unreachable".
+- name: Test remote host reachability
+  ansible.builtin.command:
+    cmd: "echo reachable"
+  register: _host_reachable
+  changed_when: false
+  ignore_errors: true
+  when:
+    - _delete_query is succeeded
+    - _instance_host | default('localhost') != 'localhost'
+
+- name: Handle unreachable remote host
+  when:
+    - _delete_query is succeeded
+    - _instance_host | default('localhost') != 'localhost'
+    - _host_reachable is failed
+  block:
+    - name: Require confirmation for unreachable delete
+      ansible.builtin.fail:
+        msg: >-
+          Remote host '{{ _instance_host }}' is unreachable.
+          Deleting will remove '{{ instance_id }}' from the registry
+          but cannot clean up remote resources.
+          Use --yes to confirm.
+      when: not (yes | default(false) | bool)
+
+    - name: Deregister unreachable instance from controller
+      canasta_registry:
+        id: "{{ instance_id }}"
+        state: absent
+      delegate_to: localhost
+      vars:
+        ansible_connection: local
+        ansible_python_interpreter: "{{ ansible_playbook_python }}"
+
+    - name: Report unreachable host deletion
+      ansible.builtin.debug:
+        msg: >-
+          Instance '{{ instance_id }}' removed from the registry.
+          Warning: remote host '{{ _instance_host }}' was unreachable —
+          remote resources (containers, files, target registry) were
+          not cleaned up.
+
+    - name: End play for unreachable host
+      ansible.builtin.meta: end_play
+
 - name: Discover unregistered instance
   when: _delete_query is failed
   block:


### PR DESCRIPTION
## Summary

- **create**: Clarify "already exists" error to say "in the registry" with the registered host and path, and suggest `canasta delete --id <id> --yes` to clean up
- **delete**: Test remote host reachability after connection switch. If the host is unreachable (VM destroyed, IP changed), deregister from the controller registry and exit with a warning instead of failing with "Host unreachable"

This handles the scenario where a user redeploys a VM (new IP or wiped disk) and wants to reuse an instance ID that's still in the controller registry.

Fixes #104

## Test plan

- [ ] `canasta create` with existing ID shows improved error message
- [ ] `canasta delete --id <id> --yes` with unreachable host deregisters from controller
- [ ] `canasta delete --id <id>` (no --yes) with unreachable host shows confirmation prompt
- [ ] Normal delete (reachable host) still works as before
- [ ] CI unit tests pass
