### PR TITLE
Add curl retry to Dockerfile downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,26 +11,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Docker CLI (not daemon - we use host's Docker via socket)
-RUN curl -fsSL https://download.docker.com/linux/static/stable/$(uname -m)/docker-27.5.1.tgz \
+RUN curl -fsSL --retry 3 --retry-delay 5 \
+        https://download.docker.com/linux/static/stable/$(uname -m)/docker-27.5.1.tgz \
     | tar xz --strip-components=1 -C /usr/local/bin docker/docker
 
 # Install Docker Compose plugin (uses uname -m for arch: x86_64/aarch64)
 RUN mkdir -p /usr/local/lib/docker/cli-plugins \
-    && curl -fsSL \
+    && curl -fsSL --retry 3 --retry-delay 5 \
          "https://github.com/docker/compose/releases/download/v5.1.1/docker-compose-linux-$(uname -m)" \
          -o /usr/local/lib/docker/cli-plugins/docker-compose \
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
 
 # Install kubectl (latest stable). dpkg --print-architecture maps to
 # amd64 / arm64, matching the directories under dl.k8s.io. See #62.
-RUN curl -fsSL \
-        "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/$(dpkg --print-architecture)/kubectl" \
+RUN curl -fsSL --retry 3 --retry-delay 5 \
+        "https://dl.k8s.io/release/$(curl -fsSL --retry 3 https://dl.k8s.io/release/stable.txt)/bin/linux/$(dpkg --print-architecture)/kubectl" \
         -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl
 
 # Install Helm (3.x via the official installer script).
-RUN curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
-        | bash
+RUN curl -fsSL --retry 3 --retry-delay 5 \
+        https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
+    | bash
 
 # Copy application
 WORKDIR /opt/canasta-ansible


### PR DESCRIPTION
## Summary
Add `--retry 3 --retry-delay 5` to all curl commands in the Dockerfile (Docker CLI, Docker Compose, kubectl, Helm). GitHub releases has been intermittently returning 504 during CI, causing Docker image builds to fail. Two consecutive failures on the same commit.
