### PR TITLE
Multi-environment K8s gitops: init + join (#112)

### DIFF
--- a/roles/gitops/tasks/init_kubernetes.yml
+++ b/roles/gitops/tasks/init_kubernetes.yml
@@ -1,9 +1,12 @@
 ---
-# GitOps init (Kubernetes) — simpler than Compose.
-# No git-crypt (secrets live in K8s Secrets, not in the repo).
-# No env.template/vars.yaml/hosts.yaml structure.
-# The git repo tracks values.yaml and config files.
-# Argo CD Application is registered to start continuous reconciliation.
+# GitOps init (Kubernetes) — multi-environment aware.
+# Uses git-crypt for secrets in per-host vars.yaml.
+# Repo structure:
+#   values.template.yaml    ← shared, with {{placeholder}} syntax
+#   hosts/hosts.yaml        ← host registry
+#   hosts/{name}/vars.yaml  ← per-host values (encrypted)
+#   hosts/{name}/rendered-values.yaml  ← rendered for Argo CD
+#   Chart.yaml, templates/  ← shared Helm chart
 # Input: host_name, role, repo, key, force, pull_requests
 # Requires: instance_path, instance_id (set by dispatcher)
 
@@ -12,6 +15,47 @@
   ansible.builtin.command:
     cmd: git --version
   changed_when: false
+
+- name: Set git user.name on target host
+  ansible.builtin.command:
+    cmd: "git config --global user.name '{{ git_user_name }}'"
+  changed_when: true
+  when: git_user_name is defined and git_user_name != ''
+
+- name: Set git user.email on target host
+  ansible.builtin.command:
+    cmd: "git config --global user.email '{{ git_user_email }}'"
+  changed_when: true
+  when: git_user_email is defined and git_user_email != ''
+
+- name: Check git identity is configured
+  ansible.builtin.command:
+    cmd: "git config user.name"
+  register: _git_identity
+  changed_when: false
+  ignore_errors: true
+
+- name: Fail if git identity not configured
+  ansible.builtin.fail:
+    msg: >-
+      Git user identity is not configured. Either pass
+      --git-user-name and --git-user-email, or run:
+      git config --global user.name "Your Name"
+      git config --global user.email "you@example.com"
+  when: _git_identity.rc != 0
+
+- name: Check git-crypt is installed
+  ansible.builtin.command:
+    cmd: "git-crypt --version"
+  register: _gitcrypt_check
+  changed_when: false
+  ignore_errors: true
+
+- name: Fail if git-crypt not installed
+  ansible.builtin.fail:
+    msg: >-
+      git-crypt is not installed. Run 'canasta install git-crypt' first.
+  when: _gitcrypt_check.rc != 0
 
 - name: Check for existing .git directory
   ansible.builtin.stat:
@@ -26,21 +70,20 @@
   when: _gitops_existing.stat.exists
 
 # --- SSH deploy key ---
-# On K8s, --key is the path where the SSH deploy key lives (or will
-# be generated). Analogous to the Compose path's git-crypt key
-# export: the credential is saved at --key for future operations
-# (gitops push, gitops join on another host).
-#
-# If the file already exists and contains a PEM key, we reuse it
-# (re-init or user-supplied key). Otherwise we generate a new one.
+# Saved to {{ key }}.ssh ({{ key }} is reserved for the git-crypt key,
+# consistent with the Compose gitops model).
+- name: Set SSH key path
+  ansible.builtin.set_fact:
+    _ssh_key_path: "{{ key }}.ssh"
+
 - name: Check if SSH deploy key already exists
   ansible.builtin.stat:
-    path: "{{ key }}"
+    path: "{{ _ssh_key_path }}"
   register: _gitops_key_exists
 
 - name: Read existing SSH deploy key
   ansible.builtin.slurp:
-    src: "{{ key }}"
+    src: "{{ _ssh_key_path }}"
   register: _gitops_ssh_key_existing
   when: _gitops_key_exists.stat.exists
   no_log: true
@@ -56,20 +99,20 @@
   ansible.builtin.command:
     cmd: >-
       ssh-keygen -t ed25519
-      -f {{ key }}
+      -f {{ _ssh_key_path }}
       -N ''
       -C 'canasta-{{ instance_id }}'
   when: not (_existing_is_ssh_key | bool)
 
 - name: Read the SSH deploy key (generated or existing)
   ansible.builtin.slurp:
-    src: "{{ key }}"
+    src: "{{ _ssh_key_path }}"
   register: _gitops_ssh_key
   no_log: true
 
 - name: Read the public key for display
   ansible.builtin.slurp:
-    src: "{{ key }}.pub"
+    src: "{{ _ssh_key_path }}.pub"
   register: _gitops_ssh_pubkey
 
 - name: Display public key for deploy key setup
@@ -89,10 +132,10 @@
   ansible.builtin.command:
     cmd: "git ls-remote {{ repo }}"
   environment:
-    GIT_SSH_COMMAND: "ssh -i {{ key }} -o StrictHostKeyChecking=no"
+    GIT_SSH_COMMAND: "ssh -i {{ _ssh_key_path }} -o StrictHostKeyChecking=no"
   register: _gitops_remote
   changed_when: false
-  ignore_errors: true  # OK if remote unreachable
+  ignore_errors: true
 
 - name: Fail if remote is not empty
   ansible.builtin.fail:
@@ -104,36 +147,110 @@
     - not (force | default(false) | bool)
 
 # --- Copy Helm chart into instance directory ---
-# Argo CD needs the chart in the git repo to render templates.
 - name: Copy Chart.yaml into instance directory
   ansible.builtin.copy:
     src: "{{ canasta_root }}/roles/orchestrator/files/helm/canasta/Chart.yaml"
     dest: "{{ instance_path }}/Chart.yaml"
     mode: preserve
 
-# Trailing / on src is critical: without it, Ansible's copy module
-# copies the directory AS 'templates' under the dest, creating
-# templates/templates/. With the trailing /, it copies the CONTENTS.
 - name: Copy Helm templates into instance directory
   ansible.builtin.copy:
     src: "{{ canasta_root }}/roles/orchestrator/files/helm/canasta/templates/"
     dest: "{{ instance_path }}/templates/"
     mode: preserve
 
-# lookup('file') runs on the controller — use slurp for remote files.
 - name: Read instance values.yaml from remote
   ansible.builtin.slurp:
     src: "{{ instance_path }}/values.yaml"
   register: _gitops_instance_values
 
 - name: Merge chart defaults with instance values
-  ansible.builtin.copy:
-    content: |
+  ansible.builtin.set_fact:
+    _merged_values: >-
       {{ lookup('file', canasta_root ~ '/roles/orchestrator/files/helm/canasta/values.yaml')
          | from_yaml
-         | combine(_gitops_instance_values.content | b64decode | from_yaml, recursive=True)
-         | to_nice_yaml(indent=2) }}
+         | combine(_gitops_instance_values.content | b64decode | from_yaml, recursive=True) }}
+
+- name: Write merged values.yaml
+  ansible.builtin.copy:
+    content: "{{ _merged_values | to_nice_yaml(indent=2) }}"
     dest: "{{ instance_path }}/values.yaml"
