### PR TITLE
Add 'canasta install' command for dependency management

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -519,7 +519,7 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
 
     # Only pass target_host for commands that need it.
     # Other commands resolve the host from the instance registry.
-    HOST_COMMANDS = {"create", "list", "doctor"}
+    HOST_COMMANDS = {"create", "list", "doctor", "install"}
     if args.host and command_name in HOST_COMMANDS:
         extra_vars["target_host"] = args.host
     elif args.host and command_name not in HOST_COMMANDS:

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -269,6 +269,26 @@ commands:
     playbook: doctor.yml
     parameters: []
 
+  - name: install
+    description: "Install dependencies on the target host"
+    long_description: |
+      Install one or more dependencies on the target host. Supported
+      packages: docker, k3s, git-crypt. Multiple packages can be
+      specified in a single command.
+    examples:
+      - "canasta install docker"
+      - "canasta install k3s"
+      - "canasta install docker git-crypt"
+      - "canasta --host prod1.example.com install docker"
+    playbook: install.yml
+    parameters:
+      - name: packages
+        type: string
+        positional: true
+        multi: true
+        required: true
+        description: "Dependencies to install (docker, k3s, git-crypt)"
+
   - name: upgrade
     description: "Upgrade Canasta instances"
     long_description: |

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -1,0 +1,32 @@
+---
+# canasta install - Install dependencies on the target host.
+# Accepts one or more package names: docker, k3s, git-crypt.
+
+- name: Validate packages
+  ansible.builtin.fail:
+    msg: >-
+      Unknown package '{{ item }}'. Supported: docker, k3s, git-crypt.
+  when: item not in ['docker', 'k3s', 'git-crypt']
+  loop: "{{ packages.split() }}"
+
+- name: Install Docker
+  ansible.builtin.include_role:
+    name: install
+    tasks_from: docker.yml
+  when: "'docker' in packages.split()"
+
+- name: Install k3s
+  ansible.builtin.include_role:
+    name: install
+    tasks_from: k3s.yml
+  when: "'k3s' in packages.split()"
+
+- name: Install git-crypt
+  ansible.builtin.include_role:
+    name: install
+    tasks_from: git_crypt.yml
+  when: "'git-crypt' in packages.split()"
+
+- name: Report installed
+  ansible.builtin.debug:
+    msg: "Installed: {{ packages }}"

--- a/roles/install/tasks/docker.yml
+++ b/roles/install/tasks/docker.yml
@@ -30,6 +30,10 @@
   when: _docker_installed.rc != 0
   become: true
   block:
+    - name: Report installing Docker
+      ansible.builtin.debug:
+        msg: "Installing Docker (this may take a few minutes)..."
+
     - name: Gather OS and hardware facts
       ansible.builtin.setup:
         gather_subset:

--- a/roles/install/tasks/docker.yml
+++ b/roles/install/tasks/docker.yml
@@ -3,6 +3,10 @@
 # Supports Debian/Ubuntu (apt) and RHEL/CentOS/Fedora (dnf).
 # Idempotent — skips if Docker is already installed and running.
 
+- name: Capture real username before become
+  ansible.builtin.set_fact:
+    _install_user: "{{ ansible_user | default(ansible_env.USER) }}"
+
 - name: Check if Docker is already installed
   ansible.builtin.command:
     cmd: docker compose version
@@ -102,7 +106,7 @@
 
     - name: Add current user to docker group
       ansible.builtin.user:
-        name: "{{ ansible_user | default(ansible_env.USER) }}"
+        name: "{{ _install_user }}"
         groups: docker
         append: true
       ignore_errors: true

--- a/roles/install/tasks/docker.yml
+++ b/roles/install/tasks/docker.yml
@@ -5,7 +5,7 @@
 
 - name: Capture real username before become
   ansible.builtin.set_fact:
-    _install_user: "{{ ansible_user | default(ansible_env.USER) }}"
+    _install_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 
 - name: Check if Docker is already installed
   ansible.builtin.command:

--- a/roles/install/tasks/docker.yml
+++ b/roles/install/tasks/docker.yml
@@ -116,5 +116,5 @@
     - name: Report Docker installed
       ansible.builtin.debug:
         msg: >-
