### PR TITLE
canasta: resolve path-type args against shell CWD instead of playbook_dir

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -524,6 +524,12 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
         if ptype == "bool":
             if value:
                 extra_vars[name] = "true"
+        elif ptype == "path":
+            # Resolve against the invoking shell's CWD (and expand ~).
+            # Ansible otherwise resolves relative paths against
+            # playbook_dir, which is the canasta.py install directory
+            # — not what users expect when they pass `-p .`.
+            extra_vars[name] = os.path.abspath(os.path.expanduser(str(value)))
         else:
             extra_vars[name] = str(value)
 

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -776,3 +776,58 @@ class TestHelperFunctions:
     def test_display_name(self):
         assert canasta_cli.display_name("fix_submodules") == "fix-submodules"
         assert canasta_cli.display_name("create") == "create"
+
+
+class TestPathResolution:
+    """Path-type args should be anchored to the caller's CWD, not
+    playbook_dir, so 'canasta create -p .' lands in the user's working
+    directory instead of the canasta.py install directory."""
+
+    def _get_vars(self, result):
+        import json
+        for i, arg in enumerate(result):
+            if arg == "-e" and i + 1 < len(result) and result[i + 1].startswith("@"):
+                with open(result[i + 1][1:]) as f:
+                    return json.load(f)
+        return {}
+
+    def test_path_dot_resolves_to_cwd(self, data, tmp_path, monkeypatch):
+        from argparse import Namespace
+        monkeypatch.chdir(tmp_path)
+        args = Namespace(
+            command="create", host=None, verbose=False, id="mysite",
+            wiki="main", domain_name=None, site_name=None,
+            database=None, path=".", orchestrator=None,
+            admin_password=None, wiki_db_password=None,
+            root_db_password=None,
+        )
+        result = canasta_cli.build_ansible_args("ap", "create", args, data)
+        extra = self._get_vars(result)
+        assert extra["path"] == str(tmp_path)
+
+    def test_path_absolute_passthrough(self, data):
+        from argparse import Namespace
+        args = Namespace(
+            command="create", host=None, verbose=False, id="mysite",
+            wiki="main", domain_name=None, site_name=None,
+            database=None, path="/srv/canasta", orchestrator=None,
+            admin_password=None, wiki_db_password=None,
+            root_db_password=None,
+        )
+        result = canasta_cli.build_ansible_args("ap", "create", args, data)
+        extra = self._get_vars(result)
+        assert extra["path"] == "/srv/canasta"
+
+    def test_path_tilde_expands(self, data):
+        from argparse import Namespace
+        args = Namespace(
+            command="create", host=None, verbose=False, id="mysite",
+            wiki="main", domain_name=None, site_name=None,
+            database=None, path="~", orchestrator=None,
+            admin_password=None, wiki_db_password=None,
+            root_db_password=None,
+        )
+        result = canasta_cli.build_ansible_args("ap", "create", args, data)
+        extra = self._get_vars(result)
+        assert extra["path"] == os.path.expanduser("~")
+        assert not extra["path"].startswith("~")


### PR DESCRIPTION
## Summary
- Convert path-type parameters to absolute form (via `os.path.abspath(os.path.expanduser(...))`) before handing them to Ansible, so relative paths anchor to the user's shell CWD.

## Test plan
- [x] `canasta create` (no `-p`, from a home dir) used to error out creating `/opt/canasta-ansible/<id>`; now lands correctly in `~/<id>`.
- [x] `canasta create -p .` — same outcome as above.
- [x] `canasta create -p ~` / `-p /absolute/path` — unchanged.

Fixes #134.