+    mode: "0644"
+
+# --- Sync config files into values.yaml ---
+- name: Set K8s namespace for config sync
+  ansible.builtin.set_fact:
+    _k8s_namespace: "canasta-{{ instance_id }}"
+
+- name: Sync config files
+  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_sync_config.yml"
+
+- name: Read values.yaml after config sync
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/values.yaml"
+  register: _gitops_values_synced
+
+- name: Read values-configdata.yaml
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/values-configdata.yaml"
+  register: _gitops_configdata
+
+- name: Merge configData into values
+  ansible.builtin.set_fact:
+    _final_values: >-
+      {{ _gitops_values_synced.content | b64decode | from_yaml
+         | combine(_gitops_configdata.content | b64decode | from_yaml, recursive=True) }}
+
+# --- Extract per-environment values into template + vars ---
+- name: Define K8s placeholder keys
+  ansible.builtin.set_fact:
+    _k8s_placeholder_keys:
+      - domains
+      - instance.id
+      - image.tag
+      - secrets.dbSecretName
+      - secrets.mwSecretName
+      - ingress.className
+      - ingress.tls
+      - web.replicaCount
+
+- name: Generate values.template.yaml
+  ansible.builtin.copy:
+    content: |
+      {{ _final_values | to_nice_yaml(indent=2) }}
+    dest: "{{ instance_path }}/values.template.yaml"
+    mode: "0644"
+
+- name: Create hosts directory
+  ansible.builtin.file:
+    path: "{{ instance_path }}/hosts/{{ host_name }}"
+    state: directory
+    mode: "0755"
+    recurse: true
+
+- name: Extract per-host vars from values
+  ansible.builtin.copy:
+    content: |
+      # Per-environment values for {{ host_name }}
+      domains:
+      {% for d in _final_values.domains | default(['localhost']) %}
+        - "{{ d }}"
+      {% endfor %}
+      instance_id: "{{ instance_id }}"
+      image_tag: "{{ _final_values.image.tag | default('') }}"
+      db_secret_name: "{{ _final_values.secrets.dbSecretName | default('') }}"
+      mw_secret_name: "{{ _final_values.secrets.mwSecretName | default('') }}"
+      ingress_class: "{{ _final_values.ingress.className | default('') }}"
+      ingress_tls: {{ _final_values.ingress.tls | default(true) | lower }}
+      web_replica_count: {{ _final_values.web.replicaCount | default(1) }}
+    dest: "{{ instance_path }}/hosts/{{ host_name }}/vars.yaml"
+    mode: "0644"
+  no_log: true
+
+- name: Write rendered-values.yaml (initial render = current values)
+  ansible.builtin.copy:
+    content: "{{ _final_values | to_nice_yaml(indent=2) }}"
+    dest: "{{ instance_path }}/hosts/{{ host_name }}/rendered-values.yaml"
     mode: "0644"
 
 # --- Initialize git repository ---
