### PR TITLE
Suppress SSH connection closed message in maintenance exec

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -307,7 +307,7 @@ def handle_interactive_exec(args):
                 " ".join(shlex.quote(a) for a in docker_cmd),
             )
             try:
-                ssh_args = ["ssh", "-t"]
+                ssh_args = ["ssh", "-t", "-o", "LogLevel=ERROR"]
                 # Include any custom SSH args (e.g. from ANSIBLE_SSH_ARGS)
                 extra_ssh = os.environ.get("ANSIBLE_SSH_ARGS", "")
                 if extra_ssh:


### PR DESCRIPTION
## Summary

Add `-o LogLevel=ERROR` to the `ssh -t` call in `maintenance exec` to suppress the "Connection to host closed." message that appears after every remote exec command.

## Test plan

- [ ] `canasta maintenance exec -i <id> -- echo hello` no longer shows "Connection closed" on remote instances
