### PR TITLE
Upgrade: restart when running containers don't match configured CANASTA_IMAGE

### DIFF
--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -154,9 +154,56 @@
     tasks_from: pull.yml
   when: _upgrade_inst.instance.buildFrom | default('') == ''
 
-- name: Check if new images were pulled (Compose)
+- name: Check if new images were pulled
   ansible.builtin.set_fact:
     _images_updated: "{{ _pull_changed | default(false) | bool }}"
+
+# Also check if the running web container's image differs from what
+# .env configures. Catches the case where a prior upgrade pulled the
+# new image but failed to restart (e.g., due to the old detection bug).
+- name: Check running container image vs configured (Compose)
+  when:
+    - instance_orchestrator | default('compose') == 'compose'
+    - not (_images_updated | bool)
+  block:
+    - name: Get running web container image ID
+      ansible.builtin.shell:
+        cmd: >-
+          docker compose ps web --format {% raw %}'{{.Image}}'{% endraw %}
+        chdir: "{{ instance_path }}"
+      register: _running_image
+      changed_when: false
+      ignore_errors: true
+
+    - name: Read configured CANASTA_IMAGE
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read
+        key: CANASTA_IMAGE
+      register: _configured_image
+
+    - name: Get configured image ID
+      ansible.builtin.command:
+        cmd: "docker image inspect {{ _configured_image.value }} --format {% raw %}{{.Id}}{% endraw %}"
+      register: _configured_id
+      changed_when: false
+      ignore_errors: true
+
+    - name: Get running image ID
+      ansible.builtin.command:
+        cmd: "docker image inspect {{ _running_image.stdout | trim }} --format {% raw %}{{.Id}}{% endraw %}"
+      register: _running_id
+      changed_when: false
+      ignore_errors: true
+      when: _running_image is succeeded
+
+    - name: Flag restart if running image differs from configured
+      ansible.builtin.set_fact:
+        _images_updated: true
+      when:
+        - _configured_id is succeeded
+        - _running_id is succeeded
+        - (_configured_id.stdout | default('')) != (_running_id.stdout | default(''))
 
 - name: Restart containers
   when: _images_updated | bool


### PR DESCRIPTION
## Problem

If a prior `canasta upgrade` pulled a new image but failed to restart (due to the old pull-detection bug), subsequent upgrades saw the image already cached → "Already up to date — no restart needed." Containers ran the old image indefinitely.

The upgrade had no way to detect that the **running** containers didn't match the **configured** image.

## Fix

After the pull-based change detection, compare the running web container's Docker image ID against the configured `CANASTA_IMAGE`'s image ID. If they differ → restart. This catches any stale-container state regardless of cause.

## Test plan
- [ ] Instance with stale containers (running 3.5.5, .env says 3.5.6, 3.5.6 cached): upgrade detects mismatch → restarts.
- [ ] Instance already on correct image: no unnecessary restart.
- [ ] Instance with newly pulled image (normal upgrade): restarts via the pull detection path (existing behavior unchanged).
