### PR TITLE
Direct command: gitops status

### DIFF
--- a/direct_commands.py
+++ b/direct_commands.py
@@ -643,3 +643,130 @@ def cmd_host_remove(args):
     _write_hosts_yml(data)
     print("Host '%s' removed from %s" % (host_name, _hosts_yml_path()))
     return 0
+
+
+# ---------------------------------------------------------------------------
+# canasta gitops status
+# ---------------------------------------------------------------------------
+
+def _gitops_status_script(path):
+    """Build a batched shell script that gathers all gitops status info."""
+    d = _SENTINEL
+    qp = _shell_quote(path)
+    return (
+        "cd %(p)s; "
+        "cat .gitops-host 2>/dev/null || echo MISSING; "
+        "echo '%(d)s'; "
+        "cat hosts/hosts.yaml 2>/dev/null || echo MISSING; "
+        "echo '%(d)s'; "
+        "git rev-parse --short HEAD 2>/dev/null || echo none; "
+        "echo '%(d)s'; "
+        "cat .gitops-applied 2>/dev/null || echo none; "
+        "echo '%(d)s'; "
+        "git diff --cached --name-only 2>/dev/null; "
+        "echo '%(d)s'; "
+        "git diff --name-only 2>/dev/null; "
+        "echo '%(d)s'; "
+        "git fetch 2>/dev/null; "
+        "git rev-list --left-right --count HEAD...@{upstream} 2>/dev/null || echo '0\t0'"
+    ) % {"p": qp, "d": d}
+
+
+def _parse_gitops_status(stdout, instance_id):
+    """Parse the batched gitops status output into a formatted string."""
+    parts = stdout.split(_SENTINEL + "\n")
+
+    hostname = parts[0].strip() if len(parts) > 0 else "unknown"
+    if hostname == "MISSING":
+        hostname = "unknown"
+
+    hosts_yaml_raw = parts[1].strip() if len(parts) > 1 else ""
+    role = "unknown"
+    pull_requests = False
+    if hosts_yaml_raw and hosts_yaml_raw != "MISSING":
+        try:
+            parsed = yaml.safe_load(hosts_yaml_raw)
+            if parsed and "hosts" in parsed and parsed["hosts"]:
+                role = parsed["hosts"][0].get("role", "unknown")
+                pull_requests = parsed["hosts"][0].get("pull_requests", False)
+        except yaml.YAMLError:
+            pass
+
+    commit = parts[2].strip() if len(parts) > 2 else "none"
+    applied = parts[3].strip() if len(parts) > 3 else "none"
+    staged_raw = parts[4].strip() if len(parts) > 4 else ""
+    unstaged_raw = parts[5].strip() if len(parts) > 5 else ""
+    revcount_raw = parts[6].strip() if len(parts) > 6 else "0\t0"
+
+    staged = staged_raw.split("\n") if staged_raw else []
+    unstaged = unstaged_raw.split("\n") if unstaged_raw else []
+
+    try:
+        revcount_parts = revcount_raw.split("\t")
+        ahead = int(revcount_parts[0])
+        behind = int(revcount_parts[1]) if len(revcount_parts) > 1 else 0
+    except (ValueError, IndexError):
+        ahead, behind = 0, 0
+
+    lines = [
+        "Host:           %s" % hostname,
+        "Role:           %s" % role,
+        "Canasta ID:     %s" % instance_id,
+        "Pull requests:  %s" % str(pull_requests),
+        "Current commit: %s" % commit,
+        "Last applied:   %s" % (applied if applied != "none" else ""),
+        "",
+    ]
+
+    if staged:
+        lines.append("Staged for push (%d files):" % len(staged))
+        for f in staged:
+            lines.append("  %s" % f)
+        lines.append("")
+
+    if unstaged:
+        lines.append("Unstaged changes (%d files):" % len(unstaged))
+        for f in unstaged:
+            lines.append("  %s" % f)
+        lines.append("")
+
+    if not staged and not unstaged:
+        lines.append("No changes.")
+        lines.append("")
+
+    if ahead > 0:
+        lines.append("Ahead of remote by %d commit(s)." % ahead)
+    elif behind > 0:
+        lines.append("Behind remote by %d commit(s)." % behind)
+    else:
+        lines.append("Up to date with remote.")
+
+    return "\n".join(lines)
+
+
+@register("gitops_status")
+def cmd_gitops_status(args):
+    inst_id, inst = _resolve_instance(args)
+    host = inst.get("host") or "localhost"
+    path = inst.get("path", "")
+
+    script = _gitops_status_script(path)
+
+    if _is_localhost(host):
+        try:
+            result = subprocess.run(
+                ["bash", "-c", script],
+                capture_output=True, text=True, timeout=30,
+            )
+            stdout = result.stdout
+        except (subprocess.TimeoutExpired, OSError) as e:
+            print("Error: %s" % e, file=sys.stderr)
+            return 1
+    else:
+        rc, stdout = _ssh_run(host, script)
+        if rc != 0 and not stdout.strip():
+            print("Error: failed to connect to %s" % host, file=sys.stderr)
+            return 1
+
+    print(_parse_gitops_status(stdout, inst_id))
+    return 0

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1085,3 +1085,101 @@ class TestHostRemove:
         args = type("Args", (), {"host_name": "prod1"})()
         rc = direct_commands.cmd_host_remove(args)
         assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Gitops status tests
