### PR TITLE
Allow colons in script names + cascade MW_SITE_SERVER changes

### DIFF
--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -318,3 +318,52 @@
              | to_nice_yaml(indent=2) }}
         dest: "{{ instance_path }}/values.yaml"
         mode: "0644"
+
+# --- MW_SITE_SERVER domain change cascade ---
+# When the domain changes, update MW_SITE_FQDN, wikis.yaml URLs,
+# and (via the existing update_config.yml in set.yml) Caddyfile.
+- name: Cascade MW_SITE_SERVER domain change
+  when: _config_key == 'MW_SITE_SERVER'
+  block:
+    - name: Extract new FQDN from MW_SITE_SERVER
+      ansible.builtin.set_fact:
+        _new_fqdn: "{{ _config_value | regex_replace('^https?://', '') }}"
+
+    - name: Read current MW_SITE_FQDN
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read
+        key: MW_SITE_FQDN
+      register: _se_old_fqdn
+
+    - name: Update MW_SITE_FQDN
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: set
+        key: MW_SITE_FQDN
+        value: "{{ _new_fqdn }}"
+
+    - name: Read wikis.yaml for domain update
+      canasta_wikis_yaml:
+        instance_path: "{{ instance_path }}"
+        state: read
+      register: _se_domain_wikis
+
+    - name: Update wikis.yaml URLs with new domain
+      ansible.builtin.shell:
+        cmd: |
+          python3 -c "
+          import yaml
+          with open('{{ instance_path }}/config/wikis.yaml') as f:
+              data = yaml.safe_load(f)
+          old = '{{ _se_old_fqdn.value | default('') }}'
+          new = '{{ _new_fqdn }}'
+          if old and data and 'wikis' in data:
+              for wiki in data['wikis']:
+                  if 'url' in wiki:
+                      wiki['url'] = wiki['url'].replace(old, new)
+          with open('{{ instance_path }}/config/wikis.yaml', 'w') as f:
+              yaml.dump(data, f, default_flow_style=False)
+          "
+      changed_when: true
+      when: _se_old_fqdn.found and _se_old_fqdn.value != _new_fqdn

--- a/roles/maintenance/tasks/extension.yml
+++ b/roles/maintenance/tasks/extension.yml
@@ -7,8 +7,8 @@
 
 - name: Validate extension script path
   ansible.builtin.fail:
-    msg: "Invalid script path '{{ script_args }}'. Must match pattern: alphanumeric, slashes, dots, hyphens."
-  when: script_args | regex_search('[^a-zA-Z0-9/_. -]') is not none
+    msg: "Invalid script path '{{ script_args }}'. Must match pattern: alphanumeric, slashes, dots, hyphens, colons."
+  when: script_args | regex_search('[^a-zA-Z0-9/_. :-]') is not none
 
 - name: Build extension script command
   ansible.builtin.set_fact:

--- a/roles/maintenance/tasks/script.yml
+++ b/roles/maintenance/tasks/script.yml
@@ -7,8 +7,8 @@
 
 - name: Validate script path
   ansible.builtin.fail:
-    msg: "Invalid script path '{{ script_args }}'. Must match pattern: alphanumeric, slashes, dots, hyphens."
-  when: script_args | regex_search('[^a-zA-Z0-9/_. -]') is not none
+    msg: "Invalid script path '{{ script_args }}'. Must match pattern: alphanumeric, slashes, dots, hyphens, colons."
+  when: script_args | regex_search('[^a-zA-Z0-9/_. :-]') is not none
 
 - name: Build script command
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Summary
Two fixes in one PR:

### #213 — Allow colons in maintenance script names
MediaWiki extensions use `Extension:ScriptName` (e.g., `CirrusSearch:ForceSearchIndex`). Added `:` to the allowed characters regex in both `script.yml` and `extension.yml`.

### #214 — Cascade MW_SITE_SERVER to FQDN, wikis.yaml, Caddyfile
`canasta config set MW_SITE_SERVER=https://new.domain` now:
1. Sets `MW_SITE_FQDN=new.domain` (strips scheme)
2. Updates all wiki URLs in `config/wikis.yaml` (replaces old domain with new)
3. Caddyfile regenerates from updated wikis.yaml (existing behavior in set.yml)
4. Gitops vars.yaml updated (#205)

Previously only `.env`'s `MW_SITE_SERVER` changed — everything else kept the old domain.

## Test plan
- [ ] `canasta maintenance script -i x -w main -- run.php CirrusSearch:ForceSearchIndex` — no longer rejected
- [ ] `canasta config set MW_SITE_SERVER=https://new.domain` — updates MW_SITE_FQDN, wikis.yaml, Caddyfile in one shot

Fixes #213, #214.
