### PR TITLE
Sync COMPOSE_PROFILES when feature flags change via config set

### DIFF
--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -261,6 +261,13 @@
         key: MW_SITE_SERVER
         value: "{{ _server_scheme }}{{ _config_value }}"
 
+- name: Sync COMPOSE_PROFILES when feature flags change
+  when:
+    - instance_orchestrator | default('compose') == 'compose'
+    - _config_key in ['CANASTA_ENABLE_ELASTICSEARCH', 'CANASTA_ENABLE_VARNISH', 'CANASTA_ENABLE_OBSERVABILITY']
+  ansible.builtin.include_tasks: >-
+    {{ canasta_root }}/roles/orchestrator/tasks/sync_compose_profiles.yml
+
 - name: Apply CANASTA_ENABLE_OBSERVABILITY side effects
   when: _config_key == 'CANASTA_ENABLE_OBSERVABILITY' and _config_value | lower == 'true'
   ansible.builtin.include_role:


### PR DESCRIPTION
Setting `CANASTA_ENABLE_ELASTICSEARCH=true` via `config set` didn't update `COMPOSE_PROFILES`, so the Elasticsearch container never started on restart. The profile sync was only called from `start.yml`, not from the config set side effects.