### PR TITLE
Direct commands: extension list, skin list

### DIFF
--- a/direct_commands.py
+++ b/direct_commands.py
@@ -135,6 +135,65 @@ def _run_compose(inst_id, inst, action_args):
         if stdout.strip():
             print(stdout.strip())
         return rc
+
+
+def _k8s_get_pod(namespace, component="web"):
+    """Get the name of a running pod by component label."""
+    try:
+        result = subprocess.run(
+            ["kubectl", "get", "pods", "-n", namespace,
+             "-l", "app.kubernetes.io/component=%s" % component,
+             "--field-selector=status.phase=Running",
+             "-o", "jsonpath={.items[0].metadata.name}"],
+            capture_output=True, text=True, timeout=10,
+        )
+        pod = result.stdout.strip()
+        return pod if result.returncode == 0 and pod else None
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+
+
+def _exec_in_container(inst_id, inst, command, service="web"):
+    """Execute a command inside a container/pod. Returns (rc, stdout)."""
+    host = inst.get("host") or "localhost"
+    path = inst.get("path", "")
+    orchestrator = inst.get("orchestrator", "compose")
+
+    if orchestrator in ("kubernetes", "k8s"):
+        ns = _k8s_namespace(inst_id)
+        pod = _k8s_get_pod(ns, service)
+        if not pod:
+            return 1, ""
+        try:
+            result = subprocess.run(
+                ["kubectl", "exec", pod, "-n", ns, "--",
+                 "/bin/bash", "-c", command],
+                capture_output=True, text=True, timeout=30,
+            )
+            return result.returncode, result.stdout
+        except (subprocess.TimeoutExpired, OSError):
+            return 1, ""
+
+    if _is_localhost(host):
+        try:
+            result = subprocess.run(
+                ["docker", "compose", "exec", "-T", service,
+                 "/bin/bash", "-c", command],
+                cwd=path, capture_output=True, text=True, timeout=30,
+            )
+            return result.returncode, result.stdout
+        except (subprocess.TimeoutExpired, OSError):
+            return 1, ""
+
+    rc, stdout = _ssh_run(
+        host,
+        "cd %s && docker compose exec -T %s /bin/bash -c %s" % (
+            _shell_quote(path), service, _shell_quote(command),
+        ),
+    )
+    return rc, stdout
+
+
 def _read_registry(conf_path):
     if not os.path.isfile(conf_path):
         return {}
@@ -823,3 +882,33 @@ def cmd_gitops_status(args):
 
     print(_parse_gitops_status(stdout, inst_id))
     return 0
+
+
+# ---------------------------------------------------------------------------
+# canasta extension list / skin list
+# ---------------------------------------------------------------------------
+
+def _list_items(args, item_type, item_dir):
+    inst_id, inst = _resolve_instance(args)
+    command = (
+        "cd /var/www/mediawiki/w/%s "
+        "&& find -L * -maxdepth 0 -type d 2>/dev/null "
+        "|| true" % item_dir
+    )
+    rc, stdout = _exec_in_container(inst_id, inst, command)
+    if rc != 0:
+        print("Error: could not list %s." % item_type, file=sys.stderr)
+        return 1
+    print("Available Canasta %s:" % item_type)
+    print(stdout.strip())
+    return 0
+
+
+@register("extension_list")
+def cmd_extension_list(args):
+    return _list_items(args, "extensions", "extensions")
+
+
+@register("skin_list")
+def cmd_skin_list(args):
+    return _list_items(args, "skins", "skins")

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1227,3 +1227,108 @@ class TestCmdGitopsStatus:
         out = capsys.readouterr().out
         assert "Canasta ID:     mysite" in out
         assert "Up to date with remote." in out
+
+
+# ---------------------------------------------------------------------------
+# Extension/skin list tests
+# ---------------------------------------------------------------------------
+
+class TestExecInContainer:
+    def test_compose_local(self, monkeypatch):
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: type("R", (), {
+                "returncode": 0, "stdout": "Cite\nVisualEditor\n",
+            })(),
+        )
+        rc, out = direct_commands._exec_in_container(
+            "test",
+            {"path": "/srv/test", "orchestrator": "compose"},
+            "find extensions",
+        )
+        assert rc == 0
+        assert "Cite" in out
+
+    def test_k8s(self, monkeypatch):
+        monkeypatch.setattr(
+            direct_commands, "_k8s_get_pod",
+            lambda ns, svc: "canasta-test-web-abc123",
+        )
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **kw: type("R", (), {
+                "returncode": 0, "stdout": "Cite\n",
+            })(),
+        )
+        rc, out = direct_commands._exec_in_container(
+            "test",
+            {"path": "/srv/test", "orchestrator": "kubernetes"},
+            "find extensions",
+        )
+        assert rc == 0
+
+    def test_k8s_no_pod(self, monkeypatch):
+        monkeypatch.setattr(
+            direct_commands, "_k8s_get_pod",
+            lambda ns, svc: None,
+        )
+        rc, out = direct_commands._exec_in_container(
+            "test",
+            {"path": "/srv/test", "orchestrator": "kubernetes"},
+            "find extensions",
+        )
+        assert rc == 1
+
+
+class TestExtensionSkinList:
+    def test_extension_list_registered(self):
+        assert direct_commands.is_direct_command("extension_list")
+
+    def test_skin_list_registered(self):
+        assert direct_commands.is_direct_command("skin_list")
+
+    def test_extension_list_output(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            direct_commands, "_resolve_instance",
+            lambda args: ("test", {"path": "/srv/test", "orchestrator": "compose"}),
+        )
+        monkeypatch.setattr(
+            direct_commands, "_exec_in_container",
+            lambda *a, **kw: (0, "Cite\nVisualEditor\nParserFunctions\n"),
+        )
+        args = type("Args", (), {"id": "test", "wiki": None})()
+        rc = direct_commands.cmd_extension_list(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Available Canasta extensions:" in out
+        assert "Cite" in out
+        assert "VisualEditor" in out
+
+    def test_skin_list_output(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            direct_commands, "_resolve_instance",
+            lambda args: ("test", {"path": "/srv/test", "orchestrator": "compose"}),
+        )
+        monkeypatch.setattr(
+            direct_commands, "_exec_in_container",
+            lambda *a, **kw: (0, "Vector\nTimeless\n"),
+        )
+        args = type("Args", (), {"id": "test", "wiki": None})()
+        rc = direct_commands.cmd_skin_list(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Available Canasta skins:" in out
+        assert "Vector" in out
+
+    def test_list_error(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            direct_commands, "_resolve_instance",
+            lambda args: ("test", {"path": "/srv/test", "orchestrator": "compose"}),
+        )
+        monkeypatch.setattr(
+            direct_commands, "_exec_in_container",
+            lambda *a, **kw: (1, ""),
+        )
+        args = type("Args", (), {"id": "test", "wiki": None})()
+        rc = direct_commands.cmd_extension_list(args)
+        assert rc == 1


### PR DESCRIPTION
## Summary
- Implement `canasta extension list` and `skin list` as direct commands
- Add shared `_exec_in_container` helper handling both Compose (`docker compose exec`) and K8s (`kubectl exec`)
- Add `_k8s_get_pod` helper for resolving running pod names — reusable by future commands needing container exec

### Performance (extension list on kamins, remote host)

| Approach | Time |
|---|---|
| Ansible | ~3.4s |
| **Direct** | **~0.8s** (4.2x faster) |

Partial fix for #171
