### PR TITLE
backup restore: fix --snapshot latest silently failing (extra-var shadow)

### DIFF
--- a/roles/backup/tasks/restore.yml
+++ b/roles/backup/tasks/restore.yml
@@ -23,6 +23,11 @@
 # a second time picks up the safety snapshot just created (which is
 # internal and typically empty) instead of the user's most recent
 # real backup.
+#
+# Note: `snapshot` is passed via -e extra vars (precedence 22), which
+# shadows any set_fact (precedence 20). We resolve into a *new* fact
+# (`_resolved_snapshot`) and use that everywhere downstream instead of
+# trying to rebind `snapshot` itself.
 - name: Resolve 'latest' snapshot (excluding internal safety snapshots)
   when: snapshot == 'latest'
   block:
@@ -36,7 +41,7 @@
 
     - name: Pick latest non-safety snapshot
       ansible.builtin.set_fact:
-        snapshot: "{{ item.short_id }}"
+        _resolved_snapshot: "{{ item.short_id }}"
       loop: "{{ (_restic_result.stdout | from_json) | sort(attribute='time') }}"
       when: "'safety-before-restore' not in (item.tags | default([]))"
       loop_control:
@@ -47,7 +52,12 @@
         msg: >-
           No backup snapshots found (excluding safety-before-restore
           snapshots). Create a backup first with 'canasta backup create'.
-      when: snapshot == 'latest'
+      when: _resolved_snapshot is not defined
+
+- name: Set effective snapshot ID
+  ansible.builtin.set_fact:
+    _resolved_snapshot: "{{ snapshot }}"
+  when: _resolved_snapshot is not defined
 
 - name: Take safety backup before restore
   when: not (skip_safety_backup | default(false) | bool)
@@ -93,7 +103,7 @@
                   - sh
                   - -c
                   - |
-                    restic --cache-dir /tmp/restic-cache restore {{ snapshot }} --target / && \
+                    restic --cache-dir /tmp/restic-cache restore {{ _resolved_snapshot }} --target / && \
                     touch /tmp/restore-done && \
                     sleep 3600
                 env:
@@ -195,7 +205,7 @@
   vars:
     backup_args:
       - "restore"
-      - "{{ snapshot }}"
+      - "{{ _resolved_snapshot }}"
       - "--target"
       - "/"
   when: instance_orchestrator | default('compose') == 'compose'
@@ -295,4 +305,4 @@
 
 - name: Display result
   ansible.builtin.debug:
-    msg: "Restored from snapshot {{ snapshot }}."
+    msg: "Restored from snapshot {{ _resolved_snapshot }}."


### PR DESCRIPTION
## Problem

The filter added in #147 to skip ``safety-before-restore`` snapshots doesn't work: ``snapshot`` is passed via canasta.py's ``-e`` extra vars (precedence 22), which shadow any ``set_fact`` (precedence 20). So the filter's ``set_fact: snapshot: <id>`` is ignored on every subsequent read — restic still receives "latest", and the fail task also sees "latest" and fires.

Observed with ``canasta -v backup restore -i pge --snapshot latest`` after a safety snapshot had been created: first loop iteration matched the oldest real snapshot (set_fact ran), all subsequent iterations skipped because block-level ``when: snapshot == 'latest'`` still evaluated True (extra var won), and finally the fail task fired with "No backup snapshots found" even though the filter had matched.

## Fix

Resolve the filtered ID into a separate fact ``_resolved_snapshot`` and use that in the three downstream places (the restic restore command on Compose and K8s, plus the final "Restored from" message). Outside the 'latest' block, copy the explicit snapshot ID into ``_resolved_snapshot`` so both code paths use the same variable.

## Test plan
- [x] Reproduced the bug on a test VM: "No backup snapshots found" despite real snapshots existing.
- [ ] With this fix, ``canasta backup restore -i pge --snapshot latest`` resolves to the newest non-safety snapshot and actually restores it.
- [ ] ``canasta backup restore -i pge --snapshot <explicit-id>`` still works unchanged.