### PR TITLE
Fix shell injection in backup list, improve SSH error reporting

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -601,12 +601,11 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
         # Update target_host in the vars file to use just the hostname,
         # not the user@host form (the hosts.yml or inline inventory
         # entry is keyed on hostname alone).
-        import json as _json
         with open(vars_file.name, "r") as f:
-            _v = _json.load(f)
+            _v = json.load(f)
         _v["target_host"] = host_spec
         with open(vars_file.name, "w") as f:
-            _json.dump(_v, f)
+            json.dump(_v, f)
 
         # Inline inventory fallback — used if the host isn't in any
         # user-defined inventory file. Goes first so that hosts.yml

--- a/direct_commands.py
+++ b/direct_commands.py
@@ -244,8 +244,14 @@ def _ssh_run(host, cmd):
         result = subprocess.run(
             full_cmd, capture_output=True, text=True, timeout=30,
         )
+        if result.returncode != 0 and result.stderr.strip():
+            print(result.stderr.strip(), file=sys.stderr)
         return result.returncode, result.stdout
-    except (subprocess.TimeoutExpired, OSError):
+    except subprocess.TimeoutExpired:
+        print("Error: SSH connection to %s timed out" % host, file=sys.stderr)
+        return 1, ""
+    except OSError as e:
+        print("Error: %s" % e, file=sys.stderr)
         return 1, ""
 
 
@@ -1035,8 +1041,10 @@ def cmd_backup_list(args):
     local_repo = env_vars.get("RESTIC_REPOSITORY", "")
     local_mount = ""
     if local_repo.startswith("/"):
-        local_mount = "-v %s:%s" % (local_repo, local_repo)
+        qrepo = _shell_quote(local_repo)
+        local_mount = "-v %s:%s" % (qrepo, qrepo)
 
+    qpath = _shell_quote(path)
     cmd = (
         "docker volume create %(vol)s >/dev/null 2>&1; "
         "docker run --rm -i "
@@ -1046,7 +1054,7 @@ def cmd_backup_list(args):
         "restic/restic "
         "--cache-dir /tmp/restic-cache "
         "snapshots"
-    ) % {"vol": bvol, "path": path, "local_mount": local_mount}
+    ) % {"vol": _shell_quote(bvol), "path": qpath, "local_mount": local_mount}
 
     if _is_localhost(host):
         try:


### PR DESCRIPTION
## Summary

Fixes from a comprehensive codebase audit:

- **Shell injection in `cmd_backup_list`**: `path`, `bvol`, and `local_repo` were interpolated unquoted into a shell string. Paths with spaces or special characters would break or could inject commands. Now uses `_shell_quote()` for all interpolated values.
- **Silent SSH failures**: `_ssh_run` was discarding stderr entirely, so remote errors were invisible. Now surfaces stderr and adds specific messages for timeouts and OS errors.
- **Unnecessary `import json as _json`**: `json` is already imported at module level in `canasta.py`. Removed the redundant aliased re-import.
