### PR TITLE
Update message for already existing instance

### DIFF
--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -18,7 +18,7 @@
 
 - name: Fail early if instance already exists
   ansible.builtin.fail:
-    msg: "Instance '{{ id }}' already exists at {{ _pre_check.instance.path }}"
+    msg: "Instance '{{ id }}' already exists in local config\nHost: {{ _pre_check.instance.host }}\nPath: {{ _pre_check.instance.path }}"
   when: _pre_check is succeeded
 
 - name: Create Canasta instance

--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -18,7 +18,11 @@
 
 - name: Fail early if instance already exists
   ansible.builtin.fail:
-    msg: "Instance '{{ id }}' already exists in local config\nHost: {{ _pre_check.instance.host }}\nPath: {{ _pre_check.instance.path }}"
+    msg: >-
+      Instance '{{ id }}' already exists in the registry
+      (path: {{ _existing.instance.path }},
+      host: {{ _existing.instance.host | default('localhost') }}).
+      Run 'canasta delete --id {{ id }} --yes' to remove it first.
   when: _pre_check is succeeded
 
 - name: Create Canasta instance

--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -20,8 +20,8 @@
   ansible.builtin.fail:
     msg: >-
       Instance '{{ id }}' already exists in the registry
-      (path: {{ _existing.instance.path }},
-      host: {{ _existing.instance.host | default('localhost') }}).
+      (path: {{ _pre_check.instance.path }},
+      host: {{ _pre_check.instance.host | default('localhost') }}).
       Run 'canasta delete --id {{ id }} --yes' to remove it first.
   when: _pre_check is succeeded
 


### PR DESCRIPTION
This changes:
```
Error: Instance 'wikiapiary' already exists at /root/wikiapiary
```
to:
```
Error: Instance 'wikiapiary' already exists in local config
Host: root@meta.wikiapiary.com
Path: /root/wikiapiary
```
Fixes #104