### PR TITLE
Fix canasta-docker -p injection for subcommands containing 'create'

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -458,9 +458,23 @@ EXTRA_ARGS=()
 HAS_CREATE=false
 HAS_PATH=false
 HAS_HOST=false
+FIRST_CMD=""
 for arg in "$@"; do
     case "$arg" in
-        create) HAS_CREATE=true ;;
+        -*) ;;  # skip flags and their values
+        *)
+            # Track the first positional argument (the top-level command).
+            # Only match 'create' as a top-level command, not as a
+            # subcommand (e.g. 'backup create').
+            if [[ -z "$FIRST_CMD" ]]; then
+                FIRST_CMD="$arg"
+                if [[ "$arg" == "create" ]]; then
+                    HAS_CREATE=true
+                fi
+            fi
+            ;;
+    esac
+    case "$arg" in
         -p|--path|-p=*|--path=*) HAS_PATH=true ;;
         -H|--host|-H=*|--host=*) HAS_HOST=true ;;
     esac


### PR DESCRIPTION
## Summary

Fix `canasta-docker` matching `create` anywhere in arguments, causing `-p $(pwd)` injection for `backup create`, `backup schedule create`, and any other subcommand containing the word `create`.

Track the first positional argument and only match `create` as the top-level command.

Fixes #121

## Test plan

- [ ] `canasta backup create --id <id> -t test` no longer gets `-p` injected
- [ ] `canasta create --id <id> -w main` still gets `-p` injected when no `-p` is given
- [ ] `canasta -H user@host create --id <id> -w main` does NOT get `-p` injected
