### PR TITLE
Add canasta uninstall k8s command

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -519,7 +519,7 @@ def build_ansible_args(ansible_playbook, command_name, args, data):
 
     # Only pass target_host for commands that need it.
     # Other commands resolve the host from the instance registry.
-    HOST_COMMANDS = {"create", "list", "doctor", "install"}
+    HOST_COMMANDS = {"create", "list", "doctor", "install", "uninstall"}
     if args.host and command_name in HOST_COMMANDS:
         extra_vars["target_host"] = args.host
     elif args.host and command_name not in HOST_COMMANDS:

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -284,6 +284,27 @@ commands:
         required: true
         description: "Dependencies to install (docker, k8s, git-crypt)"
 
+  - name: uninstall
+    description: "Uninstall dependencies from the target host"
+    long_description: |
+      Uninstall dependencies from the target host. Supported packages:
+      k8s (removes k3s, kubectl, helm, and cleans up iptables rules).
+    examples:
+      - "canasta uninstall k8s"
+    playbook: uninstall.yml
+    parameters:
+      - name: packages
+        type: string
+        positional: true
+        multi: true
+        required: true
+        description: "Dependencies to uninstall (k8s)"
+      - name: "yes"
+        short: "y"
+        type: bool
+        default: false
+        description: "Skip confirmation prompt"
+
   - name: upgrade
     description: "Upgrade Canasta instances"
     long_description: |

--- a/playbooks/uninstall.yml
+++ b/playbooks/uninstall.yml
@@ -1,0 +1,22 @@
+---
+# canasta uninstall - Uninstall dependencies from the target host.
+
+- name: Normalize package names
+  ansible.builtin.set_fact:
+    _uninstall_packages: >-
+      {{ packages.split()
+         | map('regex_replace', '^(k8s|kubernetes)$', 'k3s')
+         | list }}
+
+- name: Validate packages
+  ansible.builtin.fail:
+    msg: >-
+      Unknown package '{{ item }}'. Supported: k8s.
+  when: item not in ['k3s']
+  loop: "{{ _uninstall_packages }}"
+
+- name: Uninstall Kubernetes (k3s, kubectl, helm)
+  ansible.builtin.include_role:
+    name: install
+    tasks_from: uninstall_k3s.yml
+  when: "'k3s' in _uninstall_packages"

--- a/roles/install/tasks/uninstall_k3s.yml
+++ b/roles/install/tasks/uninstall_k3s.yml
@@ -1,0 +1,52 @@
+---
+# Uninstall k3s, kubectl, helm, and clean up iptables rules.
+# Idempotent — skips if k3s is not installed.
+
+- name: Check if k3s is installed
+  ansible.builtin.stat:
+    path: /usr/local/bin/k3s-uninstall.sh
+  register: _k3s_uninstall_script
+
+- name: Report k3s not installed
+  ansible.builtin.debug:
+    msg: "k3s is not installed."
+  when: not _k3s_uninstall_script.stat.exists
+
+- name: Uninstall k3s
+  when: _k3s_uninstall_script.stat.exists
+  become: true
+  block:
+    - name: Report uninstalling
+      ansible.builtin.debug:
+        msg: "Uninstalling Kubernetes (k3s, kubectl, helm)..."
+
+    - name: Run k3s uninstall script
+      ansible.builtin.command:
+        cmd: /usr/local/bin/k3s-uninstall.sh
+      changed_when: true
+
+    - name: Remove kubectl symlink
+      ansible.builtin.file:
+        path: /usr/local/bin/kubectl
+        state: absent
+
+    - name: Remove helm
+      ansible.builtin.file:
+        path: /usr/local/bin/helm
+        state: absent
+
+    - name: Clean up stale KUBE-SERVICES iptables rules
+      ansible.builtin.shell:
+        cmd: |
+          iptables -t nat -D PREROUTING -m comment --comment "kubernetes service portals" -j KUBE-SERVICES 2>/dev/null || true
+          iptables -t nat -D OUTPUT -m comment --comment "kubernetes service portals" -j KUBE-SERVICES 2>/dev/null || true
+      changed_when: true
+
+    - name: Remove kubeconfig
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME | default('/root') }}/.kube/config"
+        state: absent
+
+    - name: Report uninstalled
+      ansible.builtin.debug:
+        msg: "Kubernetes (k3s, kubectl, helm) uninstalled."


### PR DESCRIPTION
## Summary
Add `canasta uninstall k8s` command that fully removes Kubernetes:
- Runs `k3s-uninstall.sh` (removes k3s, its data, and systemd service)
- Removes kubectl and helm from `/usr/local/bin`
- Flushes stale KUBE-SERVICES iptables rules that break Docker port mapping
- Removes kubeconfig

Found during external DB testing: `systemctl stop k3s` leaves iptables NAT rules that silently intercept traffic before it reaches Docker containers.

Fixes #245
