### PR TITLE
Revert mitogen integration

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -70,21 +70,6 @@ def load_definitions():
         sys.exit(1)
 
 
-def _enable_mitogen_if_available():
-    """Enable mitogen strategy if the plugin is installed."""
-    try:
-        import ansible_mitogen
-        strategy_dir = os.path.join(
-            os.path.dirname(ansible_mitogen.__file__),
-            "plugins", "strategy",
-        )
-        if os.path.isdir(strategy_dir):
-            os.environ["ANSIBLE_STRATEGY_PLUGINS"] = strategy_dir
-            os.environ["ANSIBLE_STRATEGY"] = "mitogen_linear"
-    except ImportError:
-        pass
-
-
 def find_ansible_playbook():
     """Find the ansible-playbook executable."""
     venv_path = os.path.join(SCRIPT_DIR, ".venv", "bin", "ansible-playbook")
@@ -829,8 +814,6 @@ def main():
             sys.exit(0)
         # Tell the playbook to skip its own confirmation check
         args.yes = True
-
-    _enable_mitogen_if_available()
 
     ansible_playbook = find_ansible_playbook()
     ansible_args = build_ansible_args(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 ansible-core>=2.15
 kubernetes>=28.1.0
-mitogen>=0.3.33
 molecule>=6.0
 molecule-plugins[docker]>=23.0
 pytest>=7.0


### PR DESCRIPTION
## Summary

Revert the mitogen integration (#219, #222). Mitogen 0.3.46 has a fatal incompatibility with ansible-core 2.20: the apt module's `respawn_module()` calls `main._module_fqn` which doesn't exist under mitogen's execution model:

```
AttributeError: module '__main__' has no attribute '_module_fqn'
```

This breaks any command using `become: true`, including `canasta install docker`. Found during testing of the install script on a fresh EC2 VM.

The ~18% Ansible path speedup from mitogen is not worth the breakage, especially since the direct commands work (#171) already delivers 3-14x speedups on the frequently-used commands.

**Removed:** `_enable_mitogen_if_available()`, mitogen from requirements.txt
**Kept:** `pipelining = True` in ansible.cfg (good standalone optimization)
