### PR TITLE
Fix upgrade not restarting after pulling new images

### DIFF
--- a/roles/orchestrator/tasks/pull.yml
+++ b/roles/orchestrator/tasks/pull.yml
@@ -1,13 +1,44 @@
 ---
 # Pull latest images for an instance.
 # Input: instance_path, instance_orchestrator
+# Output: _pull_changed (bool) — whether the Canasta image ID changed.
+
+- name: Read CANASTA_IMAGE from .env
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read
+    key: CANASTA_IMAGE
+  register: _pull_image_env
+  when: instance_orchestrator | default('compose') == 'compose'
+
+- name: Get image ID before pull
+  ansible.builtin.command:
+    cmd: "docker image inspect {{ _pull_image_env.value }} --format {% raw %}{{.Id}}{% endraw %}"
+  register: _pre_pull_id
+  changed_when: false
+  ignore_errors: true
+  when: instance_orchestrator | default('compose') == 'compose'
 
 - name: Pull images (Compose)
   ansible.builtin.command:
     cmd: "docker compose pull --ignore-buildable --ignore-pull-failures"
     chdir: "{{ instance_path }}"
-  register: _pull_result
-  changed_when: "'Pull complete' in (_pull_result.stderr | default(''))"
+  changed_when: false
+  when: instance_orchestrator | default('compose') == 'compose'
+
+- name: Get image ID after pull
+  ansible.builtin.command:
+    cmd: "docker image inspect {{ _pull_image_env.value }} --format {% raw %}{{.Id}}{% endraw %}"
+  register: _post_pull_id
+  changed_when: false
+  ignore_errors: true
+  when: instance_orchestrator | default('compose') == 'compose'
+
+- name: Detect image changes
+  ansible.builtin.set_fact:
+    _pull_changed: >-
+      {{ (_pre_pull_id.stdout | default('')) !=
+         (_post_pull_id.stdout | default('')) }}
   when: instance_orchestrator | default('compose') == 'compose'
 
 # Kubernetes: image pulls happen automatically during helm upgrade.

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -156,7 +156,7 @@
 
 - name: Check if new images were pulled (Compose)
   ansible.builtin.set_fact:
-    _images_updated: "{{ _pull_result is defined and _pull_result is changed }}"
+    _images_updated: "{{ _pull_changed | default(false) | bool }}"
 
 - name: Restart containers
   when: _images_updated | bool


### PR DESCRIPTION
## Problem

`canasta upgrade` pulled new Canasta images but didn't restart containers. The change detection in `pull.yml` used:

```yaml
changed_when: "'Pull complete' in (_pull_result.stderr | default(''))"
```

Newer Docker Compose versions changed their pull output format — `"Pull complete"` per-layer messages were replaced with progress bars and `"Pulled"` summaries. The string match returned false even after downloading new images → `_images_updated = false` → no restart.

Observed: `canasta upgrade` pulled 3.5.6 for kamins and pge, reported "Already up to date — no restart needed", left containers running 3.5.5.

## Fix

Replace the fragile string match with a digest comparison:

1. Snapshot `docker compose images --format json` before pull.
2. Run pull.
3. Snapshot again after pull.
4. If the JSON differs → images changed → restart.

## Test plan
- [ ] Instance on old image: `canasta upgrade` pulls new image, detects change, restarts.
- [ ] Instance already on latest: `canasta upgrade` pulls (no-op), no change detected, no restart.
