### PR TITLE
Disable mitogen auto-enable: broken with ansible-core 2.20 become

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -71,7 +71,18 @@ def load_definitions():
 
 
 def _enable_mitogen_if_available():
-    """Enable mitogen strategy if the plugin is installed."""
+    """Enable mitogen strategy if explicitly requested.
+
+    Mitogen 0.3.46 has a known incompatibility with ansible-core 2.20's
+    module respawn logic (AttributeError: _module_fqn), which breaks
+    become operations like 'canasta install docker'. Disabled by default
+    until upstream fixes the issue. Set CANASTA_ENABLE_MITOGEN=1 to
+    opt in.
+    """
+    if not os.environ.get("CANASTA_ENABLE_MITOGEN"):
+        return
+    if os.environ.get("ANSIBLE_STRATEGY"):
+        return
     try:
         import ansible_mitogen
         strategy_dir = os.path.join(


### PR DESCRIPTION
## Summary

Mitogen 0.3.46 has an incompatibility with ansible-core 2.20's module respawn logic. The apt module's `respawn_module()` calls `main._module_fqn` which doesn't exist under mitogen's execution model, producing:

```
AttributeError: module '__main__' has no attribute '_module_fqn'
```

This breaks any command using `become: true`, including `canasta install docker`.

**Fix:** Disable mitogen auto-enable. Users can opt in with `CANASTA_ENABLE_MITOGEN=1` if they only run commands that don't use become. Also respects `ANSIBLE_STRATEGY` if already set.

Found during testing of the `get-canasta.sh` install script on a fresh EC2 VM.