+# ---------------------------------------------------------------------------
+
+class TestParseGitopsStatus:
+    def _make_output(self, hostname="myhost", hosts_yaml="MISSING",
+                     commit="abc1234", applied="abc1234",
+                     staged="", unstaged="", revcount="0\t0"):
+        d = direct_commands._SENTINEL
+        return (
+            hostname + "\n" + d + "\n"
+            + hosts_yaml + "\n" + d + "\n"
+            + commit + "\n" + d + "\n"
+            + applied + "\n" + d + "\n"
+            + staged + "\n" + d + "\n"
+            + unstaged + "\n" + d + "\n"
+            + revcount + "\n"
+        )
+
+    def test_basic_status(self):
+        out = self._make_output()
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "Host:           myhost" in result
+        assert "Canasta ID:     mysite" in result
+        assert "Current commit: abc1234" in result
+        assert "No changes." in result
+        assert "Up to date with remote." in result
+
+    def test_with_staged_files(self):
+        out = self._make_output(staged="config/.env\nconfig/wikis.yaml")
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "Staged for push (2 files):" in result
+        assert "config/.env" in result
+        assert "config/wikis.yaml" in result
+
+    def test_with_unstaged_files(self):
+        out = self._make_output(unstaged="docker-compose.override.yml")
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "Unstaged changes (1 files):" in result
+
+    def test_ahead_of_remote(self):
+        out = self._make_output(revcount="3\t0")
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "Ahead of remote by 3 commit(s)." in result
+
+    def test_behind_remote(self):
+        out = self._make_output(revcount="0\t2")
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "Behind remote by 2 commit(s)." in result
+
+    def test_with_hosts_yaml(self):
+        hosts_yaml = "hosts:\n  - role: production\n    pull_requests: true"
+        out = self._make_output(hosts_yaml=hosts_yaml)
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "Role:           production" in result
+        assert "Pull requests:  True" in result
+
+    def test_missing_host_file(self):
+        out = self._make_output(hostname="MISSING")
+        result = direct_commands._parse_gitops_status(out, "mysite")
+        assert "Host:           unknown" in result
+
+
+class TestCmdGitopsStatus:
+    def test_registered(self):
+        assert direct_commands.is_direct_command("gitops_status")
+
+    def test_remote_uses_ssh(self, monkeypatch, capsys):
+        d = direct_commands._SENTINEL
+        ssh_output = (
+            "myhost\n" + d + "\n"
+            + "MISSING\n" + d + "\n"
+            + "abc1234\n" + d + "\n"
+            + "abc1234\n" + d + "\n"
+            + "\n" + d + "\n"
+            + "\n" + d + "\n"
+            + "0\t0\n"
+        )
+        monkeypatch.setattr(
+            direct_commands, "_resolve_instance",
+            lambda args: ("mysite", {
+                "path": "/srv/mysite",
+                "orchestrator": "compose",
+                "host": "admin@remote",
+            }),
+        )
+        monkeypatch.setattr(
+            direct_commands, "_ssh_run",
+            lambda host, cmd: (0, ssh_output),
+        )
+        args = type("Args", (), {"id": "mysite"})()
+        rc = direct_commands.cmd_gitops_status(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Canasta ID:     mysite" in out
+        assert "Up to date with remote." in out


### PR DESCRIPTION
## Summary
- Implement `canasta gitops status` as a direct command (Compose instances)
- Batches all operations (read .gitops-host, hosts.yaml, git rev-parse, git diff, git fetch, git rev-list) into a single SSH call
- Parses the batched output and formats it identically to the Ansible playbook
- Shows: host, role, pull requests mode, current/applied commit, staged/unstaged files, ahead/behind

### Performance (remote instance)

| Approach | Warm avg |
|---|---|
| Ansible | ~3.5s |
| **Direct** | **~0.8s** (4.4x faster) |

Partial fix for #171
