### PR TITLE
Fix upgrade CI: use 'is match' for boolean when condition

### DIFF
--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -139,7 +139,7 @@
         value: "{{ canasta_default_image }}"
       when:
         - _upgrade_current_image.found
-        - _upgrade_current_image.value | regex_search('^ghcr\\.io/canastawiki/canasta:')
+        - _upgrade_current_image.value is match('^ghcr\\.io/canastawiki/canasta:')
         - _upgrade_current_image.value != canasta_default_image
 
 # --- Pull and restart ---


### PR DESCRIPTION
Regression from #178. `regex_search` returns a string (truthy but not boolean); Ansible's strict mode rejects it in `when:`. Replace with `is match()` which returns a proper boolean.