### PR TITLE
Fix mitogen CI failure: detect at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,6 @@ COPY . .
 # Make wrapper executable
 RUN chmod +x canasta-native
 
-# Create symlink for mitogen strategy plugins (dynamic path resolution)
-RUN ln -s $(python -c "import site; print(site.getsitepackages()[0])")/ansible_mitogen/plugins/strategy /opt/canasta-ansible/.mitogen-strategy-plugins
-
 # Build metadata (injected by CI)
 ARG BUILD_COMMIT=unknown
 ARG BUILD_DATE=unknown

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -11,10 +11,6 @@ deprecation_warnings = False
 nocows = True
 retry_files_enabled = False
 
-# Mitogen strategy for faster SSH execution
-strategy_plugins = /opt/canasta-ansible/.mitogen-strategy-plugins
-strategy = mitogen_linear
-
 [ssh_connection]
 control_path_dir = /tmp/.ansible-cp
 ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=accept-new

--- a/canasta.py
+++ b/canasta.py
@@ -70,6 +70,21 @@ def load_definitions():
         sys.exit(1)
 
 
+def _enable_mitogen_if_available():
+    """Enable mitogen strategy if the plugin is installed."""
+    try:
+        import ansible_mitogen
+        strategy_dir = os.path.join(
+            os.path.dirname(ansible_mitogen.__file__),
+            "plugins", "strategy",
+        )
+        if os.path.isdir(strategy_dir):
+            os.environ["ANSIBLE_STRATEGY_PLUGINS"] = strategy_dir
+            os.environ["ANSIBLE_STRATEGY"] = "mitogen_linear"
+    except ImportError:
+        pass
+
+
 def find_ansible_playbook():
     """Find the ansible-playbook executable."""
     venv_path = os.path.join(SCRIPT_DIR, ".venv", "bin", "ansible-playbook")
@@ -812,6 +827,8 @@ def main():
             sys.exit(0)
         # Tell the playbook to skip its own confirmation check
         args.yes = True
+
+    _enable_mitogen_if_available()
 
     ansible_playbook = find_ansible_playbook()
     ansible_args = build_ansible_args(


### PR DESCRIPTION
## Summary
- Remove hardcoded `strategy = mitogen_linear` from ansible.cfg (breaks CI and any install without mitogen)
- Add runtime detection in canasta.py: import `ansible_mitogen`, find the plugin directory, set `ANSIBLE_STRATEGY_PLUGINS` and `ANSIBLE_STRATEGY` env vars
- Falls back silently to default `linear` strategy when mitogen is not installed
- Remove the Dockerfile symlink (no longer needed — path resolved dynamically)

Fixes #221