@@ -146,32 +263,73 @@
 - name: Write .gitignore
   ansible.builtin.copy:
     content: |
-      # Secrets live in K8s Secrets, not in this repo
       .env
-
-      # Generated at runtime by Ansible
       .gitops-host
       .gitops-applied
-
-      # Instance template files not needed in gitops
       _initdb/
       docker-compose*.yml
       my.cnf
       scripts/
-
-      # Admin passwords
       admin-password_*
-
-      # Transient config sync file
       values-configdata.yaml
-
-      # Runtime data directories (backed by PVCs on K8s, not by git)
       images/
       extensions/
       skins/
       public_assets/
       wikis/
     dest: "{{ instance_path }}/.gitignore"
+    mode: "0644"
+
+- name: Write .gitattributes for git-crypt
+  ansible.builtin.copy:
+    src: "{{ role_path }}/files/gitattributes.default"
+    dest: "{{ instance_path }}/.gitattributes"
+    mode: "0644"
+
+# --- Initialize git-crypt ---
+- name: Initialize git-crypt
+  ansible.builtin.command:
+    cmd: "git-crypt init"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
+- name: Export git-crypt key on remote host
+  ansible.builtin.command:
+    cmd: "git-crypt export-key /tmp/canasta-gitcrypt-key"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
+- name: Read git-crypt key from remote host
+  ansible.builtin.slurp:
+    src: /tmp/canasta-gitcrypt-key
+  register: _gitcrypt_key_data
+  no_log: true
+
+- name: Remove temporary key from remote
+  ansible.builtin.file:
+    path: /tmp/canasta-gitcrypt-key
+    state: absent
+
+- name: Write git-crypt key to controller
+  ansible.builtin.copy:
+    content: "{{ _gitcrypt_key_data.content | b64decode }}"
+    dest: "{{ key }}"
+    mode: "0600"
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_python_interpreter: "{{ ansible_playbook_python }}"
+  no_log: true
+
+# --- Create hosts metadata ---
+- name: Create hosts.yaml
+  ansible.builtin.copy:
+    content: |
+      hosts:
+        - name: {{ host_name }}
+          role: {{ role | default('both') }}
+          pull_requests: {{ pull_requests | default(false) | bool | lower }}
+    dest: "{{ instance_path }}/hosts/hosts.yaml"
     mode: "0644"
 
 # --- Create Argo CD application manifest ---
@@ -197,7 +355,7 @@
           path: .
           helm:
             valueFiles:
-              - values.yaml
+              - hosts/{{ host_name }}/rendered-values.yaml
         destination:
           server: https://kubernetes.default.svc
           namespace: canasta-{{ instance_id }}
@@ -215,36 +373,6 @@
   ansible.builtin.copy:
     content: "{{ host_name }}"
     dest: "{{ instance_path }}/.gitops-host"
