### PR TITLE
gitops join: render .env from templates to pick up shared vars

### DIFF
--- a/roles/gitops/tasks/join.yml
+++ b/roles/gitops/tasks/join.yml
@@ -273,7 +273,21 @@
     dest: "{{ instance_path }}/.gitops-host"
     mode: "0644"
 
-# --- Step 9: Update submodules ---
+# --- Step 9: Render .env and wikis.yaml from templates + vars ---
+# Join builds host vars from the fresh create's .env, but doesn't
+# re-render .env from the template. Without this, shared vars from
+# hosts/_shared/vars.yaml (backup creds, etc.) never flow into .env.
+- name: Render .env and wikis.yaml from templates
+  ansible.builtin.include_role:
+    name: gitops
+    tasks_from: render_compose.yml
+
+- name: Regenerate orchestrator config (Caddyfile)
+  ansible.builtin.include_role:
+    name: orchestrator
+    tasks_from: update_config.yml
+
+# --- Step 10: Update submodules ---
 - name: Update submodules
   ansible.builtin.command:
     cmd: "git submodule update --init --recursive"
@@ -281,7 +295,7 @@
   changed_when: true
   ignore_errors: true  # OK if no submodules configured
 
-# --- Step 10: Commit and push ---
+# --- Step 11: Commit and push ---
 - name: Stage all changes
   ansible.builtin.command:
     cmd: "git add -A"


### PR DESCRIPTION
## Problem
After `canasta gitops join`, `.env` was missing all values from `hosts/_shared/vars.yaml` (backup creds, AWS keys). `canasta backup restore` failed immediately with "Please specify repository location."

Join read the current `.env` to build `hosts/<name>/vars.yaml`, but never re-rendered `.env` from `env.template` + merged vars. The `_shared/vars.yaml` merge (PR #150) only existed in `pull_compose.yml` and `render_compose.yml` — join had its own inline flow that skipped it.

## Fix
Call `render_compose.yml` + `update_config.yml` after writing host vars and `.gitops-host`, before committing. This renders `.env` and `wikis.yaml` with the full merged context (host + shared vars) and regenerates the Caddyfile.

## Test plan
- [ ] `canasta gitops join` on a fresh instance with `hosts/_shared/vars.yaml` containing backup creds: `.env` includes RESTIC_REPOSITORY, AWS_* after join — no manual append needed.
- [ ] `canasta backup restore` works immediately after join without intervention.