### PR TITLE
Add external database support for Compose instances

### DIFF
--- a/roles/backup/tasks/create.yml
+++ b/roles/backup/tasks/create.yml
@@ -36,7 +36,7 @@
     exec_service: web
     exec_no_log: true
     exec_command: >-
-      mariadb-dump -h db -u root
+      mariadb-dump -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}"
       -p{{ _backup_dbpass.value | quote }}
       --single-transaction
       --databases {{ item | quote }}

--- a/roles/backup/tasks/restore.yml
+++ b/roles/backup/tasks/restore.yml
@@ -84,7 +84,7 @@
         exec_service: web
         exec_no_log: true
         exec_command: >-
-          mariadb-dump -h db -u root
+          mariadb-dump -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}"
           -p{{ _restore_dbpass.value | quote }}
           --single-transaction
           --databases {{ item | quote }}
@@ -207,7 +207,7 @@
     exec_service: web
     exec_no_log: true
     exec_command: >-
-      mariadb -h db -u root
+      mariadb -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}"
       -p{{ _restore_dbpass.value | quote }}
       < /mediawiki/config/backup/db_{{ item | quote }}.sql
   loop: "{{ _restore_wikis.wiki_ids }}"

--- a/roles/backup/tasks/schedule_set.yml
+++ b/roles/backup/tasks/schedule_set.yml
@@ -81,9 +81,9 @@
                           - |
                             mkdir -p /currentsnapshot/config/backup
                             EXCLUDE='^(information_schema|performance_schema|mysql|sys)$'