-    mode: "0644"
-
-# Key file is either the user's existing key or the one we just
-# generated. No placeholder needed — we always have a real key now.
-
-# --- Sync config files into values.yaml ---
-- name: Set K8s namespace for config sync
-  ansible.builtin.set_fact:
-    _k8s_namespace: "canasta-{{ instance_id }}"
-
-- name: Sync config files
-  ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/k8s_sync_config.yml"
-
-- name: Read values.yaml from remote for configData merge
-  ansible.builtin.slurp:
-    src: "{{ instance_path }}/values.yaml"
-  register: _gitops_values_for_merge
-
-- name: Read values-configdata.yaml from remote
-  ansible.builtin.slurp:
-    src: "{{ instance_path }}/values-configdata.yaml"
-  register: _gitops_configdata_for_merge
-
-- name: Merge configData into values.yaml for git
-  ansible.builtin.copy:
-    content: >-
-      {{ _gitops_values_for_merge.content | b64decode | from_yaml
-         | combine(_gitops_configdata_for_merge.content | b64decode | from_yaml, recursive=True)
-         | to_nice_yaml(indent=2) }}
-    dest: "{{ instance_path }}/values.yaml"
     mode: "0644"
 
 # --- Initial commit and push ---
@@ -271,13 +399,10 @@
     cmd: "git push -u origin main {{ (force | default(false) | bool) | ternary('--force', '') }}"
     chdir: "{{ instance_path }}"
   environment:
-    GIT_SSH_COMMAND: "ssh -i {{ key }} -o StrictHostKeyChecking=no"
+    GIT_SSH_COMMAND: "ssh -i {{ _ssh_key_path }} -o StrictHostKeyChecking=no"
   changed_when: true
 
 # --- Create Argo CD repo credential Secret ---
-# The SSH deploy key (generated or user-supplied) is stored as a K8s
-# Secret that Argo CD discovers via the repository label. This is what
-# lets Argo CD pull from the git repo without manual kubectl steps.
 - name: Create or update Argo CD repo credential Secret
   kubernetes.core.k8s:
     state: present
@@ -307,8 +432,8 @@
 - name: Report gitops initialized
   ansible.builtin.debug:
     msg: >-
-      GitOps initialized for '{{ instance_id }}'.
-      SSH deploy key saved to: {{ key }}.
-      Argo CD repo credential Secret created.
-      Store the key securely — it is needed to push config changes
-      and to set up additional hosts.
+      GitOps initialized for '{{ instance_id }}' (environment: {{ host_name }}).
+      Git-crypt key: {{ key }}
+      SSH deploy key: {{ _ssh_key_path }}
+      Argo CD Application points to hosts/{{ host_name }}/rendered-values.yaml.
+      Store both keys securely — they are needed for additional environments.

--- a/roles/gitops/tasks/join.yml
+++ b/roles/gitops/tasks/join.yml
@@ -10,13 +10,12 @@
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
-- name: Not applicable for Kubernetes
-  ansible.builtin.fail:
-    msg: >-
-      'canasta gitops join' is not yet implemented for the kubernetes
-      orchestrator. Multi-environment K8s gitops requires a different
-      repo structure (per-environment branches or directories) that
-      is not yet supported.
+- name: Dispatch to K8s join
+  ansible.builtin.include_tasks: join_kubernetes.yml
+  when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+
+- name: Skip Compose join for K8s
+  ansible.builtin.meta: end_play
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
 
 # --- Step 1: Validate prerequisites ---

