### PR TITLE
Map standard AWS env vars to short names in compose template

### DIFF
--- a/roles/orchestrator/files/compose/docker-compose.yml
+++ b/roles/orchestrator/files/compose/docker-compose.yml
@@ -62,6 +62,13 @@ services:
       - CANASTA_ENABLE_WIKI_DIRECTORY=${CANASTA_ENABLE_WIKI_DIRECTORY:-false}
       - CANASTA_ENABLE_VERY_SHORT_URLS=${CANASTA_ENABLE_VERY_SHORT_URLS:-false}
       - MW_SITEMAP_PAUSE_DAYS=${MW_SITEMAP_PAUSE_DAYS:-1}
+      # AWS: map standard SDK names to the short names the MW AWS
+      # extension reads. Users only need to set the standard pair
+      # (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY) in .env.
+      - AWS_ACCESS_KEY=${AWS_ACCESS_KEY_ID:-}
+      - AWS_SECRET_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      - AWS_REGION=${AWS_REGION:-}
+      - AWS_BUCKET_NAME=${AWS_BUCKET_NAME:-}
     volumes:
       - ./extensions:/var/www/mediawiki/w/user-extensions
       - ./skins:/var/www/mediawiki/w/user-skins


### PR DESCRIPTION
## Problem
Users had to maintain two pairs of identical AWS credentials in `.env`:
- `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (standard, used by Restic/AWS CLI)
- `AWS_ACCESS_KEY` / `AWS_SECRET_KEY` (non-standard, used by MW AWS extension)

Deleting either pair broke something silently.

## Fix
Map standard → short in the compose template's web environment:
```yaml
- AWS_ACCESS_KEY=${AWS_ACCESS_KEY_ID:-}
- AWS_SECRET_KEY=${AWS_SECRET_ACCESS_KEY:-}
```

Users only need the standard pair in `.env`. Also passes `AWS_REGION` and `AWS_BUCKET_NAME`.

## Backward compat
Existing instances with both pairs in `.env`: the docker-compose.override.yml (which has the short names explicitly) takes precedence. No change in behavior.

Fixes #137.