### PR TITLE
Upgrade: pull configured image and rebuild buildable services

### DIFF
--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -182,6 +182,14 @@
         key: CANASTA_IMAGE
       register: _configured_image
 
+    - name: Pull configured image if not on disk (handles buildable services skipped by docker compose pull)
+      ansible.builtin.command:
+        cmd: "docker pull {{ _configured_image.value }}"
+      register: _ensure_pull
+      changed_when: "'Downloaded newer image' in (_ensure_pull.stdout | default(''))"
+      ignore_errors: true
+      when: _configured_image.found
+
     - name: Get configured image ID
       ansible.builtin.command:
         cmd: "docker image inspect {{ _configured_image.value }} --format {% raw %}{{.Id}}{% endraw %}"
@@ -204,6 +212,16 @@
         - _configured_id is succeeded
         - _running_id is succeeded
         - (_configured_id.stdout | default('')) != (_running_id.stdout | default(''))
+
+    - name: Rebuild buildable services if image was bumped
+      ansible.builtin.command:
+        cmd: "docker compose build --build-arg CANASTA_IMAGE={{ _configured_image.value }} web"
+        chdir: "{{ instance_path }}"
+      changed_when: true
+      ignore_errors: true
+      when:
+        - _images_updated | bool
+        - _configured_image.found
 
 - name: Restart containers
   when: _images_updated | bool


### PR DESCRIPTION
## Problem
`docker compose pull --ignore-buildable` skips services with a `build:` directive. Instances using a custom Dockerfile (`FROM ${CANASTA_IMAGE}`) never get the new base image, so the stale-container check fails (configured image not on disk).

## Fix
1. In the stale-container check, `docker pull` the configured image if not on disk.
2. After detecting a mismatch, `docker compose build` the web service to rebuild with the new base image.

## Test plan
- [ ] Instance with `Dockerfile.custom` and `build:` in override: upgrade pulls new base, detects mismatch, rebuilds, restarts.
- [ ] Instance without `build:` directive: existing pull path works unchanged.

Fixes #187.