### PR TITLE
Add crontab check to canasta doctor

### DIFF
--- a/playbooks/doctor.yml
+++ b/playbooks/doctor.yml
@@ -93,6 +93,14 @@
   changed_when: false
   ignore_errors: true  # Checking if installed
 
+# --- Required for scheduled backups ---
+- name: Check crontab
+  ansible.builtin.shell:
+    cmd: command -v crontab
+  register: _doc_crontab
+  changed_when: false
+  ignore_errors: true  # Checking if installed
+
 # --- System resources ---
 - name: Check system memory
   ansible.builtin.command:
@@ -135,6 +143,9 @@
       GitOps (optional):
         git:             {{ (_doc_git.rc == 0) | ternary('OK (' + _doc_git.stdout | trim + ')', 'not installed') }}
         git-crypt:       {{ (_doc_gitcrypt.rc == 0) | ternary('OK', 'not installed') }}
+
+      Scheduled backups (optional):
+        crontab:         {{ (_doc_crontab.rc == 0) | ternary('OK', 'not installed (install cron to use canasta backup schedule)') }}
 
       System:
         Memory:          {{ _doc_memory.stdout | default('unknown') | trim }}


### PR DESCRIPTION
## Summary
- Add a crontab availability check to \`canasta doctor\`
- Surfaces a missing \`cron\` package *before* a user tries \`canasta backup schedule set\` and hits \`Failed to find required executable "crontab"\`

## Context
Minimal server images (Ubuntu Server, many cloud AMIs) don't include the \`cron\` package. \`canasta backup schedule\` uses \`crontab\` on the target host (same as the Go CLI), so the dependency was silently missing. Discovered on an ESIP host mid-backup setup.

## Test plan
- [ ] Run \`canasta doctor\` on a host with cron installed — shows \`crontab: OK\`
- [ ] Run \`canasta doctor\` on a host without cron — shows \`not installed (install cron to use canasta backup schedule)\`