--- a/roles/gitops/tasks/join_kubernetes.yml
+++ b/roles/gitops/tasks/join_kubernetes.yml
@@ -1,0 +1,236 @@
+---
+# GitOps join (Kubernetes) — connect a K8s instance to an existing
+# gitops repository as a new environment.
+#
+# Clones the repo, unlocks git-crypt, creates per-host vars from the
+# instance's current values.yaml, renders rendered-values.yaml, creates
+# an Argo CD Application pointing at the new rendered file.
+#
+# Input: host_name, role, repo, key, force
+# Requires: instance_path, instance_id (set by dispatcher)
+
+# --- Validate prerequisites ---
+- name: Check git is installed
+  ansible.builtin.command:
+    cmd: "git --version"
+  changed_when: false
+
+- name: Check git-crypt is installed
+  ansible.builtin.command:
+    cmd: "git-crypt --version"
+  changed_when: false
+
+- name: Check for existing .git directory
+  ansible.builtin.stat:
+    path: "{{ instance_path }}/.git"
+  register: _join_existing_git
+
+- name: Fail if git repo already exists
+  ansible.builtin.fail:
+    msg: >-
+      GitOps already initialized ({{ instance_path }}/.git exists).
+      This instance is already connected to a gitops repository.
+  when: _join_existing_git.stat.exists
+
+# --- Clone repo to temp location ---
+- name: Create temp directory for clone
+  ansible.builtin.tempfile:
+    state: directory
+    prefix: "canasta-join-"
+  register: _join_tmpdir
+
+- name: Clone gitops repository
+  ansible.builtin.command:
+    cmd: "git clone -b main {{ repo }} ."
+    chdir: "{{ _join_tmpdir.path }}"
+  changed_when: true
+
+# --- Copy key to remote and unlock git-crypt ---
+- name: Copy git-crypt key from controller to remote
+  ansible.builtin.copy:
+    src: "{{ key }}"
+    dest: "/tmp/canasta-gitcrypt-key"
+    mode: "0600"
+
+- name: Unlock git-crypt with provided key
+  ansible.builtin.command:
+    cmd: "git-crypt unlock /tmp/canasta-gitcrypt-key"
+    chdir: "{{ _join_tmpdir.path }}"
+  changed_when: true
+
+- name: Remove temp key from remote
+  ansible.builtin.file:
+    path: "/tmp/canasta-gitcrypt-key"
+    state: absent
+
+# --- Validate host name not already in config ---
+- name: Read hosts.yaml from cloned repo
+  ansible.builtin.slurp:
+    src: "{{ _join_tmpdir.path }}/hosts/hosts.yaml"
+  register: _join_hosts_raw
+
+- name: Parse hosts config
+  ansible.builtin.set_fact:
+    _join_hosts: "{{ _join_hosts_raw.content | b64decode | from_yaml }}"
+
+- name: Fail if host name already exists
+  ansible.builtin.fail:
+    msg: >-
+      Environment '{{ host_name }}' already exists in the gitops repository.
+      Choose a different name or remove the existing environment first.
+  when: >-
+    _join_hosts.hosts | default([])
+    | selectattr('name', 'equalto', host_name)
+    | list | length > 0
+
+# --- Move .git into instance directory ---
+- name: Move .git from temp clone to instance
+  ansible.builtin.command:
+    cmd: "mv {{ _join_tmpdir.path }}/.git {{ instance_path }}/.git"
+  changed_when: true
+
+- name: Checkout tracked files from repo (decrypted via git-crypt)
+  ansible.builtin.command:
+    cmd: "git checkout HEAD -- ."
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
+- name: Configure git pull strategy
+  ansible.builtin.command:
+    cmd: "git config pull.rebase false"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
+# --- Extract per-host vars from current values.yaml ---
+- name: Read current values.yaml
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/values.yaml"
+  register: _join_values_raw
+
+- name: Parse values
+  ansible.builtin.set_fact:
+    _join_values: "{{ _join_values_raw.content | b64decode | from_yaml }}"
+
+# --- Add host to config and write vars ---
+- name: Add host to hosts.yaml
+  ansible.builtin.copy:
+    content: |
+      {{ _join_hosts
+         | combine({'hosts': _join_hosts.hosts | default([])
+                    + [{'name': host_name,
+                        'role': role | default('both')}]},
+                   recursive=True)
+         | to_nice_yaml(indent=2) }}
+    dest: "{{ instance_path }}/hosts/hosts.yaml"
+    mode: "0644"
+
+- name: Create host vars directory
+  ansible.builtin.file:
+    path: "{{ instance_path }}/hosts/{{ host_name }}"
+    state: directory
+    mode: "0755"
+
+- name: Write host vars from current values
+  ansible.builtin.copy:
+    content: |
+      # Per-environment values for {{ host_name }}
+      domains:
+      {% for d in _join_values.domains | default(['localhost']) %}
+        - "{{ d }}"
+      {% endfor %}
+      instance_id: "{{ instance_id }}"
+      image_tag: "{{ _join_values.image.tag | default('') }}"
+      db_secret_name: "{{ _join_values.secrets.dbSecretName | default('') }}"
+      mw_secret_name: "{{ _join_values.secrets.mwSecretName | default('') }}"
+      ingress_class: "{{ _join_values.ingress.className | default('') }}"
+      ingress_tls: {{ _join_values.ingress.tls | default(true) | lower }}
+      web_replica_count: {{ _join_values.web.replicaCount | default(1) }}
+    dest: "{{ instance_path }}/hosts/{{ host_name }}/vars.yaml"
+    mode: "0644"
+  no_log: true
+
+# --- Save host identity (before render, which reads it) ---
+- name: Save .gitops-host identity
+  ansible.builtin.copy:
+    content: "{{ host_name }}"
+    dest: "{{ instance_path }}/.gitops-host"
+    mode: "0644"
+
+# --- Render values for this environment ---
+- name: Render values from template + vars
+  ansible.builtin.include_tasks: render_kubernetes.yml
+
+# --- Create Argo CD Application for this environment ---
+- name: Create argocd directory
+  ansible.builtin.file:
+    path: "{{ instance_path }}/argocd"
+    state: directory
+    mode: "0755"
+
+- name: Generate Argo CD Application manifest
+  ansible.builtin.copy:
+    content: |
+      apiVersion: argoproj.io/v1alpha1
+      kind: Application
+      metadata:
+        name: canasta-{{ instance_id }}
+        namespace: {{ argocd_namespace | default('argocd') }}
+      spec:
+        project: default
+        source:
+          repoURL: {{ repo }}
+          targetRevision: HEAD
+          path: .
+          helm:
+            valueFiles:
+              - hosts/{{ host_name }}/rendered-values.yaml
+        destination:
+          server: https://kubernetes.default.svc
+          namespace: canasta-{{ instance_id }}
+        syncPolicy:
+          automated:
+            selfHeal: true
+            prune: true
+          syncOptions:
+            - CreateNamespace=true
+    dest: "{{ instance_path }}/argocd/application.yaml"
+    mode: "0644"
+
+- name: Apply Argo CD Application to cluster
+  kubernetes.core.k8s:
+    state: present
+    src: "{{ instance_path }}/argocd/application.yaml"
+
+# --- Commit and push ---
+- name: Stage all changes
+  ansible.builtin.command:
+    cmd: "git add -A"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
+- name: Commit
+  ansible.builtin.command:
+    cmd: "git commit -m 'Add environment {{ host_name }}'"
+    chdir: "{{ instance_path }}"
+  changed_when: true
+
+- name: Push to remote
+  ansible.builtin.command:
+    cmd: "git push {{ (force | default(false) | bool) | ternary('--force', '') }}"
+    chdir: "{{ instance_path }}"
+  environment:
+    GIT_SSH_COMMAND: "ssh -i {{ key }} -o StrictHostKeyChecking=no"
+  changed_when: true
+
+# --- Clean up ---
+- name: Remove temp clone directory
+  ansible.builtin.file:
+    path: "{{ _join_tmpdir.path }}"
+    state: absent
+
+- name: Report gitops joined
+  ansible.builtin.debug:
+    msg: >-
+      Joined gitops repository for '{{ instance_id }}' as
+      environment '{{ host_name }}'.
+      Argo CD Application points to hosts/{{ host_name }}/rendered-values.yaml.

