### PR TITLE
Add file path argument to gitops rm

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1145,8 +1145,12 @@ commands:
 
   - name: gitops_rm
     description: "Remove configuration from git tracking"
-    long_description: "Remove configuration files from git tracking."
+    long_description: |
+      Remove configuration files from git tracking. If a file path is
+      given, delete that file and stage the deletion. Without a path,
+      stage all pending deletions (files already deleted from disk).
     examples:
+      - "canasta gitops rm -i mysite public_assets/main/.htaccess"
       - "canasta gitops rm -i mysite"
     playbook: gitops_rm.yml
     parameters:
@@ -1154,6 +1158,10 @@ commands:
         short: i
         type: string
         description: "Canasta instance ID"
+      - name: path
+        type: string
+        positional: true
+        description: "File path to remove (relative to instance root)"
 
   - name: gitops_push
     description: "Push configuration changes"

--- a/roles/gitops/tasks/rm.yml
+++ b/roles/gitops/tasks/rm.yml
@@ -2,8 +2,23 @@
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
-- name: Remove deleted files from tracking
+- name: Remove specific file
+  when: path is defined and path != ''
+  block:
+    - name: Delete file from disk
+      ansible.builtin.file:
+        path: "{{ instance_path }}/{{ path }}"
+        state: absent
+
+    - name: Stage file deletion
+      ansible.builtin.command:
+        cmd: "git rm --cached --ignore-unmatch {{ path }}"
+        chdir: "{{ instance_path }}"
+      changed_when: true
+
+- name: Stage all pending deletions
   ansible.builtin.command:
     cmd: "git add -u"
-    chdir: "{{ instance_path }}/config"
+    chdir: "{{ instance_path }}"
   changed_when: true
+  when: path is not defined or path == ''


### PR DESCRIPTION
## Summary
- `canasta gitops rm -i mysite path/to/file` now deletes the file and stages the deletion
- Without a path, existing behavior preserved: stages all pending deletions (`git add -u`)

Fixes #240