-          Docker installed successfully. Run 'newgrp docker' to use
-          Docker in your current shell session, or log out and back in.
+          Docker installed successfully. Log out and back in for
+          docker group membership to take effect.

--- a/roles/install/tasks/docker.yml
+++ b/roles/install/tasks/docker.yml
@@ -1,0 +1,114 @@
+---
+# Install Docker Engine and Docker Compose plugin.
+# Supports Debian/Ubuntu (apt) and RHEL/CentOS/Fedora (dnf).
+# Idempotent — skips if Docker is already installed and running.
+
+- name: Check if Docker is already installed
+  ansible.builtin.command:
+    cmd: docker compose version
+  register: _docker_installed
+  changed_when: false
+  ignore_errors: true
+
+- name: Skip if Docker already available
+  ansible.builtin.debug:
+    msg: "Docker is already installed."
+  when: _docker_installed.rc == 0
+
+- name: Install Docker
+  when: _docker_installed.rc != 0
+  become: true
+  block:
+    - name: Gather OS facts
+      ansible.builtin.setup:
+        gather_subset:
+          - distribution
+
+    - name: Install Docker (Debian/Ubuntu)
+      when: ansible_os_family == 'Debian'
+      block:
+        - name: Install prerequisites
+          ansible.builtin.apt:
+            name:
+              - ca-certificates
+              - curl
+              - gnupg
+            state: present
+            update_cache: true
+
+        - name: Create keyrings directory
+          ansible.builtin.file:
+            path: /etc/apt/keyrings
+            state: directory
+            mode: "0755"
+
+        - name: Download Docker GPG key
+          ansible.builtin.get_url:
+            url: "https://download.docker.com/linux/{{ ansible_distribution | lower }}/gpg"
+            dest: /etc/apt/keyrings/docker.asc
+            mode: "0644"
+
+        - name: Add Docker repository
+          ansible.builtin.apt_repository:
+            repo: >-
+              deb [arch={{ ansible_architecture | regex_replace('x86_64', 'amd64')
+                          | regex_replace('aarch64', 'arm64') }}
+                   signed-by=/etc/apt/keyrings/docker.asc]
+              https://download.docker.com/linux/{{ ansible_distribution | lower }}
+              {{ ansible_distribution_release }} stable
+            state: present
+            filename: docker
+
+        - name: Install Docker packages
+          ansible.builtin.apt:
+            name:
+              - docker-ce
+              - docker-ce-cli
+              - containerd.io
+              - docker-compose-plugin
+            state: present
+            update_cache: true
+
+    - name: Install Docker (RHEL/CentOS/Fedora)
+      when: ansible_os_family == 'RedHat'
+      block:
+        - name: Install prerequisites
+          ansible.builtin.dnf:
+            name:
+              - dnf-plugins-core
+            state: present
+
+        - name: Add Docker repository
+          ansible.builtin.command:
+            cmd: >-
+              dnf config-manager --add-repo
+              https://download.docker.com/linux/centos/docker-ce.repo
+          changed_when: true
+
+        - name: Install Docker packages
+          ansible.builtin.dnf:
+            name:
+              - docker-ce
+              - docker-ce-cli
+              - containerd.io
+              - docker-compose-plugin
+            state: present
+
+    - name: Enable and start Docker
+      ansible.builtin.systemd:
+        name: docker
+        state: started
+        enabled: true
+
+    - name: Add current user to docker group
+      ansible.builtin.user:
+        name: "{{ ansible_user | default(ansible_env.USER) }}"
+        groups: docker
+        append: true
+      ignore_errors: true
+
+    - name: Report Docker installed
+      ansible.builtin.debug:
+        msg: >-
+          Docker installed. You may need to log out and back in
+          for docker group membership to take effect.

--- a/roles/install/tasks/docker.yml
+++ b/roles/install/tasks/docker.yml
@@ -7,6 +7,13 @@
   ansible.builtin.set_fact:
     _install_user: "{{ ansible_user | default(lookup('env', 'USER')) }}"
 
