### PR TITLE
backup restore: re-render gitops-managed config after restore (compose)

### DIFF
--- a/roles/backup/tasks/restore.yml
+++ b/roles/backup/tasks/restore.yml
@@ -229,6 +229,33 @@
   ignore_errors: true  # OK if backup dir doesn't exist
   when: instance_orchestrator | default('compose') == 'compose'
 
+# When the instance is under gitops, the snapshot just restored contains
+# the SOURCE host's rendered files (.env, wikis.yaml, Caddyfile). On this
+# host those need to be re-rendered from the templates + current host
+# vars, otherwise Caddy tries to issue a cert for the source host's FQDN,
+# MediaWiki serves URLs pointing at the wrong host, etc.
+- name: Detect gitops instance
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/.gitops-host"
+  register: _restore_gitops_stat
+  when: instance_orchestrator | default('compose') == 'compose'
+
+- name: Re-render gitops templates against this host's vars
+  ansible.builtin.include_role:
+    name: gitops
+    tasks_from: render_compose.yml
+  when:
+    - instance_orchestrator | default('compose') == 'compose'
+    - _restore_gitops_stat.stat.exists | default(false)
+
+- name: Regenerate orchestrator config (e.g. Caddyfile)
+  ansible.builtin.include_role:
+    name: orchestrator
+    tasks_from: update_config.yml
+  when:
+    - instance_orchestrator | default('compose') == 'compose'
+    - _restore_gitops_stat.stat.exists | default(false)
+
 - name: Restart instance after restore
   ansible.builtin.include_role:
     name: instance_lifecycle

--- a/roles/gitops/tasks/render_compose.yml
+++ b/roles/gitops/tasks/render_compose.yml
@@ -1,0 +1,106 @@
+---
+# Render rendered files (.env, wikis.yaml, admin passwords) from the
+# current on-disk templates + host vars (+ optional shared vars).
+#
+# Does NOT touch git; safe to call whenever local rendered files have
+# drifted from the canonical templates, e.g. after 'canasta backup
+# restore' overwrites them with the source host's copies.
+#
+# Requires: instance_path. Must only be called when the instance is
+# a gitops checkout (.gitops-host exists).
+
+- name: Read .gitops-host
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/.gitops-host"
+  register: _render_host_raw
+
+- name: Set host name
+  ansible.builtin.set_fact:
+    _render_hostname: "{{ _render_host_raw.content | b64decode | trim }}"
+
+- name: Read host vars
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/hosts/{{ _render_hostname }}/vars.yaml"
+  register: _render_vars_raw
+
+- name: Check for shared vars
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/hosts/_shared/vars.yaml"
+  register: _render_shared_vars_stat
+
+- name: Read shared vars (if present)
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/hosts/_shared/vars.yaml"
+  register: _render_shared_vars_raw
+  when: _render_shared_vars_stat.stat.exists
+
+- name: Parse host vars (with shared merged in; host wins)
+  ansible.builtin.set_fact:
+    _render_vars: >-
+      {{ (_render_shared_vars_stat.stat.exists
+          | ternary(_render_shared_vars_raw.content | b64decode | from_yaml, {}))
+         | combine(_render_vars_raw.content | b64decode | from_yaml) }}
+
+- name: Read env.template
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/env.template"
+  register: _render_env_template_raw
+
+- name: Render .env from template
+  ansible.builtin.copy:
+    content: |
+      {% for line in (_render_env_template_raw.content | b64decode).split('\n') %}
+      {% if '={{' in line and '}}' in line %}
+      {% set key = line.split('=', 1)[0] %}
+      {% set placeholder = line.split('={{', 1)[1].split('}}', 1)[0] %}
+      {{ key }}={{ _render_vars[placeholder] | default('') }}
+      {% else %}
+      {{ line }}
+      {% endif %}
+      {% endfor %}
+    dest: "{{ instance_path }}/.env"
+    mode: "0600"
+
+- name: Check if wikis.yaml.template exists
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/wikis.yaml.template"
+  register: _render_wikis_template_stat
+
+- name: Render wikis.yaml from template
+  when: _render_wikis_template_stat.stat.exists
+  block:
+    - name: Read wikis.yaml.template
+      ansible.builtin.slurp:
+        src: "{{ instance_path }}/wikis.yaml.template"
+      register: _render_wikis_template_raw
+
+    - name: Render config/wikis.yaml from template
+      ansible.builtin.copy:
+        content: |
+          {% for line in (_render_wikis_template_raw.content | b64decode).split('\n') %}
+          {% if '{{' in line and '}}' in line %}
+          {% set before = line.split('{{', 1)[0] %}
+          {% set placeholder = line.split('{{', 1)[1].split('}}', 1)[0] %}
+          {% set after = line.split('}}', 1)[1] if '}}' in line else '' %}
+          {{ before }}{{ _render_vars[placeholder] | default('') }}{{ after }}
+          {% else %}
+          {{ line }}
+          {% endif %}
+          {% endfor %}
+        dest: "{{ instance_path }}/config/wikis.yaml"
+        mode: "0644"
+
+- name: Write admin password files from vars
+  ansible.builtin.copy:
+    content: "{{ item.value }}"
+    dest: >-
+      {{ instance_path }}/admin-password_{{ item.key
+         | regex_replace('^admin_password_', '') }}
+    mode: "0600"
+  loop: >-
+    {{ _render_vars | dict2items
+       | selectattr('key', 'match', '^admin_password_')
+       | list }}
+  loop_control:
+    label: "{{ item.key }}"
+  no_log: true


### PR DESCRIPTION
## Summary
- Extract the render logic from ``pull_compose.yml`` into a new ``roles/gitops/tasks/render_compose.yml`` that operates purely on on-disk templates and vars (no git involvement).
- Call it from ``roles/backup/tasks/restore.yml`` after file restoration but before restart, gated on the presence of ``.gitops-host``.
- Also regenerate Caddyfile via ``update_config.yml`` so the orchestrator sees the rendered values.

## Rationale
When a Compose-orchestrated gitops instance restores from a snapshot taken on a different host, the restored ``.env`` / ``wikis.yaml`` / ``Caddyfile`` have the SOURCE host's rendered values. Caddy tries to issue Let's Encrypt certs for the wrong FQDN, MediaWiki serves URLs to the wrong host, etc. This change re-renders against the target host's ``hosts/<name>/vars.yaml`` (plus the shared vars from #150 if present), so the instance comes up configured for its current host.

## Scope
- Compose only. Kubernetes restore uses ConfigMaps and is a different path; the K8s equivalent is a separate follow-up.
- Does not rely on the ``gitops pull`` fast-path change (which still exits early when git is up-to-date). Render is called unconditionally when ``.gitops-host`` exists.

## Test plan
- [ ] Non-gitops instance: restore unchanged (no render, no regen).
- [ ] Gitops instance restored from a snapshot taken on a different host: ``.env``, ``wikis.yaml``, and ``Caddyfile`` end up rendered with the target host's FQDN. Caddy's Let's Encrypt challenge succeeds.
- [ ] Admin password files are re-written from vars.

Fixes #142 (Compose path).