### PR TITLE
Fix backup schedule list matching the wrong crontab line

### DIFF
--- a/roles/backup/tasks/schedule_list.yml
+++ b/roles/backup/tasks/schedule_list.yml
@@ -17,11 +17,15 @@
       changed_when: false
       ignore_errors: true  # OK if no crontab exists
 
+    # Ansible's cron module writes two lines to the crontab: a
+    # '#Ansible: <name>' comment and the actual cron entry. Match the
+    # command line (which contains 'canasta backup create -i <id>'),
+    # not the comment (which contains 'canasta-backup-<id>').
     - name: Filter backup schedule
       ansible.builtin.set_fact:
         _schedule_lines: >-
           {{ _cron_list.stdout_lines | default([])
-             | select('search', 'canasta-backup-' + instance_id)
+             | select('search', 'canasta backup create -i ' + instance_id + '\\b')
              | list }}
 
     - name: No schedule found

--- a/roles/backup/tasks/schedule_list.yml
+++ b/roles/backup/tasks/schedule_list.yml
@@ -15,7 +15,15 @@
         cmd: "crontab -l"
       register: _cron_list
       changed_when: false
-      ignore_errors: true  # OK if no crontab exists
+      failed_when: false  # rc=1 when crontab is empty; we handle missing binary below
+
+    - name: Fail if crontab command is missing
+      ansible.builtin.fail:
+        msg: >-
+          The 'crontab' command is not available on this host. Install
+          the cron package (e.g. 'apt install cron') to use backup
+          schedules.
+      when: _cron_list.rc is not defined
 
     # Ansible's cron module writes two lines to the crontab: a
     # '#Ansible: <name>' comment and the actual cron entry. Match the


### PR DESCRIPTION
## Problem

\`canasta backup schedule list\` was matching the wrong line of the crontab entry, producing output like:

\`\`\`
Instance 'mysite' is scheduled for backup at: #Ansible: canasta-backup-mysite
Auto-purge: not configured (snapshots will accumulate)
\`\`\`

…even when a schedule and \`--purge-older-than\` were set.

## Root cause

Ansible's \`cron\` module writes two lines to the crontab:

\`\`\`
#Ansible: canasta-backup-mysite
0 3 * * 0 canasta backup create -i mysite --tag scheduled && canasta backup purge -i mysite --keep-within 120d >> ...
\`\`\`

The previous filter selected lines matching \`canasta-backup-<id>\` — a string that only appears in the **comment line**. Split/parse logic then extracted the cron expression and command from the comment, giving the nonsensical output above.

## Fix

Match the command line by searching for \`canasta backup create -i <id>\` (with a \`\b\` boundary) — a string that only appears in the real cron entry, never in the comment.

## Why the integration tests added in #252 didn't catch it

Remote integration tests skip on PRs (\`if: github.event_name != 'pull_request'\` in \`tests.yml\`, per #67). They only run on push to main, so my own tests in #252 never exercised the buggy code path before merge.

## Test plan
- [x] Manual: \`canasta backup schedule list -i mysite\` now shows \`scheduled for backup at: 0 3 * * 0\` and \`Auto-purge: snapshots older than 120d\`
- [ ] Existing integration tests (from #252) will validate on next push to main