-                            for db in $(mariadb -h db -u root -p"$MYSQL_PASSWORD" \
+                            for db in $(mariadb -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}" -p"$MYSQL_PASSWORD" \
                               -N -e "SHOW DATABASES" | grep -vE "$EXCLUDE"); do
-                              mariadb-dump -h db -u root -p"$MYSQL_PASSWORD" \
+                              mariadb-dump -h "${MYSQL_HOST:-db}" -u "${MYSQL_USER:-root}" -p"$MYSQL_PASSWORD" \
                                 --single-transaction --databases "$db" \
                                 > "/currentsnapshot/config/backup/db_${db}.sql"
                             done

--- a/roles/config/tasks/_validate_key.yml
+++ b/roles/config/tasks/_validate_key.yml
@@ -2,6 +2,16 @@
 # Validate a config key against the known keys list.
 # Input: _config_key (str), force (bool)
 
+# Database infrastructure keys are set at create time and cannot be
+# changed afterward — all wikis in the instance share the same DB
+# connection, and changing it would orphan existing data.
+- name: Block immutable database keys
+  ansible.builtin.fail:
+    msg: >-
+      '{{ _config_key }}' cannot be changed after instance creation.
+      Delete the instance and recreate with the new database configuration.
+  when: _config_key in ['USE_EXTERNAL_DB', 'MYSQL_HOST', 'MYSQL_PORT', 'MYSQL_USER', 'MYSQL_SSL']
+
 - name: Check if key is recognized
   ansible.builtin.fail:
     msg: >-

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -345,6 +345,44 @@
   when: (wikidbuser | default('root')) != 'root'
   no_log: true
 
+# --- External database setup ---
+# If USE_EXTERNAL_DB=true was set (via -e envfile), validate that
+# MYSQL_HOST is also present, and configure COMPOSE_PROFILES to skip
+# the bundled db container.
+- name: Check for external database configuration
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read
+    key: USE_EXTERNAL_DB
+  register: _ext_db_check
+
+- name: Validate external DB config
+  when: _ext_db_check.found and _ext_db_check.value | lower == 'true'
+  block:
+    - name: Check MYSQL_HOST is set
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read
+        key: MYSQL_HOST
+      register: _ext_db_host
+
+    - name: Fail if MYSQL_HOST not set for external DB
+      ansible.builtin.fail:
+        msg: >-
+          USE_EXTERNAL_DB=true but MYSQL_HOST is not set. Include
+          MYSQL_HOST in your env file (-e) to specify the external
+          database server.
+      when: not _ext_db_host.found or _ext_db_host.value == ''
+
+- name: Set COMPOSE_PROFILES for database mode
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: set
+    key: COMPOSE_PROFILES
+    value: >-
+      {{ (_ext_db_check.found and _ext_db_check.value | lower == 'true')
+         | ternary('', 'internal-db') }}
+
 # Generate a placeholder MW_SECRET_KEY so docker compose variable substitution
 # doesn't warn about it being empty during the first 'docker compose up'.
 # install.php later replaces this with the key from LocalSettings.php,

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -256,6 +256,33 @@
         value: "{{ item.split('=', 1)[1] }}"
       loop: "{{ (_custom_env.content | b64decode).split('\n') | select('match', '^[A-Z].*=') | list }}"
 
+# For external DB, use the password from the env file instead of the
+# generated one. The env file was merged above and may contain
+# MYSQL_PASSWORD from the user's -e file.
+- name: Check if using external DB
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read
+    key: USE_EXTERNAL_DB
+  register: _ext_db_early_check
+
+- name: Use external DB password from env file
+  when: _ext_db_early_check.found and _ext_db_early_check.value | lower == 'true'
+  block:
+    - name: Read MYSQL_PASSWORD from env file
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read
+        key: MYSQL_PASSWORD
+      register: _ext_db_password
+
+    - name: Override root DB password with external DB password
+      ansible.builtin.set_fact:
+        _rootdbpass: "{{ _ext_db_password.value }}"
+        _wikidbpass: "{{ _ext_db_password.value }}"
+      when: _ext_db_password.found
+      no_log: true
+
 - name: Read HTTPS_PORT and CADDY_AUTO_HTTPS from .env
   canasta_env:
     path: "{{ instance_path }}/.env"

--- a/roles/mediawiki/tasks/install_single_wiki.yml
+++ b/roles/mediawiki/tasks/install_single_wiki.yml
@@ -12,6 +12,17 @@
     _install_domain: >-
       {{ _wiki.url | regex_replace('/.*$', '') }}
 
+- name: Read DB connection from .env
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read_all
+  register: _install_env
+
+- name: Set DB server for install
+  ansible.builtin.set_fact:
+    _install_dbserver: >-
+      {{ _install_env.variables.MYSQL_HOST | default('db') }}:{{ _install_env.variables.MYSQL_PORT | default('3306') }}
+
 - name: "Run install.php for wiki '{{ _wiki.id }}'"
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/orchestrator/tasks/exec.yml
@@ -20,7 +31,7 @@
     exec_command: >-
       env -u MW_SECRET_KEY php maintenance/install.php
       --skins='Vector'
-      --dbserver=db
+      --dbserver={{ _install_dbserver }}
       --dbname={{ _wiki.id }}
       --confpath=/tmp/canasta-install/
       --scriptpath=/w

--- a/roles/mediawiki/tasks/wait_for_db.yml
+++ b/roles/mediawiki/tasks/wait_for_db.yml
@@ -3,8 +3,19 @@
 # Mirrors Go mediawiki.WaitForDB().
 # Input: instance_path
 
+- name: Read DB connection from .env
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read_all
+  register: _wait_db_env
+
+- name: Set DB host and port
+  ansible.builtin.set_fact:
+    _db_host: "{{ _wait_db_env.variables.MYSQL_HOST | default('db') }}"
+    _db_port: "{{ _wait_db_env.variables.MYSQL_PORT | default('3306') }}"
+
 - name: Wait for database to accept connections
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"
   vars:
     exec_service: web
-    exec_command: "/wait-for-it.sh -t {{ canasta_db_wait_timeout | default(10) }} db:3306"
+    exec_command: "/wait-for-it.sh -t {{ canasta_db_wait_timeout | default(10) }} {{ _db_host }}:{{ _db_port }}"

--- a/roles/orchestrator/files/compose/docker-compose.yml
+++ b/roles/orchestrator/files/compose/docker-compose.yml
@@ -14,6 +14,8 @@ x-logging: &default-logging
 
 services:
   db:
+    profiles:
+      - internal-db
     image: docker.io/library/mariadb:11.4
     command: >
       bash -c "
@@ -50,11 +52,17 @@ services:
     depends_on:
       db:
         condition: service_healthy
+        required: false
     environment:
       # Sourced from .env
       - MW_SITE_SERVER=${MW_SITE_SERVER:-https://localhost}
       - MW_SECRET_KEY=${MW_SECRET_KEY}
+      - MYSQL_HOST=${MYSQL_HOST:-db}
+      - MYSQL_PORT=${MYSQL_PORT:-3306}
+      - MYSQL_USER=${MYSQL_USER:-root}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - MYSQL_SSL=${MYSQL_SSL:-false}
+      - USE_EXTERNAL_DB=${USE_EXTERNAL_DB:-false}
       - PHP_UPLOAD_MAX_FILESIZE=${PHP_UPLOAD_MAX_FILESIZE:-10M}
       - PHP_POST_MAX_SIZE=${PHP_UPLOAD_MAX_FILESIZE:-10M}
       - PHP_MAX_INPUT_VARS=${PHP_MAX_INPUT_VARS:-1000}

--- a/roles/orchestrator/files/helm/canasta/templates/configmap-db.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/configmap-db.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.db.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -16,3 +17,4 @@ data:
   my.cnf: |
     {{- .Files.Get "files/my.cnf" | nindent 4 }}
   {{- end }}
+{{- end }}

--- a/roles/orchestrator/files/helm/canasta/templates/deployment-jobrunner.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/deployment-jobrunner.yaml
@@ -67,7 +67,15 @@ spec:
                 optional: true
           env:
             - name: MYSQL_HOST
-              value: db
+              value: {{ if .Values.db.enabled }}"db"{{ else }}"{{ .Values.externalDatabase.host }}"{{ end }}
+            - name: MYSQL_PORT
+              value: {{ if .Values.db.enabled }}"3306"{{ else }}"{{ .Values.externalDatabase.port }}"{{ end }}
+            - name: MYSQL_USER
+              value: {{ if .Values.db.enabled }}"root"{{ else }}"{{ .Values.externalDatabase.user }}"{{ end }}
+            - name: MYSQL_SSL
+              value: {{ if .Values.db.enabled }}"false"{{ else }}"{{ .Values.externalDatabase.ssl }}"{{ end }}
+            - name: USE_EXTERNAL_DB
+              value: "{{ not .Values.db.enabled }}"
             - name: MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/deployment-web.yaml
@@ -86,7 +86,15 @@ spec:
               value: "{{ index .Values.domains 0 }}"
             {{- end }}
             - name: MYSQL_HOST
-              value: db
+              value: {{ if .Values.db.enabled }}"db"{{ else }}"{{ .Values.externalDatabase.host }}"{{ end }}
+            - name: MYSQL_PORT
+              value: {{ if .Values.db.enabled }}"3306"{{ else }}"{{ .Values.externalDatabase.port }}"{{ end }}
+            - name: MYSQL_USER
+              value: {{ if .Values.db.enabled }}"root"{{ else }}"{{ .Values.externalDatabase.user }}"{{ end }}
+            - name: MYSQL_SSL
+              value: {{ if .Values.db.enabled }}"false"{{ else }}"{{ .Values.externalDatabase.ssl }}"{{ end }}
+            - name: USE_EXTERNAL_DB
+              value: "{{ not .Values.db.enabled }}"
             - name: MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/roles/orchestrator/files/helm/canasta/templates/statefulset-db.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/statefulset-db.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.db.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -91,3 +92,4 @@ spec:
         resources:
           requests:
             storage: {{ .Values.db.storage }}
+{{- end }}

--- a/roles/orchestrator/files/helm/canasta/values.yaml
+++ b/roles/orchestrator/files/helm/canasta/values.yaml
@@ -50,7 +50,9 @@ varnish:
       memory: 256Mi
 
 # Database (MariaDB)
+# Set db.enabled=false and externalDatabase settings to use an external DB.
 db:
+  enabled: true
   image: mariadb:11.4
   storage: 10Gi
   storageClass: ""
@@ -61,6 +63,13 @@ db:
     limits:
       cpu: 500m
       memory: 512Mi
+
+# External database (when db.enabled=false)
+externalDatabase:
+  host: ""
+  port: "3306"
+  user: "root"
+  ssl: "false"
 
 # Elasticsearch (optional)
 elasticsearch:

--- a/roles/upgrade/tasks/main.yml
+++ b/roles/upgrade/tasks/main.yml
@@ -38,6 +38,7 @@
     - remove_legacy_git_dir.yml
     - remove_skip_binary_as_hex.yml
     - backfill_canasta_image.yml
+    - backfill_compose_profiles.yml
   loop_control:
     loop_var: _migration
 

--- a/roles/upgrade/tasks/migrations/backfill_compose_profiles.yml
+++ b/roles/upgrade/tasks/migrations/backfill_compose_profiles.yml
@@ -1,0 +1,34 @@
+---
+# Migration: Ensure COMPOSE_PROFILES is set for existing instances.
+# New instances get this at create time. Existing instances need it
+# backfilled so the db service profile (internal-db) is active.
+
+- name: Display a progress message
+  ansible.builtin.debug:
+    msg: "Checking COMPOSE_PROFILES..."
+
+- name: Check if COMPOSE_PROFILES is set
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read
+    key: COMPOSE_PROFILES
+  register: _profiles_check
+
+- name: Check USE_EXTERNAL_DB
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read
+    key: USE_EXTERNAL_DB
+  register: _ext_db_check
+  when: not _profiles_check.found
+
+- name: Set COMPOSE_PROFILES if missing
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: set
+    key: COMPOSE_PROFILES
+    value: >-
+      {{ (_ext_db_check.found | default(false) and
+          (_ext_db_check.value | default('false')) | lower == 'true')
+         | ternary('', 'internal-db') }}
+  when: not _profiles_check.found


### PR DESCRIPTION
## Summary
External database support for Compose instances. Use an external MariaDB/MySQL instead of the bundled db container.

### Usage
```bash
cat > external-db.env << 'EOF2'
USE_EXTERNAL_DB=true
MYSQL_HOST=rds.example.com
MYSQL_PORT=3307
MYSQL_USER=root
MYSQL_PASSWORD=secret
EOF2
canasta create -i mysite -w main -n example.com -e external-db.env
```

### Changes
1. **docker-compose.yml**: db service uses profiles (`internal-db`); web passes MYSQL_* vars
2. **canasta create**: validates MYSQL_HOST when external, sets COMPOSE_PROFILES, uses external DB password from env file instead of generating one
3. **canasta config set**: blocks immutable DB keys after create
4. **wait_for_db.yml**: reads MYSQL_HOST/PORT from .env (was hardcoded to `db:3306`)
5. **install_single_wiki.yml**: passes MYSQL_HOST:PORT to install.php (was hardcoded to `db`)
6. **Backup tasks**: use `${MYSQL_HOST:-db}` instead of hardcoded `db`
7. **Upgrade migration**: backfills COMPOSE_PROFILES for existing instances
8. **K8s Helm values**: `db.enabled` flag and `externalDatabase` section

### Backward compatibility
Existing instances: upgrade migration adds `COMPOSE_PROFILES=internal-db` → db container keeps running, unchanged.

### Tested
End-to-end on EC2 VM with external MariaDB container on port 3307:
- `canasta create` with `-e external-db.env` → wiki created, no internal db container
- install.php connected to correct host:port
- MediaWiki runtime connects via `$wgDBserver` (requires CanastaBase #162 for separate host/port)
- Wiki loads in browser

### Dependencies
- CanastaBase #158 (merged) — `$wgDBserver`/`$wgDBport`/`$wgDBuser` from env
- CanastaBase #162 (open) — append port to `$wgDBserver` when non-standard

Fixes #57
