### PR TITLE
Upgrade: bump Compose CANASTA_IMAGE tag to match CANASTA_VERSION

### DIFF
--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -116,6 +116,32 @@
         dest: "{{ instance_path }}/values.yaml"
         mode: "0644"
 
+# --- Update Compose CANASTA_IMAGE tag ---
+# Match Go CLI behavior: bump the tag if it's the default ghcr.io image,
+# leave it alone if user set a custom/local-build image.
+- name: Update Compose image tag
+  when:
+    - instance_orchestrator | default('compose') == 'compose'
+    - _upgrade_inst.instance.buildFrom | default('') == ''
+  block:
+    - name: Read current CANASTA_IMAGE
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read
+        key: CANASTA_IMAGE
+      register: _upgrade_current_image
+
+    - name: Update CANASTA_IMAGE to latest default tag
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: set
+        key: CANASTA_IMAGE
+        value: "{{ canasta_default_image }}"
+      when:
+        - _upgrade_current_image.found
+        - _upgrade_current_image.value | regex_search('^ghcr\\.io/canastawiki/canasta:')
+        - _upgrade_current_image.value != canasta_default_image
+
 # --- Pull and restart ---
 - name: Report pulling images
   ansible.builtin.debug:


### PR DESCRIPTION
## Summary
- During `canasta upgrade`, if a Compose instance's `CANASTA_IMAGE` in `.env` matches the default registry (`ghcr.io/canastawiki/canasta:*`), update the tag to the current `CANASTA_VERSION`.
- Skip if: not Compose, or `BuildFrom` is set (local build), or the image is from a non-default registry (user set it intentionally).

## Why
Compose instances created on older Canasta versions (e.g., 3.5.3) stayed pinned to that tag forever. `canasta upgrade` pulled the same cached image and reported "already up to date." The K8s path already bumps the tag in `values.yaml`; this adds the equivalent for `.env`.

## Test plan
- [ ] Instance with `CANASTA_IMAGE=ghcr.io/canastawiki/canasta:3.5.3`: after upgrade, `.env` shows `3.5.5` (or whatever CANASTA_VERSION is).
- [ ] Instance with `CANASTA_IMAGE=myregistry.example.com/canasta:custom`: unchanged after upgrade.
- [ ] Instance with `BuildFrom` set: CANASTA_IMAGE unchanged (local build path).

Fixes #177.
