### PR TITLE
Handle K8s instances in direct commands

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -804,7 +804,9 @@ def main():
     if not os.environ.get("CANASTA_FORCE_ANSIBLE"):
         import direct_commands
         if direct_commands.is_direct_command(command_name):
-            sys.exit(direct_commands.run_direct_command(command_name, args))
+            result = direct_commands.run_direct_command(command_name, args)
+            if result is not direct_commands.FALLBACK:
+                sys.exit(result)
 
     # Interactive confirmation for destructive commands.
     # If the command defines a "yes" parameter and the user did not pass it,

--- a/direct_commands.py
+++ b/direct_commands.py
@@ -24,6 +24,9 @@ def register(command_name):
     return decorator
 
 
+FALLBACK = object()
+
+
 def is_direct_command(command_name):
     return command_name in DIRECT_COMMANDS
 
@@ -531,21 +534,71 @@ def cmd_config_get(args):
 # canasta start / stop / restart
 # ---------------------------------------------------------------------------
 
+def _k8s_namespace(instance_id):
+    return "canasta-%s" % instance_id
+
+
+def _run_kubectl(kubectl_args, timeout=30):
+    """Run a kubectl command. Returns exit code."""
+    cmd = ["kubectl"] + kubectl_args
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        if result.stdout.strip():
+            print(result.stdout.strip())
+        if result.returncode != 0 and result.stderr.strip():
+            print(result.stderr.strip(), file=sys.stderr)
+        return result.returncode
+    except (subprocess.TimeoutExpired, OSError) as e:
+        print("Error: %s" % e, file=sys.stderr)
+        return 1
+
+
+def _k8s_stop(instance_id):
+    """Stop a K8s instance: suspend Argo CD sync, scale everything to 0."""
+    ns = _k8s_namespace(instance_id)
+
+    result = subprocess.run(
+        ["kubectl", "get", "application", "canasta-%s" % instance_id,
+         "-n", "argocd", "-o", "jsonpath={.metadata.name}"],
+        capture_output=True, text=True, timeout=10,
+    )
+    if result.returncode == 0:
+        _run_kubectl([
+            "patch", "application", "canasta-%s" % instance_id,
+            "-n", "argocd", "--type", "merge",
+            "-p", '{"spec":{"syncPolicy":null}}',
+        ])
+
+    _run_kubectl(["scale", "deployment", "--all", "--replicas=0", "-n", ns])
+    _run_kubectl(["scale", "statefulset", "--all", "--replicas=0", "-n", ns])
+    return 0
+
+
 @register("start")
 def cmd_start(args):
     inst_id, inst = _resolve_instance(args)
+    if inst.get("orchestrator", "compose") in ("kubernetes", "k8s"):
+        # K8s start requires chart copy + helm deploy + config sync;
+        # these are multi-step controller-to-remote operations that
+        # need Ansible.
+        return FALLBACK
     return _run_compose(inst_id, inst, ["up", "-d"])
 
 
 @register("stop")
 def cmd_stop(args):
     inst_id, inst = _resolve_instance(args)
+    if inst.get("orchestrator", "compose") in ("kubernetes", "k8s"):
+        return _k8s_stop(inst_id)
     return _run_compose(inst_id, inst, ["down"])
 
 
 @register("restart")
 def cmd_restart(args):
     inst_id, inst = _resolve_instance(args)
+    if inst.get("orchestrator", "compose") in ("kubernetes", "k8s"):
+        # K8s restart needs Ansible for the start half (helm deploy).
+        return FALLBACK
     rc = _run_compose(inst_id, inst, ["down"])
     if rc != 0:
         return rc

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -817,6 +817,50 @@ class TestLifecycleCommands:
     def test_restart_registered(self):
         assert direct_commands.is_direct_command("restart")
 
+    def test_k8s_start_falls_back(self, monkeypatch):
+        monkeypatch.setattr(
+            direct_commands, "_resolve_instance",
+            lambda args: ("k8s-site", {
+                "path": "/srv/k8s-site",
+                "orchestrator": "kubernetes",
+            }),
+        )
+        args = type("Args", (), {"id": "k8s-site"})()
+        assert direct_commands.cmd_start(args) is direct_commands.FALLBACK
+
+    def test_k8s_restart_falls_back(self, monkeypatch):
+        monkeypatch.setattr(
+            direct_commands, "_resolve_instance",
+            lambda args: ("k8s-site", {
+                "path": "/srv/k8s-site",
+                "orchestrator": "kubernetes",
+            }),
+        )
+        args = type("Args", (), {"id": "k8s-site"})()
+        assert direct_commands.cmd_restart(args) is direct_commands.FALLBACK
+
+    def test_k8s_stop_runs_kubectl(self, monkeypatch):
+        kubectl_cmds = []
+
+        def mock_run(cmd, **kw):
+            kubectl_cmds.append(cmd)
+            return type("R", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+        monkeypatch.setattr(subprocess, "run", mock_run)
+        monkeypatch.setattr(
+            direct_commands, "_resolve_instance",
+            lambda args: ("k8s-site", {
+                "path": "/srv/k8s-site",
+                "orchestrator": "kubernetes",
+            }),
+        )
+        args = type("Args", (), {"id": "k8s-site"})()
+        rc = direct_commands.cmd_stop(args)
+        assert rc == 0
+        cmds_str = str(kubectl_cmds)
+        assert "scale" in cmds_str
+        assert "replicas=0" in cmds_str
+
     def test_start_runs_up(self, monkeypatch):
         captured_cmds = []
 


### PR DESCRIPTION
## Summary

Handle K8s instances properly in direct commands instead of blindly falling back for everything.

**K8s stop** — implemented directly:
- Suspend Argo CD auto-sync (prevents selfHeal from reverting scale-to-zero)
- Scale all deployments to 0
- Scale all statefulsets to 0

**K8s start/restart** — fall back to Ansible:
- Start requires chart copy from controller to remote, helm deploy, config sync, rollout waits, and Argo CD restore — genuinely multi-step controller-to-remote operations that need Ansible
- Restart includes start, so it also needs Ansible

### Design

The `FALLBACK` sentinel lets a direct command say "this specific case needs Ansible." The dispatcher in `canasta.py` checks for it and falls through to the Ansible path. This is used only where there's a real architectural reason (controller-to-remote file sync), not as a blanket orchestrator check.
