### PR TITLE
canasta-docker: stop passing all host groups to fix id noise on macOS

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -182,17 +182,17 @@ if ! grep -q "^[^:]*:[^:]*:$(id -u):" "$CANASTA_PASSWD" 2>/dev/null; then
     echo "canasta:x:$(id -u):$(id -g):canasta:$HOME:/bin/sh" >> "$CANASTA_PASSWD"
 fi
 MOUNTS+=(-v "$CANASTA_PASSWD:/etc/passwd:ro")
-# Add the docker socket GID and all of the host user's supplementary
-# groups so the container process has the same group memberships as the
-# host user (e.g., www-data for writing to container-owned files).
+# Add only the groups the container actually needs: the Docker socket
+# GID (for docker commands) and www-data (for writing to container-
+# created files). Previously all host supplementary groups were passed
+# via --group-add, but most (dialout, cdrom, floppy, etc.) don't exist
+# in the container's /etc/group, causing 'id -nG' to emit noisy
+# "cannot find name for group ID" warnings.
 if [[ -n "$DOCKER_SOCK_GID" ]]; then
     MOUNTS+=(--group-add "$DOCKER_SOCK_GID")
 fi
-for gid in $(id -G); do
-    [[ "$gid" == "$(id -g)" ]] && continue  # skip primary (already set)
-    [[ "$gid" == "$DOCKER_SOCK_GID" ]] && continue  # skip if already added
-    MOUNTS+=(--group-add "$gid")
-done
+# www-data is GID 33 on Debian-based images (which canasta-ansible uses).
+MOUNTS+=(--group-add 33)
 
 # Parse args to find instance path from --id/-i (look up in conf.json)
 # so we can mount it if it's outside the current directory.

--- a/canasta-docker
+++ b/canasta-docker
@@ -191,7 +191,7 @@ MOUNTS+=(-v "$CANASTA_PASSWD:/etc/passwd:ro")
 if [[ -n "$DOCKER_SOCK_GID" ]]; then
     MOUNTS+=(--group-add "$DOCKER_SOCK_GID")
 fi
-# www-data is GID 33 on Debian-based images (which canasta-ansible uses).
+# www-data is GID 33 in the canasta-docker container image (Debian-based).
 MOUNTS+=(--group-add 33)
 
 # Parse args to find instance path from --id/-i (look up in conf.json)


### PR DESCRIPTION
## Problem
On macOS, `canasta doctor` showed:
```
Error: dialout root man www-data 61 79 80 81 98 users 204 250 ...
id: cannot find name for group ID 61
id: cannot find name for group ID 79
...
```

All host supplementary groups were passed via `--group-add`, but most don't exist in the container's `/etc/group`.

## Fix
Only pass the two groups the container needs: Docker socket GID + www-data (GID 33). Drops the blanket `for gid in $(id -G)` loop.

## Test plan
- [ ] `canasta doctor` on macOS: no "cannot find name for group ID" noise
- [ ] Docker commands inside container still work (socket GID present)
- [ ] Container can write to www-data-owned files (GID 33 present)

Fixes #131.