--- a/roles/gitops/tasks/render_kubernetes.yml
+++ b/roles/gitops/tasks/render_kubernetes.yml
@@ -1,0 +1,83 @@
+---
+# Render per-environment values.yaml from template + host vars.
+# Reads values.template.yaml as base, overlays per-host vars.
+# Output: hosts/{hostname}/rendered-values.yaml
+#
+# Requires: instance_path, instance_id (set by dispatcher)
+
+- name: Read .gitops-host
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/.gitops-host"
+  register: _render_host_file
+
+- name: Set hostname
+  ansible.builtin.set_fact:
+    _render_hostname: "{{ _render_host_file.content | b64decode | trim }}"
+
+- name: Read values.template.yaml
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/values.template.yaml"
+  register: _render_template_raw
+
+- name: Parse template values
+  ansible.builtin.set_fact:
+    _render_template: "{{ _render_template_raw.content | b64decode | from_yaml }}"
+
+- name: Read host vars
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/hosts/{{ _render_hostname }}/vars.yaml"
+  register: _render_vars_raw
+
+- name: Parse host vars
+  ansible.builtin.set_fact:
+    _render_vars: "{{ _render_vars_raw.content | b64decode | from_yaml }}"
+
+- name: Read shared vars if present
+  ansible.builtin.slurp:
+    src: "{{ instance_path }}/hosts/_shared/vars.yaml"
+  register: _render_shared_raw
+  ignore_errors: true
+
+- name: Parse shared vars
+  ansible.builtin.set_fact:
+    _render_shared: >-
+      {{ (_render_shared_raw.content | b64decode | from_yaml)
+         if _render_shared_raw is succeeded
+         else {} }}
+
+- name: Merge shared + host vars (host wins)
+  ansible.builtin.set_fact:
+    _render_merged_vars: "{{ _render_shared | combine(_render_vars, recursive=True) }}"
+
+- name: Apply per-host overrides to template
+  ansible.builtin.set_fact:
+    _rendered_values: >-
+      {{ _render_template
+         | combine({
+             'domains': _render_merged_vars.domains | default(_render_template.domains),
+             'instance': _render_template.instance | default({})
+               | combine({'id': _render_merged_vars.instance_id | default(instance_id)}),
+             'image': _render_template.image | default({})
+               | combine({'tag': _render_merged_vars.image_tag | default('')}
+                         if _render_merged_vars.image_tag | default('') != ''
+                         else {}),
+             'secrets': {
+               'dbSecretName': _render_merged_vars.db_secret_name | default(''),
+               'mwSecretName': _render_merged_vars.mw_secret_name | default(''),
+             },
+             'ingress': _render_template.ingress | default({})
+               | combine({
+                   'className': _render_merged_vars.ingress_class | default(''),
+                   'tls': _render_merged_vars.ingress_tls | default(true) | bool,
+                 }),
+             'web': _render_template.web | default({})
+               | combine({
+                   'replicaCount': _render_merged_vars.web_replica_count | default(1) | int,
+                 }),
+           }, recursive=True) }}
+
+- name: Write rendered-values.yaml
+  ansible.builtin.copy:
+    content: "{{ _rendered_values | to_nice_yaml(indent=2) }}"
+    dest: "{{ instance_path }}/hosts/{{ _render_hostname }}/rendered-values.yaml"
+    mode: "0644"


