### PR TITLE
gitops push: respect staged state, fix misleading report

### DIFF
--- a/roles/gitops/tasks/push_compose.yml
+++ b/roles/gitops/tasks/push_compose.yml
@@ -35,12 +35,10 @@
       does not allow pushing. Only 'source' and 'both' roles can push.
   when: _push_role not in ['source', 'both']
 
-# --- Stage, commit, and push ---
-- name: Stage all changes
-  ansible.builtin.command:
-    cmd: "git add -A"
-    chdir: "{{ instance_path }}"
-  changed_when: false
+# --- Commit and push ---
+# Note: no 'git add -A' here. Users stage changes explicitly via
+# 'canasta gitops add' (which runs git add -A). Push only commits
+# what's already staged and pushes any unpushed commits.
 
 - name: Check for staged changes
   ansible.builtin.command:
@@ -76,5 +74,6 @@
 - name: Report result
   ansible.builtin.debug:
     msg: >-
-      {{ (_push_staged.rc != 0)
+      {{ (_push_staged.rc != 0 or
+          (_push_unpushed.stdout | default('') | trim | length > 0))
          | ternary('Configuration pushed.', 'No changes to push.') }}


### PR DESCRIPTION
## Problem
1. `push` ran `git add -A` before committing — silently expanding the user's carefully-staged files to include everything dirty.
2. "No changes to push." was reported even when commits were actually pushed (if nothing was newly staged this run).

## Fix
1. Removed `git add -A` from push. Users stage via `canasta gitops add`; push only commits what's already in the index.
2. Report checks both `_push_staged.rc` (new commit) and `_push_unpushed` (existing commits) — "Configuration pushed." if either is true.

## Test plan
- [ ] `git add FILE1` then `canasta gitops push`: only FILE1 in the commit, not other dirty files.
- [ ] Commit manually, then `canasta gitops push`: reports "Configuration pushed." (not "No changes").
- [ ] Nothing staged, nothing unpushed: reports "No changes to push."

Fixes #174.