### PR TITLE
gitops status: fetch before reporting ahead/behind

### DIFF
--- a/roles/gitops/tasks/status_compose.yml
+++ b/roles/gitops/tasks/status_compose.yml
@@ -45,6 +45,16 @@
   register: _gops_unstaged
   changed_when: false
 
+# Fetch before comparing so ahead/behind reflects the actual remote,
+# not the stale local cache. Without this, 'status' happily reports
+# "Up to date with remote." while another host has already pushed.
+- name: Fetch from remote (for up-to-date comparison)
+  ansible.builtin.command:
+    cmd: git fetch
+    chdir: "{{ instance_path }}"
+  changed_when: false
+  ignore_errors: true  # OK if offline or no remote — fall back to cache
+
 - name: Check ahead/behind
   ansible.builtin.command:
     cmd: git rev-list --left-right --count HEAD...@{upstream}


### PR DESCRIPTION
## Summary
- Run ``git fetch`` before the ``git rev-list`` ahead/behind comparison so the reported state reflects the actual remote.
- ``ignore_errors`` preserves offline behavior (fall back to cached upstream).

## Test plan
- [ ] With a clean local and no remote divergence, status shows "Up to date with remote."
- [ ] After another host pushes, ``canasta gitops status`` now correctly reports "Behind remote by N commit(s)" instead of "Up to date".
- [ ] With no network, command still completes (may report stale info, but doesn't error).

Fixes #139.