### PR TITLE
k3s install: add skip message when already installed

### DIFF
--- a/roles/orchestrator/tasks/k8s_install_k3s.yml
+++ b/roles/orchestrator/tasks/k8s_install_k3s.yml
@@ -16,6 +16,11 @@
   changed_when: false
   ignore_errors: true  # OK if k3s not installed yet
 
+- name: Skip if k3s already running
+  ansible.builtin.debug:
+    msg: "k3s is already installed."
+  when: _k3s_running.rc == 0
+
 - name: Install k3s
   when: _k3s_running.rc != 0
   block:


### PR DESCRIPTION
Matches docker and git-crypt installers which print 'X is already installed.' when skipping. k3s silently skipped — now prints the same style message.