+- name: Warn on unsupported platforms
+  ansible.builtin.fail:
+    msg: >-
+      'canasta install docker' is for Linux servers only. On macOS or
+      Windows, install Docker Desktop from https://www.docker.com/products/docker-desktop/
+  when: ansible_system | default(lookup('pipe', 'uname -s')) not in ['Linux']
+
 - name: Check if Docker is already installed
   ansible.builtin.command:
     cmd: docker compose version

--- a/roles/install/tasks/docker.yml
+++ b/roles/install/tasks/docker.yml
@@ -23,10 +23,11 @@
   when: _docker_installed.rc != 0
   become: true
   block:
-    - name: Gather OS facts
+    - name: Gather OS and hardware facts
       ansible.builtin.setup:
         gather_subset:
           - distribution
+          - hardware
 
     - name: Install Docker (Debian/Ubuntu)
       when: ansible_os_family == 'Debian'

--- a/roles/install/tasks/docker.yml
+++ b/roles/install/tasks/docker.yml
@@ -107,8 +107,14 @@
         append: true
       ignore_errors: true
 
+    - name: Verify Docker is accessible
+      ansible.builtin.command:
+        cmd: docker info
+      changed_when: false
+      become: true
+
     - name: Report Docker installed
       ansible.builtin.debug:
         msg: >-
-          Docker installed. You may need to log out and back in
-          for docker group membership to take effect.
+          Docker installed successfully. Run 'newgrp docker' to use
+          Docker in your current shell session, or log out and back in.

--- a/roles/install/tasks/git_crypt.yml
+++ b/roles/install/tasks/git_crypt.yml
@@ -1,0 +1,41 @@
+---
+# Install git-crypt on the target host.
+# Idempotent — skips if git-crypt is already installed.
+
+- name: Check if git-crypt is already installed
+  ansible.builtin.command:
+    cmd: git-crypt --version
+  register: _gitcrypt_installed
+  changed_when: false
+  ignore_errors: true
+
+- name: Skip if git-crypt already available
+  ansible.builtin.debug:
+    msg: "git-crypt is already installed."
+  when: _gitcrypt_installed.rc == 0
+
+- name: Install git-crypt
+  when: _gitcrypt_installed.rc != 0
+  become: true
+  block:
+    - name: Gather OS facts
+      ansible.builtin.setup:
+        gather_subset:
+          - distribution
+
+    - name: Install git-crypt (Debian/Ubuntu)
+      ansible.builtin.apt:
+        name: git-crypt
+        state: present
+        update_cache: true
+      when: ansible_os_family == 'Debian'
+
+    - name: Install git-crypt (RHEL/CentOS/Fedora)
+      ansible.builtin.dnf:
+        name: git-crypt
+        state: present
+      when: ansible_os_family == 'RedHat'
+
+    - name: Report git-crypt installed
+      ansible.builtin.debug:
+        msg: "git-crypt installed."

--- a/roles/install/tasks/git_crypt.yml
+++ b/roles/install/tasks/git_crypt.yml
@@ -18,6 +18,10 @@
   when: _gitcrypt_installed.rc != 0
   become: true
   block:
+    - name: Report installing git-crypt
+      ansible.builtin.debug:
+        msg: "Installing git-crypt..."
+
     - name: Gather OS facts
       ansible.builtin.setup:
         gather_subset:

--- a/roles/install/tasks/k3s.yml
+++ b/roles/install/tasks/k3s.yml
@@ -3,6 +3,10 @@
 # Reuses the existing k3s install logic from the orchestrator role.
 # Idempotent — skips if k3s is already running.
 
+- name: Report installing k3s
+  ansible.builtin.debug:
+    msg: "Installing k3s (this may take a few minutes)..."
+
 - name: Install k3s
   ansible.builtin.include_role:
     name: orchestrator

--- a/roles/install/tasks/k3s.yml
+++ b/roles/install/tasks/k3s.yml
@@ -1,0 +1,9 @@
+---
+# Install k3s on the target host.
+# Reuses the existing k3s install logic from the orchestrator role.
+# Idempotent — skips if k3s is already running.
+
+- name: Install k3s
+  ansible.builtin.include_role:
+    name: orchestrator
+    tasks_from: k8s_install_k3s.yml

--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -24,6 +24,16 @@
         cmd: "curl -sfL https://get.k3s.io | sh -"
       changed_when: true
 
