### PR TITLE
Fix MW_SITE_SERVER cascade: replace Python yaml with ansible.builtin.replace

### DIFF
--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -343,27 +343,9 @@
         key: MW_SITE_FQDN
         value: "{{ _new_fqdn }}"
 
-    - name: Read wikis.yaml for domain update
-      canasta_wikis_yaml:
-        instance_path: "{{ instance_path }}"
-        state: read
-      register: _se_domain_wikis
-
     - name: Update wikis.yaml URLs with new domain
-      ansible.builtin.shell:
-        cmd: |
-          python3 -c "
-          import yaml
-          with open('{{ instance_path }}/config/wikis.yaml') as f:
-              data = yaml.safe_load(f)
-          old = '{{ _se_old_fqdn.value | default('') }}'
-          new = '{{ _new_fqdn }}'
-          if old and data and 'wikis' in data:
-              for wiki in data['wikis']:
-                  if 'url' in wiki:
-                      wiki['url'] = wiki['url'].replace(old, new)
-          with open('{{ instance_path }}/config/wikis.yaml', 'w') as f:
-              yaml.dump(data, f, default_flow_style=False)
-          "
-      changed_when: true
+      ansible.builtin.replace:
+        path: "{{ instance_path }}/config/wikis.yaml"
+        regexp: "{{ _se_old_fqdn.value | regex_escape() }}"
+        replace: "{{ _new_fqdn }}"
       when: _se_old_fqdn.found and _se_old_fqdn.value != _new_fqdn


### PR DESCRIPTION
Fixes CI failure from #215 — the inline Python script used `import yaml` which isn't available on the system Python in CI. Replaced with `ansible.builtin.replace` for a simple string replacement in wikis.yaml. No external modules needed.