### PR TITLE
config set: propagate changes to gitops vars.yaml

### DIFF
--- a/roles/config/tasks/_update_gitops_var.yml
+++ b/roles/config/tasks/_update_gitops_var.yml
@@ -1,0 +1,45 @@
+---
+# Update the gitops vars.yaml for a single KEY=VALUE setting.
+# Input: _config_setting (str), _config_placeholder_map (dict),
+#        _config_host_raw, instance_path
+
+- name: Parse key and value
+  ansible.builtin.set_fact:
+    _ugv_key: "{{ _config_setting.split('=', 1)[0] }}"
+    _ugv_value: "{{ _config_setting.split('=', 1)[1] | default('') }}"
+
+- name: Look up placeholder name
+  ansible.builtin.set_fact:
+    _ugv_placeholder: "{{ _config_placeholder_map[_ugv_key] | default('') }}"
+
+- name: Update vars.yaml if key has a gitops placeholder
+  when: _ugv_placeholder != ''
+  block:
+    - name: Determine vars file path
+      ansible.builtin.set_fact:
+        _ugv_vars_file: >-
+          {{ instance_path }}/hosts/{{ _config_host_raw.content | b64decode | trim }}/vars.yaml
+
+    - name: Read current vars
+      ansible.builtin.slurp:
+        src: "{{ _ugv_vars_file }}"
+      register: _ugv_vars_raw
+
+    - name: Update var value
+      ansible.builtin.set_fact:
+        _ugv_updated_vars: >-
+          {{ (_ugv_vars_raw.content | b64decode | from_yaml)
+             | combine({_ugv_placeholder: _ugv_value}) }}
+
+    - name: Write updated vars.yaml
+      ansible.builtin.copy:
+        content: "{{ _ugv_updated_vars | to_nice_yaml(indent=2) }}"
+        dest: "{{ _ugv_vars_file }}"
+        mode: "0644"
+      no_log: true
+
+    - name: Stage updated vars.yaml
+      ansible.builtin.command:
+        cmd: "git add {{ _ugv_vars_file }}"
+        chdir: "{{ instance_path }}"
+      changed_when: true

--- a/roles/config/tasks/set.yml
+++ b/roles/config/tasks/set.yml
@@ -12,6 +12,44 @@
     loop_var: _setting
     label: "{{ _setting.split('=', 1)[0] }}"
 
+# If the instance is gitops-managed, update vars.yaml so the change
+# survives the next gitops pull (which re-renders .env from template).
+- name: Check for gitops instance
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/.gitops-host"
+  register: _config_gitops_stat
+
+- name: Update gitops vars for changed keys
+  when:
+    - _config_gitops_stat.stat.exists | default(false)
+    - instance_orchestrator | default('compose') == 'compose'
+  block:
+    - name: Read .gitops-host
+      ansible.builtin.slurp:
+        src: "{{ instance_path }}/.gitops-host"
+      register: _config_host_raw
+
+    - name: Read env.template
+      ansible.builtin.slurp:
+        src: "{{ instance_path }}/env.template"
+      register: _config_env_template
+
+    - name: Build key-to-placeholder map from env.template
+      ansible.builtin.set_fact:
+        _config_placeholder_map: >-
+          {{ dict((_config_env_template.content | b64decode).split('\n')
+             | select('match', '^[A-Z].*=\\{\\{')
+             | map('regex_replace', '^([^=]+)=\\{\\{([^}]+)\\}\\}.*', '\\1,\\2')
+             | map('split', ',')
+             | list) }}
+
+    - name: Update vars.yaml for each changed key
+      ansible.builtin.include_tasks: _update_gitops_var.yml
+      loop: "{{ settings.split() }}"
+      loop_control:
+        loop_var: _config_setting
+        label: "{{ _config_setting.split('=', 1)[0] }}"
+
 - name: Regenerate Caddyfile after config change
   ansible.builtin.include_role:
     name: orchestrator


### PR DESCRIPTION
## Problem
`canasta config set` on a gitops instance only updated `.env`. The next `gitops pull` re-rendered from the template and overrote the change.

## Fix
After setting each key in `.env`, reverse-map through `env.template` to find the placeholder name (e.g., `MW_SITE_SERVER` → `mw_site_server`), then update the host's `vars.yaml`. The change is also git-staged for the next push.

## Scope
- Compose only (K8s has its own config path).
- Only keys that have a corresponding `={{placeholder}}` in `env.template` get propagated to vars.yaml.
- Non-gitops instances: unchanged.

## Test plan
- [ ] `canasta config set -i X MW_SITE_SERVER=https://new.example.com` on a gitops instance: vars.yaml updated, change survives `gitops pull`.
- [ ] Same on a non-gitops instance: .env updated, no vars.yaml (unchanged behavior).
- [ ] Key not in env.template (e.g., custom var): .env only, no error.

Fixes #110.