### PR TITLE
Add 'canasta config regenerate' command

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -26,7 +26,7 @@ os.environ.setdefault("ANSIBLE_CONFIG", ANSIBLE_CFG)
 
 # Commands that have subcommands (e.g., "config get" -> "config_get")
 SUBCOMMAND_GROUPS = {
-    "config": ["get", "set", "unset"],
+    "config": ["get", "set", "unset", "regenerate"],
     "extension": ["list", "enable", "disable"],
     "skin": ["list", "enable", "disable"],
     "maintenance": ["update", "script", "extension", "exec"],

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -465,6 +465,23 @@ commands:
         default: false
         description: "Allow setting unrecognized keys"
 
+  - name: config_regenerate
+    description: "Regenerate rendered config files (e.g. Caddyfile) from current sources"
+    long_description: |
+      Re-render the orchestrator's config files from the current .env
+      and wikis.yaml. Useful after 'canasta backup restore' (which
+      overwrites rendered files with the source host's copies) or
+      after any manual edit that left rendered state drifted from the
+      canonical sources.
+    examples:
+      - "canasta config regenerate -i mysite"
+    playbook: config_regenerate.yml
+    parameters:
+      - name: id
+        short: i
+        type: string
+        description: "Canasta instance ID"
+
   - name: config_unset
     description: "Remove configuration keys"
     long_description: |

--- a/playbooks/config_regenerate.yml
+++ b/playbooks/config_regenerate.yml
@@ -1,0 +1,20 @@
+---
+# canasta config regenerate - Regenerate rendered config files from
+# current sources of truth (.env, wikis.yaml).
+#
+# Useful after operations that overwrite rendered files (e.g. restore)
+# or after manual edits that drifted rendered Caddyfile from the
+# canonical state.
+
+- name: Resolve instance
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/common/tasks/resolve_instance.yml
+
+- name: Regenerate rendered config
+  ansible.builtin.include_role:
+    name: orchestrator
+    tasks_from: update_config.yml
+
+- name: Report
+  ansible.builtin.debug:
+    msg: "Regenerated config for '{{ instance_id }}'. Restart the instance to apply."

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -97,6 +97,15 @@ class TestBuildParser:
         args = parser.parse_args(["config", "get", "-i", "mysite"])
         assert args.key is None
 
+    def test_config_regenerate_subcommand(self, parser):
+        args = parser.parse_args(
+            ["config", "regenerate", "-i", "mysite"],
+        )
+        assert args.command == "config"
+        assert args.subcommand == "regenerate"
+        assert args.id == "mysite"
+        assert canasta_cli.resolve_command_name(args) == "config_regenerate"
+
     def test_short_flags(self, parser):
         args = parser.parse_args(["create", "-i", "mysite", "-w", "main",
                                    "-n", "example.com"])


### PR DESCRIPTION
## Summary
- New subcommand: ``canasta config regenerate -i <id>``.
- New playbook ``playbooks/config_regenerate.yml`` that includes the existing ``orchestrator/tasks/update_config.yml``.
- New command entry in ``meta/command_definitions.yml``; registered as a ``config`` subcommand in ``canasta.py``.

## Test plan
- [ ] After ``canasta backup restore`` from a different host, running ``canasta config regenerate -i <id>`` re-renders Caddyfile from the test host's ``wikis.yaml`` without any dummy key changes.
- [ ] ``make validate`` passes (command definitions in sync).

Fixes #143.