### PR TITLE
backup restore: re-render gitops config after restore (Kubernetes)

### DIFF
--- a/roles/backup/tasks/restore_k8s.yml
+++ b/roles/backup/tasks/restore_k8s.yml
@@ -126,6 +126,20 @@
     name: restic-restore
     namespace: "{{ _k8s_namespace }}"
 
+# Re-render gitops templates after restore. The snapshot contains the
+# SOURCE host's rendered .env and config. On this host those need to
+# be re-rendered from templates + current host vars.
+- name: Detect gitops instance
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/.gitops-host"
+  register: _restore_k8s_gitops_stat
+
+- name: Re-render gitops templates against this host's vars
+  ansible.builtin.include_role:
+    name: gitops
+    tasks_from: render_compose.yml
+  when: _restore_k8s_gitops_stat.stat.exists | default(false)
+
 - name: Sync config to ConfigMaps
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/orchestrator/tasks/k8s_sync_config.yml


### PR DESCRIPTION
## Summary
Mirror of PR #151 (Compose). After K8s restore copies files from the snapshot, detect gitops and call `render_compose.yml` to re-render `.env`/`wikis.yaml` with the current host's vars before `k8s_sync_config.yml` pushes ConfigMaps. Otherwise the source host's FQDN and credentials end up in the cluster.

## Test plan
- [ ] K8s gitops instance restored from a different host: ConfigMaps reflect the target host's values.
- [ ] Non-gitops K8s instance: restore unchanged (no render step).

Fixes #158.