### PR TITLE
CLI: list subcommands when a group is invoked without one

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -441,6 +441,31 @@ def build_parser(data):
     return parser
 
 
+def print_subcommand_help(group, data):
+    """Print subcommands available for a group with one-line descriptions."""
+    cmd_index = {c["name"]: c for c in data["commands"]}
+    subcmds = SUBCOMMAND_GROUPS.get(group, [])
+    nested = NESTED_SUBCOMMAND_GROUPS.get(group, {})
+
+    rows = []
+    for sub in subcmds:
+        internal = "%s_%s" % (group, internal_name(sub))
+        desc = cmd_index.get(internal, {}).get("description", "") or ""
+        rows.append((sub, desc))
+    # Include nested subcommand names (e.g., 'schedule' under 'backup')
+    for nested_name in nested:
+        if nested_name not in subcmds:
+            # The nested group itself; describe it succinctly
+            rows.append((nested_name, "(subcommand group; run 'canasta %s %s' for subcommands)" % (group, nested_name)))
+
+    width = max((len(r[0]) for r in rows), default=0)
+    print("Available '%s' subcommands:" % group)
+    for name, desc in rows:
+        print("  %-*s  %s" % (width, name, desc))
+    print("")
+    print("Run 'canasta %s <subcommand> --help' for details." % group)
+
+
 def resolve_command_name(args):
     """Resolve the internal command name from parsed args."""
     cmd = args.command
@@ -716,6 +741,11 @@ def main():
     # Verify command exists in definitions
     all_cmd_names = {c["name"] for c in data["commands"]}
     if command_name not in all_cmd_names:
+        # Subcommand group invoked without a subcommand (e.g. 'canasta gitops'):
+        # list the subcommands with descriptions instead of erroring.
+        if command_name in SUBCOMMAND_GROUPS:
+            print_subcommand_help(command_name, data)
+            sys.exit(2)
         print("Unknown command: %s" % command_name, file=sys.stderr)
         sys.exit(1)
 

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -868,3 +868,28 @@ class TestPathResolution:
         extra = self._get_vars(result)
         assert extra["path"] == os.path.expanduser("~")
         assert not extra["path"].startswith("~")
+
+
+class TestSubcommandGroupHelp:
+    """Invoking a subcommand group with no subcommand should list
+    subcommands, not error with 'Unknown command'."""
+
+    def test_prints_subcommands_for_gitops(self, data, capsys):
+        canasta_cli.print_subcommand_help("gitops", data)
+        out = capsys.readouterr().out
+        assert "Available 'gitops' subcommands:" in out
+        assert "init" in out
+        assert "fix-submodules" in out
+        assert "Run 'canasta gitops <subcommand> --help'" in out
+
+    def test_prints_subcommands_for_config(self, data, capsys):
+        canasta_cli.print_subcommand_help("config", data)
+        out = capsys.readouterr().out
+        assert "regenerate" in out
+        assert "Regenerate rendered config" in out
+
+    def test_prints_nested_group_marker_for_backup(self, data, capsys):
+        canasta_cli.print_subcommand_help("backup", data)
+        out = capsys.readouterr().out
+        assert "schedule" in out
+        assert "subcommand group" in out


### PR DESCRIPTION
## Summary
- When a subcommand group name (e.g. `gitops`, `config`, `backup`) is invoked without a subcommand, print a table of available subcommands + descriptions instead of the confusing "Unknown command: gitops" error.
- Pulls descriptions from `meta/command_definitions.yml`. Nested groups like `backup schedule` are marked so users know to drill down.
- Exits 2 (argparse's "missing required arg" convention) so shell pipelines can distinguish help-invocation from an actual error.

## Example
```
$ canasta gitops
Available 'gitops' subcommands:
  init            Initialize git-based configuration management
  join            Join an existing gitops repository
  add             Add configuration changes to git
  ...
  fix-submodules  Fix gitops submodules
  sync            Trigger an immediate Argo CD sync (kubernetes only)

Run 'canasta gitops <subcommand> --help' for details.
```

## Test plan
- [x] Unit tests: `TestSubcommandGroupHelp` covers gitops, config, and backup (nested).
- [x] Manual: `canasta gitops`, `canasta config`, `canasta backup`, `canasta host` all print the listing.

Fixes #172.