### PR TITLE
doctor: accept --host for pre-instance dependency checks

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -494,7 +494,7 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
 
     # Only pass target_host for commands that need it.
     # Other commands resolve the host from the instance registry.
-    HOST_COMMANDS = {"create", "list"}
+    HOST_COMMANDS = {"create", "list", "doctor"}
     if args.host and command_name in HOST_COMMANDS:
         extra_vars["target_host"] = args.host
     elif args.host and command_name not in HOST_COMMANDS:

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -404,6 +404,34 @@ class TestHostCommandsBehavior:
         captured = capsys.readouterr()
         assert "ignored" in captured.err.lower() or "Warning" in captured.err
 
+    def test_host_flag_on_doctor(self, data):
+        """-H should be passed through for 'doctor' so users can check a
+        remote host's dependencies before creating an instance."""
+        from argparse import Namespace
+        args = Namespace(
+            command="doctor", host="newhost.example.com", verbose=False,
+        )
+        result = canasta_cli.build_ansible_args(
+            "ap", "doctor", args, data
+        )
+        extra = self._get_vars(result)
+        assert extra["target_host"] == "newhost.example.com"
+        assert "--limit" in result
+        assert "newhost.example.com" in result
+
+    def test_host_flag_absent_on_doctor_runs_locally(self, data):
+        """Without -H, doctor runs on localhost (no target_host set)."""
+        from argparse import Namespace
+        args = Namespace(
+            command="doctor", host=None, verbose=False,
+        )
+        result = canasta_cli.build_ansible_args(
+            "ap", "doctor", args, data
+        )
+        extra = self._get_vars(result)
+        assert "target_host" not in extra
+        assert "--limit" not in result
+
 
 class TestRemainderArgs:
     """Test that exec_args/script_args consume flags after command."""


### PR DESCRIPTION
## Summary
- Add ``doctor`` to the list of commands that honor ``--host``, instead of warning and falling back to localhost.
- The playbook already uses ``inventory_hostname`` in its header and report — no playbook changes needed.

## Test plan
- [ ] ``canasta doctor`` — unchanged, runs on localhost.
- [ ] ``canasta doctor --host <registered-host>`` — now reports against the remote host's dependencies.
- [ ] ``canasta doctor --host user@raw.example.com`` — now works as a pre-flight before ``canasta host add`` / ``canasta create``.

Fixes #130.