### PR TITLE
gitops: merge hosts/_shared/vars.yaml into rendered output

### DIFF
--- a/roles/gitops/tasks/pull_compose.yml
+++ b/roles/gitops/tasks/pull_compose.yml
@@ -88,9 +88,23 @@
     src: "{{ instance_path }}/hosts/{{ _pull_hostname }}/vars.yaml"
   register: _pull_vars_raw
 
-- name: Parse host vars
+- name: Check for shared vars
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/hosts/_shared/vars.yaml"
+  register: _pull_shared_vars_stat
+
+- name: Read shared vars (if present)
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/hosts/_shared/vars.yaml"
+  register: _pull_shared_vars_raw
+  when: _pull_shared_vars_stat.stat.exists
+
+- name: Parse host vars (with shared merged in; host wins)
   ansible.builtin.set_fact:
-    _pull_vars: "{{ _pull_vars_raw.content | b64decode | from_yaml }}"
+    _pull_vars: >-
+      {{ (_pull_shared_vars_stat.stat.exists
+          | ternary(_pull_shared_vars_raw.content | b64decode | from_yaml, {}))
+         | combine(_pull_vars_raw.content | b64decode | from_yaml) }}
 
 # --- Step 6: Render .env from env.template + vars ---
 - name: Read env.template


### PR DESCRIPTION
## Summary
- During ``canasta gitops pull``, load ``hosts/_shared/vars.yaml`` if it exists, merge its values into the render context as the base, and let per-host ``hosts/<name>/vars.yaml`` override any keys that need to vary.
- Opt-in: the file is optional. Existing repos keep working unchanged.

## Rationale
Values like backup credentials (``RESTIC_*``, ``AWS_*``) are the same across every host that talks to the same backup repository. Requiring every joined host to independently rediscover them defeats gitops. With this change, users can put shared values in one place and new hosts inherit them automatically on pull.

## Scope
- Read/render only. ``gitops init`` and ``gitops push`` still only manage per-host ``vars.yaml``. Auto-detecting backup credentials and moving them to ``_shared/vars.yaml`` on init/push is a follow-up worth filing separately once the file is in use.

## Test plan
- [ ] With no ``_shared/vars.yaml``: ``canasta gitops pull`` behaves exactly as before.
- [ ] With ``_shared/vars.yaml`` containing ``restic_password: foo``: rendered ``.env`` on every host has ``RESTIC_PASSWORD=foo``.
- [ ] Per-host override still wins: if a host's ``vars.yaml`` has ``restic_password: bar``, the rendered value is ``bar``.

Partially fixes #136.