+    - name: Make k3s kubeconfig readable (before verification)
+      ansible.builtin.file:
+        path: /etc/rancher/k3s/k3s.yaml
+        mode: "0644"
+      become: true
+      retries: 10
+      delay: 3
+      until: _chmod_result is succeeded
+      register: _chmod_result
+
     - name: Wait for k3s to be ready
       ansible.builtin.command:
         cmd: k3s kubectl cluster-info
@@ -70,15 +80,8 @@
   become: true
   when: _k8s_python.rc != 0
 
-# k3s writes its kubeconfig to /etc/rancher/k3s/k3s.yaml with mode
-# 600 (root-only). The k3s binary (used via the kubectl symlink)
-# reads this file by default. Make it readable so non-root users
-# can use kubectl without sudo.
-- name: Make k3s kubeconfig readable
-  ansible.builtin.file:
-    path: /etc/rancher/k3s/k3s.yaml
-    mode: "0644"
-  become: true
+# k3s kubeconfig permissions were already set in the install block
+# above (before the wait-for-ready check). No need to repeat here.
 
 - name: Ensure kubeconfig directory exists
   ansible.builtin.file:

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -893,3 +893,37 @@ class TestSubcommandGroupHelp:
         out = capsys.readouterr().out
         assert "schedule" in out
         assert "subcommand group" in out
+
+
+class TestInstallCommand:
+    """Test the 'canasta install' command parsing."""
+
+    def test_install_single_package(self, parser):
+        args = parser.parse_args(["install", "docker"])
+        assert args.command == "install"
+        assert args.packages == ["docker"]
+
+    def test_install_multiple_packages(self, parser):
+        args = parser.parse_args(["install", "docker", "k3s", "git-crypt"])
+        assert args.command == "install"
+        assert args.packages == ["docker", "k3s", "git-crypt"]
+
+    def test_install_with_host(self, data):
+        from argparse import Namespace
+        args = Namespace(
+            command="install", host="prod1", verbose=False,
+            packages=["docker"],
+        )
+        result = canasta_cli.build_ansible_args("ap", "install", args, data)
+        # install is in HOST_COMMANDS, so target_host should be set
+        import json
+        for i, arg in enumerate(result):
+            if arg == "-e" and i + 1 < len(result) and result[i + 1].startswith("@"):
+                with open(result[i + 1][1:]) as f:
+                    extra = json.load(f)
+                break
+        assert extra["target_host"] == "prod1"
+
+    def test_install_resolves_to_correct_command(self, parser):
+        args = parser.parse_args(["install", "docker"])
+        assert canasta_cli.resolve_command_name(args) == "install"


### PR DESCRIPTION
## Summary

New `canasta install` command that installs dependencies on the target host:

```bash
canasta install docker              # Docker + Compose
canasta install k3s                 # k3s (single-node K8s)
canasta install git-crypt           # git-crypt for gitops
canasta install docker k3s          # multiple in one command
canasta --host prod1 install docker # remote host
```

Idempotent — checks first, skips if present. Supports Debian/Ubuntu (apt) and RHEL/CentOS/Fedora (dnf).

## Design

Separates dependency installation from instance creation:
- `canasta doctor` — tells you what's missing
- `canasta install` — fixes it
- `canasta create` — creates the instance

## Files
- `meta/command_definitions.yml` — new `install` command with multi-value positional `packages`
- `canasta.py` — `install` added to `HOST_COMMANDS`
- `playbooks/install.yml` — dispatcher (validates packages, includes per-package tasks)
- `roles/install/tasks/docker.yml` — Docker + Compose installer (based on hexmode's #118, cleaned up)
- `roles/install/tasks/k3s.yml` — delegates to existing `k8s_install_k3s.yml`
- `roles/install/tasks/git_crypt.yml` — git-crypt installer
- Unit tests for argument parsing + host flag passthrough

## Test plan
- [ ] `canasta install docker` on a fresh Ubuntu host — installs Docker, starts daemon, adds user to docker group
- [ ] `canasta install docker` on a host with Docker — reports "already installed", no changes
- [ ] `canasta install docker k3s git-crypt` — installs all three in sequence
- [ ] `canasta --host remote install docker` — installs on remote host

Fixes #128. Addresses #101, #118, #124.
