### PR TITLE
Fix flaky remote integration test

### DIFF
--- a/tests/integration/remote/run_tests.sh
+++ b/tests/integration/remote/run_tests.sh
@@ -86,6 +86,7 @@ echo "=== Starting mock remote host ==="
 
 # Tell SSH and Ansible to use our test SSH config
 export ANSIBLE_SSH_ARGS="-F ${SSH_CONFIG}"
+export ANSIBLE_HOST_KEY_CHECKING=False
 
 echo ""
 echo "=== Running remote integration tests ==="


### PR DESCRIPTION
## Summary
- Export `ANSIBLE_HOST_KEY_CHECKING=False` in the remote integration test runner
- Ansible has its own host key check that's separate from SSH's `StrictHostKeyChecking` — the test was only setting the SSH-level config, not the Ansible-level one
- This caused intermittent CI failures on every commit since #219

Fixes #226
