### PR TITLE
Fix 'wiki is undefined' Jinja crash in maintenance/sitemap tasks

### DIFF
--- a/roles/maintenance/tasks/extension.yml
+++ b/roles/maintenance/tasks/extension.yml
@@ -12,7 +12,7 @@
 
 - name: Build extension script command
   ansible.builtin.set_fact:
-    _ext_cmd: "php extensions/{{ script_args }}{{ (wiki is defined and wiki != '') | ternary(' --wiki=' + (wiki | quote), '') }}"
+    _ext_cmd: "php extensions/{{ script_args }}{{ ((wiki | default('')) != '') | ternary(' --wiki=' + (wiki | quote), '') }}"
 
 - name: Run extension maintenance script
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"

--- a/roles/maintenance/tasks/script.yml
+++ b/roles/maintenance/tasks/script.yml
@@ -12,7 +12,7 @@
 
 - name: Build script command
   ansible.builtin.set_fact:
-    _script_cmd: "php maintenance/{{ script_args }}{{ (wiki is defined and wiki != '') | ternary(' --wiki=' + (wiki | quote), '') }}"
+    _script_cmd: "php maintenance/{{ script_args }}{{ ((wiki | default('')) != '') | ternary(' --wiki=' + (wiki | quote), '') }}"
 
 - name: Run maintenance script
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"

--- a/roles/maintenance/tasks/update.yml
+++ b/roles/maintenance/tasks/update.yml
@@ -17,7 +17,7 @@
 - name: Determine wikis to update
   ansible.builtin.set_fact:
     _update_wikis: >-
-      {{ (wiki is defined and wiki != '')
+      {{ ((wiki | default('')) != '')
          | ternary([wiki], _maint_wikis.wiki_ids) }}
 
 - name: Run update.php for each wiki

--- a/roles/sitemap/tasks/generate.yml
+++ b/roles/sitemap/tasks/generate.yml
@@ -21,7 +21,7 @@
 
 - name: Determine wikis for sitemap generation
   ansible.builtin.set_fact:
-    _sitemap_targets: "{{ (wiki is defined and wiki != '') | ternary([wiki], _sitemap_wikis.wiki_ids) }}"
+    _sitemap_targets: "{{ ((wiki | default('')) != '') | ternary([wiki], _sitemap_wikis.wiki_ids) }}"
 
 - name: Create sitemap directories and generate for each wiki
   ansible.builtin.include_tasks: _generate_single.yml

--- a/roles/sitemap/tasks/remove.yml
+++ b/roles/sitemap/tasks/remove.yml
@@ -14,7 +14,7 @@
 
 - name: Determine wikis for sitemap removal
   ansible.builtin.set_fact:
-    _sitemap_targets: "{{ (wiki is defined and wiki != '') | ternary([wiki], _sitemap_wikis.wiki_ids) }}"
+    _sitemap_targets: "{{ ((wiki | default('')) != '') | ternary([wiki], _sitemap_wikis.wiki_ids) }}"
 
 - name: Remove sitemaps for each wiki
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"


### PR DESCRIPTION
## Summary
- Replace `(wiki is defined and wiki != '')` with `((wiki | default('')) != '')` in 5 files.
- Fixes the `'wiki' is undefined` crash when running e.g. `canasta maintenance script -i <id> update.php` without `-w`.

## Root cause
Jinja's boolean operators don't reliably short-circuit inside expression values — the `!= ''` comparison evaluates even when the `is defined` check is false, raising `UndefinedError`. Ansible `when:` clauses handle this correctly; the affected uses are all in `set_fact` values.

## Test plan
- [ ] `canasta maintenance script -i <id> update.php` (no `-w`) — runs without crashing.
- [ ] `canasta maintenance script -i <id> -w mywiki update.php` — scopes correctly to `mywiki`.
- [ ] `canasta sitemap generate -i <id>` (no `-w`) — generates for all wikis.
- [ ] `canasta sitemap remove -i <id> -w mywiki` — targets the one wiki.

Fixes #175.