### PR TITLE
Fix backup schedule list: handle missing purge flag

### DIFF
--- a/roles/backup/tasks/schedule_list.yml
+++ b/roles/backup/tasks/schedule_list.yml
@@ -42,9 +42,9 @@
         - name: Check for purge flag
           ansible.builtin.set_fact:
             _sched_purge: >-
-              {{ _sched_cmd
+              {{ (_sched_cmd
                  | regex_search('keep-within\s+(\S+)', '\1')
-                 | default([]) | first | default('') }}
+                 | default([], true)) | first | default('') }}
 
         - name: Display schedule
           ansible.builtin.debug:

--- a/roles/backup/tasks/schedule_list.yml
+++ b/roles/backup/tasks/schedule_list.yml
@@ -52,6 +52,8 @@
               Instance '{{ instance_id }}' is scheduled for backup at: {{ _sched_cron }}
               {% if _sched_purge %}
               Auto-purge: snapshots older than {{ _sched_purge }}
+              {% else %}
+              Auto-purge: not configured (snapshots will accumulate)
               {% endif %}
 
 # --- Kubernetes: CronJob ---

--- a/roles/backup/tasks/schedule_list.yml
+++ b/roles/backup/tasks/schedule_list.yml
@@ -73,9 +73,29 @@
         msg: "No backup schedule found for instance '{{ instance_id }}'."
       when: _k8s_cronjob.resources | length == 0
 
-    - name: Display schedule
-      ansible.builtin.debug:
-        msg: >-
-          Instance '{{ instance_id }}' is scheduled for backup at:
-          {{ _k8s_cronjob.resources[0].spec.schedule }}
+    - name: Parse and display schedule
       when: _k8s_cronjob.resources | length > 0
+      block:
+        - name: Extract restic command
+          ansible.builtin.set_fact:
+            _k8s_restic_cmd: >-
+              {{ ((_k8s_cronjob.resources[0].spec.jobTemplate.spec.template.spec.containers
+                  | selectattr('name', 'equalto', 'restic') | list | first
+                  | default({})).command | default([])) | last | default('') }}
+
+        - name: Check for purge flag
+          ansible.builtin.set_fact:
+            _k8s_sched_purge: >-
+              {{ (_k8s_restic_cmd
+                 | regex_search('keep-within\s+(\S+)', '\1')
+                 | default([], true)) | first | default('') }}
+
+        - name: Display schedule
+          ansible.builtin.debug:
+            msg: |-
+              Instance '{{ instance_id }}' is scheduled for backup at: {{ _k8s_cronjob.resources[0].spec.schedule }}
+              {% if _k8s_sched_purge %}
+              Auto-purge: snapshots older than {{ _k8s_sched_purge }}
+              {% else %}
+              Auto-purge: not configured (snapshots will accumulate)
+              {% endif %}

--- a/tests/integration/remote/Dockerfile
+++ b/tests/integration/remote/Dockerfile
@@ -2,12 +2,14 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install SSH server, Python 3, sudo, and prerequisites for Docker CLI
+# Install SSH server, Python 3, sudo, cron (for backup schedule tests),
+# and prerequisites for Docker CLI
 RUN apt-get update && apt-get install -y --no-install-recommends \
         openssh-server \
         python3 \
         python3-yaml \
         sudo \
+        cron \
         ca-certificates \
         curl \
         gnupg \

--- a/tests/integration/remote/run_tests.sh
+++ b/tests/integration/remote/run_tests.sh
@@ -124,8 +124,38 @@ else
 fi
 echo ""
 
-# --- Test 4: Delete without -H (resolved from registry) ---
-echo "Test 4: canasta delete without -H"
+# --- Test 4: Backup schedule set/list without --purge ---
+echo "Test 4: backup schedule list (no --purge)"
+if ! canasta backup schedule set -i "${INSTANCE_ID}" "0 3 * * *" 2>&1; then
+    fail "schedule set without --purge"
+else
+    SCHED_OUTPUT=$(canasta backup schedule list -i "${INSTANCE_ID}" 2>&1) || true
+    if echo "${SCHED_OUTPUT}" | grep -q "0 3 \* \* \*" \
+       && echo "${SCHED_OUTPUT}" | grep -qi "not configured"; then
+        pass "schedule list shows 'not configured' when --purge absent"
+    else
+        fail "schedule list (no --purge) unexpected output: ${SCHED_OUTPUT}"
+    fi
+fi
+echo ""
+
+# --- Test 5: Backup schedule set/list with --purge ---
+echo "Test 5: backup schedule list (with --purge)"
+if ! canasta backup schedule set -i "${INSTANCE_ID}" "0 4 * * *" --purge-older-than 30d 2>&1; then
+    fail "schedule set with --purge-older-than"
+else
+    SCHED_OUTPUT=$(canasta backup schedule list -i "${INSTANCE_ID}" 2>&1) || true
+    if echo "${SCHED_OUTPUT}" | grep -q "0 4 \* \* \*" \
+       && echo "${SCHED_OUTPUT}" | grep -q "snapshots older than 30d"; then
+        pass "schedule list shows purge duration when --purge set"
+    else
+        fail "schedule list (with --purge) unexpected output: ${SCHED_OUTPUT}"
+    fi
+fi
+echo ""
+
+# --- Test 6: Delete without -H (resolved from registry) ---
+echo "Test 6: canasta delete without -H"
 if canasta delete -i "${INSTANCE_ID}" -y 2>&1; then
     pass "delete without -H"
 else
@@ -133,8 +163,8 @@ else
 fi
 echo ""
 
-# --- Test 5: List (verify empty) ---
-echo "Test 5: canasta list (should be empty)"
+# --- Test 7: List (verify empty) ---
+echo "Test 7: canasta list (should be empty)"
 LIST_OUTPUT=$(canasta list 2>&1) || true
 if echo "${LIST_OUTPUT}" | grep -q "${INSTANCE_ID}"; then
     fail "list still shows deleted instance (output: ${LIST_OUTPUT})"


### PR DESCRIPTION
## Summary
- `regex_search` returns `None` (not an empty list) when there's no match
- `| default([])` only triggers on undefined, not on `None`, so `None | first` raised a `NoneType` error
- Use `| default([], true)` to trigger on falsy values including `None`

## Repro
\`\`\`
$ canasta backup schedule list -i \<instance\>
Error: Task failed: Finalization of task args for 'ansible.builtin.set_fact' failed: Error while resolving value for '_sched_purge': The filter plugin 'ansible.builtin.first' failed: 'NoneType' object is not iterable
\`\`\`
Hit when a schedule was set without `--purge`, so the cron command line has no `keep-within` clause.

## Test plan
- [x] Manual: run `canasta backup schedule list -i <instance>` where the schedule was set without `--purge` — now prints the schedule cleanly
- [ ] Verify schedule set *with* `--purge` still displays the auto-purge line