### PR TITLE
Improve 'instance already exists' error message (rebased #127)

### DIFF
--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -18,7 +18,7 @@
 
 - name: Fail early if instance already exists
   ansible.builtin.fail:
-    msg: "Instance '{{ id }}' already exists at {{ _pre_check.instance.path }}"
+    msg: "Instance '{{ id }}' already exists in local config\nHost: {{ _pre_check.instance.host }}\nPath: {{ _pre_check.instance.path }}"
   when: _pre_check is succeeded
 
 - name: Create Canasta instance

--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -18,7 +18,11 @@
 
 - name: Fail early if instance already exists
   ansible.builtin.fail:
-    msg: "Instance '{{ id }}' already exists in local config\nHost: {{ _pre_check.instance.host }}\nPath: {{ _pre_check.instance.path }}"
+    msg: >-
+      Instance '{{ id }}' already exists in the registry
+      (path: {{ _existing.instance.path }},
+      host: {{ _existing.instance.host | default('localhost') }}).
+      Run 'canasta delete --id {{ id }} --yes' to remove it first.
   when: _pre_check is succeeded
 
 - name: Create Canasta instance

--- a/playbooks/create.yml
+++ b/playbooks/create.yml
@@ -20,8 +20,8 @@
   ansible.builtin.fail:
     msg: >-
       Instance '{{ id }}' already exists in the registry
-      (path: {{ _existing.instance.path }},
-      host: {{ _existing.instance.host | default('localhost') }}).
+      (path: {{ _pre_check.instance.path }},
+      host: {{ _pre_check.instance.host | default('localhost') }}).
       Run 'canasta delete --id {{ id }} --yes' to remove it first.
   when: _pre_check is succeeded
 


### PR DESCRIPTION
## Summary

Rebased version of #127 (hexmode). Cherry-picked the two create.yml commits onto current main, dropping the stale CANASTA_VERSION and multi-node.md changes that were already merged.

Improves the "instance already exists" error message to show host, path, and a delete hint:

```
Instance 'X' already exists in the registry
(path: /root/X, host: root@example.com).
Run 'canasta delete --id X --yes' to remove it first.
```

Also fixed a variable name bug in the original (`_existing` → `_pre_check` to match the register).

Fixes #104. Supersedes #127.