### PR DESCRIPTION
## Summary

Implement multi-environment K8s gitops using Option E (Hybrid) from the design doc: template + per-host vars rendered to committed files, with Argo CD watching the rendered output.

### Repo structure after init

```
instance_path/
  Chart.yaml
  templates/
  values.template.yaml           ← shared base (all environments)
  hosts/
    hosts.yaml                   ← environment registry
    dev/
      vars.yaml                  ← per-env values (encrypted via git-crypt)
      rendered-values.yaml       ← rendered for Argo CD (unencrypted)
  argocd/
    application.yaml             ← points at hosts/dev/rendered-values.yaml
```

### What changed

**`init_kubernetes.yml`** — restructured for multi-env:
- Adds git-crypt (secrets in per-host vars, same model as Compose)
- Extracts per-environment values (domains, secrets, replicas, ingress) into `hosts/{name}/vars.yaml`
- Generates `values.template.yaml` as shared base
- Renders `hosts/{name}/rendered-values.yaml`
- Argo CD Application points at per-host rendered values
- `--key` saves the git-crypt key; SSH deploy key saved to `--key.ssh`
- Validates git identity before committing (supports `--git-user-name` / `--git-user-email`)

**`join_kubernetes.yml`** — new file, unblocks `canasta gitops join` for K8s:
- Clones repo (explicit `-b main`), unlocks git-crypt, creates per-host vars from current values.yaml
- Renders per-host values, creates Argo CD Application
- Same flow as Compose join, adapted for Helm values

**`render_kubernetes.yml`** — new shared task:
- Reads `values.template.yaml` + `hosts/{name}/vars.yaml`
- Supports `hosts/_shared/vars.yaml` (shared defaults, host overrides)
- Produces `hosts/{name}/rendered-values.yaml`

**`join.yml`** — dispatches to K8s join instead of failing

### Tested

End-to-end on a fresh EC2 VM:
1. `canasta create -i wikifarm -w main -o k8s` 
2. `canasta gitops init -i wikifarm --name dev --repo /tmp/gitops-test.git --key ~/gitops-key`
3. `canasta create -i wikifarm-staging -w main -o k8s`
4. `canasta gitops join -i wikifarm-staging --name staging --repo /tmp/gitops-test.git --key ~/gitops-key`
5. Verified: hosts.yaml has both environments, each has vars.yaml + rendered-values.yaml, Argo CD Applications point to correct per-env files, git repo has both commits

### What's next (Phase 3)
- Update `push_kubernetes.yml` and `pull_kubernetes.yml` to call `render_kubernetes.yml`
- Multi-env awareness in `gitops status` and `gitops diff`

Partial fix for #112
