### PR TITLE
canasta-docker: don't mount -p locally when --host targets a remote

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -300,6 +300,16 @@ to_abs_path() {
 # Relative paths are resolved to absolute form and the argument list
 # is rewritten in place so the container receives absolute paths
 # (Docker bind-mount destinations must be absolute).
+# Pre-scan for --host/-H to know if this is a remote operation.
+# When targeting a remote host, -p is a remote path that must NOT
+# be mounted locally (it may not exist on the local machine).
+_REMOTE_OP=false
+for _arg in "$@"; do
+    case "$_arg" in
+        -H|--host|-H=*|--host=*) _REMOTE_OP=true; break ;;
+    esac
+done
+
 ARGS=("$@")
 NEW_ARGS=()
 i=0
@@ -308,6 +318,13 @@ while [[ $i -lt ${#ARGS[@]} ]]; do
     case "$arg" in
         --path|-p)
             if [[ $((i+1)) -lt ${#ARGS[@]} ]]; then
+                if [[ "$_REMOTE_OP" == "true" ]]; then
+                    # Remote operation: pass path through without
+                    # mounting (it's a path on the remote host).
+                    NEW_ARGS+=("$arg" "${ARGS[$((i+1))]}")
+                    i=$((i+2))
+                    continue
+                fi
                 CREATE_PATH_ABS="$(to_abs_path "${ARGS[$((i+1))]}")"
                 NEW_ARGS+=("$arg" "$CREATE_PATH_ABS")
                 CWD="$(pwd)"


### PR DESCRIPTION
## Problem
`canasta create --host remote -p /home/admin` fails on Mac:
```
docker: Error response from daemon: mounts denied:
The path /home/admin is not shared from the host
```
The wrapper tries to bind-mount a remote-side path into the local container.

## Fix
Pre-scan for `--host`/`-H`. If present, pass `-p` through without resolving or mounting — it's a remote path.

## Test plan
- [ ] `canasta create --host remote -p /home/admin` — no mount error
- [ ] `canasta create -p ~/local` (no --host) — still mounts correctly

Fixes #132.