### PR TITLE
Direct command: version

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -801,9 +801,10 @@ def main():
             pass
 
     # Direct command bypass: run simple commands without Ansible overhead.
-    import direct_commands
-    if direct_commands.is_direct_command(command_name):
-        sys.exit(direct_commands.run_direct_command(command_name, args))
+    if not os.environ.get("CANASTA_FORCE_ANSIBLE"):
+        import direct_commands
+        if direct_commands.is_direct_command(command_name):
+            sys.exit(direct_commands.run_direct_command(command_name, args))
 
     # Interactive confirmation for destructive commands.
     # If the command defines a "yes" parameter and the user did not pass it,

--- a/direct_commands.py
+++ b/direct_commands.py
@@ -42,6 +42,11 @@ def _get_config_dir():
     return get_config_dir()
 
 
+def _get_script_dir():
+    from canasta import SCRIPT_DIR
+    return SCRIPT_DIR
+
+
 def _read_registry(conf_path):
     if not os.path.isfile(conf_path):
         return {}
@@ -357,4 +362,53 @@ def cmd_list(args):
     details = _gather_all_instances(instances)
 
     _print_table(details)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# canasta version
+# ---------------------------------------------------------------------------
+
+@register("version")
+def cmd_version(args):
+    script_dir = _get_script_dir()
+
+    version_file = os.path.join(script_dir, "VERSION")
+    try:
+        with open(version_file) as f:
+            version = f.read().strip()
+    except OSError:
+        version = "unknown"
+
+    build_commit_file = os.path.join(script_dir, "BUILD_COMMIT")
+    if os.path.isfile(build_commit_file):
+        mode = "docker"
+        try:
+            with open(build_commit_file) as f:
+                commit = f.read().strip()
+            with open(os.path.join(script_dir, "BUILD_DATE")) as f:
+                date = f.read().strip()
+        except OSError:
+            commit = "unknown"
+            date = "unknown"
+    else:
+        mode = "native"
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"],
+                cwd=script_dir, capture_output=True, text=True, timeout=5,
+            )
+            commit = result.stdout.strip() if result.returncode == 0 else "unknown"
+        except (subprocess.TimeoutExpired, OSError):
+            commit = "unknown"
+        try:
+            result = subprocess.run(
+                ["git", "log", "-1", "--format=%cd", "--date=format:%Y-%m-%d %H:%M:%S"],
+                cwd=script_dir, capture_output=True, text=True, timeout=5,
+            )
+            date = result.stdout.strip() if result.returncode == 0 else "unknown"
+        except (subprocess.TimeoutExpired, OSError):
+            date = "unknown"
+
+    print("Canasta CLI v%s (%s, commit %s, built %s)" % (version, mode, commit, date))
     return 0

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -622,3 +622,65 @@ class TestCmdList:
         out = capsys.readouterr().out
         assert "NOT FOUND" in out
         assert "(no wikis)" in out
+
+
+# ---------------------------------------------------------------------------
+# Version command tests
+# ---------------------------------------------------------------------------
+
+class TestCmdVersion:
+    def test_registered(self):
+        assert direct_commands.is_direct_command("version")
+
+    def test_native_checkout(self, tmp_path, monkeypatch, capsys):
+        (tmp_path / "VERSION").write_text("4.0.0\n")
+        monkeypatch.setattr(direct_commands, "_get_script_dir", lambda: str(tmp_path))
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: type("R", (), {
+                "returncode": 0,
+                "stdout": "abc1234\n" if "rev-parse" in a[0] else "2026-04-18 12:00:00\n",
+            })(),
+        )
+        rc = direct_commands.cmd_version(None)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "v4.0.0" in out
+        assert "native" in out
+        assert "abc1234" in out
+
+    def test_docker_mode(self, tmp_path, monkeypatch, capsys):
+        (tmp_path / "VERSION").write_text("4.0.0\n")
+        (tmp_path / "BUILD_COMMIT").write_text("def5678\n")
+        (tmp_path / "BUILD_DATE").write_text("2026-04-18 10:00:00\n")
+        monkeypatch.setattr(direct_commands, "_get_script_dir", lambda: str(tmp_path))
+        rc = direct_commands.cmd_version(None)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "v4.0.0" in out
+        assert "docker" in out
+        assert "def5678" in out
+
+    def test_missing_version_file(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(direct_commands, "_get_script_dir", lambda: str(tmp_path))
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: type("R", (), {"returncode": 1, "stdout": ""})(),
+        )
+        rc = direct_commands.cmd_version(None)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "unknown" in out
+
+    def test_not_a_git_repo(self, tmp_path, monkeypatch, capsys):
+        (tmp_path / "VERSION").write_text("4.0.0\n")
+        monkeypatch.setattr(direct_commands, "_get_script_dir", lambda: str(tmp_path))
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: type("R", (), {"returncode": 128, "stdout": ""})(),
+        )
+        rc = direct_commands.cmd_version(None)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "v4.0.0" in out
+        assert "unknown" in out


### PR DESCRIPTION
## Summary
- Implement `canasta version` as a direct command, bypassing Ansible
- Add `CANASTA_FORCE_ANSIBLE` env var to force the Ansible path for any command (useful for debugging/benchmarking)

### Performance

| Approach | Time |
|---|---|
| Ansible | ~1.08s |
| **Direct** | **~0.09s** (11x faster) |

Partial fix for #171
