### PR TITLE
Fix canasta upgrade self-update skipping on native installs with BUILD_COMMIT

### DIFF
--- a/playbooks/_pull_latest_playbooks.yml
+++ b/playbooks/_pull_latest_playbooks.yml
@@ -9,39 +9,23 @@
   ansible.builtin.set_fact:
     _repo_dir: "{{ playbook_dir }}"
 
-- name: Check for baked-in Docker build marker
+- name: Check if playbook directory is a git repo
   ansible.builtin.stat:
-    path: "{{ _repo_dir }}/BUILD_COMMIT"
+    path: "{{ _repo_dir }}/.git"
   delegate_to: localhost
   vars:
     ansible_connection: local
     ansible_python_interpreter: "{{ ansible_playbook_python }}"
-  register: _docker_build
+  register: _is_git_repo_early
 
 - name: Report Docker image already updated
   ansible.builtin.debug:
     msg: "Canasta CLI updated to the latest Docker image."
-  when: _docker_build.stat.exists
+  when: not (_is_git_repo_early.stat.exists | default(false))
 
 - name: Self-update from git checkout
-  when: not _docker_build.stat.exists
+  when: _is_git_repo_early.stat.exists | default(false)
   block:
-    - name: Check if playbook directory is a git repo
-      ansible.builtin.stat:
-        path: "{{ _repo_dir }}/.git"
-      delegate_to: localhost
-      vars:
-        ansible_connection: local
-        ansible_python_interpreter: "{{ ansible_playbook_python }}"
-      register: _is_git_repo
-
-    - name: Fail if not a git repository
-      ansible.builtin.fail:
-        msg: >-
-          Canasta-Ansible is not installed from a git repository ({{ _repo_dir }}).
-          Clone the repo first: git clone https://github.com/CanastaWiki/Canasta-Ansible.git
-      when: not _is_git_repo.stat.exists
-
     - name: Get current version
       ansible.builtin.slurp:
         src: "{{ _repo_dir }}/VERSION"


### PR DESCRIPTION
## Problem

Native installs that followed the documented `sudo make build-info` step have a `BUILD_COMMIT` file. The self-update logic in `_pull_latest_playbooks.yml` treated this as a "Docker image" marker and skipped `git pull` entirely. Result: `canasta upgrade` on native installs never pulled new code — CANASTA_VERSION stayed stale, instances never got bumped.

## Fix

Use `.git` directory presence as the signal instead of `BUILD_COMMIT` absence. `.git` exists = native git checkout = self-update via `git pull`. No `.git` = Docker image = skip (docker pull handles it).

## Test plan
- [ ] Native install with BUILD_COMMIT + .git: `canasta upgrade` does `git pull`, picks up new CANASTA_VERSION, bumps instances.
- [ ] Docker install (no .git): `canasta upgrade` reports "Docker image already updated", skips git pull.