### PR TITLE
Fix CWD-based instance resolution: pass host PWD, reject empty IDs

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -81,6 +81,11 @@ MOUNTS=(
     -e "HOME=$HOME"
     -v "$(pwd)":"$(pwd)"
     -w "$(pwd)"
+    # Pass the host's real PWD so playbooks can resolve instances by
+    # current directory. Inside the container, $PWD is the container's
+    # working directory — which may differ from the host path after
+    # Docker remaps it.
+    -e "CANASTA_HOST_PWD=$(pwd)"
     --user "$(id -u):$(id -g)"
 )
 

--- a/playbooks/export.yml
+++ b/playbooks/export.yml
@@ -24,7 +24,7 @@
 
 - name: Resolve output path
   ansible.builtin.set_fact:
-    _export_file: "{{ _export_raw if _export_raw.startswith('/') else lookup('env', 'PWD') + '/' + _export_raw }}"
+    _export_file: "{{ _export_raw if _export_raw.startswith('/') else (lookup('env', 'CANASTA_HOST_PWD') | default(lookup('env', 'PWD'), true)) + '/' + _export_raw }}"
 
 - name: Check if gzip requested
   ansible.builtin.set_fact:

--- a/roles/common/tasks/resolve_instance.yml
+++ b/roles/common/tasks/resolve_instance.yml
@@ -73,7 +73,7 @@
   block:
     - name: Look up by PWD
       canasta_registry:
-        path: "{{ lookup('env', 'PWD') }}"
+        path: "{{ lookup('env', 'CANASTA_HOST_PWD') | default(lookup('env', 'PWD'), true) }}"
         state: query_by_path
       register: _pwd_lookup
 

--- a/roles/delete/tasks/main.yml
+++ b/roles/delete/tasks/main.yml
@@ -14,7 +14,7 @@
   block:
     - name: Look up instance by path
       canasta_registry:
-        path: "{{ lookup('env', 'PWD') }}"
+        path: "{{ lookup('env', 'CANASTA_HOST_PWD') | default(lookup('env', 'PWD'), true) }}"
         state: query_by_path
       delegate_to: localhost
       vars:
@@ -28,7 +28,9 @@
         msg: >-
           No Canasta instance found for the current directory.
           Provide --id explicitly or run from inside an instance directory.
-      when: _delete_pwd_query is failed
+      when: >-
+        _delete_pwd_query is failed
+        or (_delete_pwd_query.instance.id | default('')) == ''
 
     - name: Use resolved ID
       ansible.builtin.set_fact:

--- a/tests/unit/test_canasta_docker.py
+++ b/tests/unit/test_canasta_docker.py
@@ -394,3 +394,23 @@ class TestDatabaseFileMount:
             "database file under cwd should not be double-mounted, "
             "found: %s" % v_mounts
         )
+
+
+class TestHostPWDEnvVar:
+    """Verify canasta-docker passes CANASTA_HOST_PWD into the container."""
+
+    def test_canasta_host_pwd_is_set(self):
+        argv, _ = run_dry(["version"])
+        env_args = [
+            argv[i + 1] for i, a in enumerate(argv)
+            if a == "-e" and i + 1 < len(argv)
+            and argv[i + 1].startswith("CANASTA_HOST_PWD=")
+        ]
+        assert env_args, (
+            "expected -e CANASTA_HOST_PWD=... in argv:\n%s"
+            % "\n".join(argv)
+        )
+        val = env_args[0].split("=", 1)[1]
+        assert val and os.path.isabs(val), (
+            "CANASTA_HOST_PWD should be an absolute path, got: %s" % val
+        )


### PR DESCRIPTION
## Summary
- **canasta-docker**: exports `CANASTA_HOST_PWD=$(pwd)` so playbooks can resolve instances against the host filesystem
- **roles/delete/tasks/main.yml**: reads `CANASTA_HOST_PWD` (falls back to `PWD`); rejects empty IDs instead of proceeding with "unknown"
- **roles/common/tasks/resolve_instance.yml**: same `CANASTA_HOST_PWD` fallback
- **playbooks/export.yml**: same fallback for relative output paths
- **Test**: verifies `CANASTA_HOST_PWD` is set as an absolute path in dry-run

## Test plan
- [ ] canasta-docker: `canasta delete` from inside instance dir resolves the correct instance name
- [ ] canasta-native: same behavior (uses `PWD` directly — unchanged)
- [ ] `canasta delete` from a non-instance dir without `-i`: clear error message, not "unknown"

Fixes #191, #192.
