### PR TITLE
Fix regex escaping in backup schedule list filter

### DIFF
--- a/roles/backup/tasks/schedule_list.yml
+++ b/roles/backup/tasks/schedule_list.yml
@@ -27,13 +27,14 @@
 
     # Ansible's cron module writes two lines to the crontab: a
     # '#Ansible: <name>' comment and the actual cron entry. Match the
-    # command line (which contains 'canasta backup create -i <id>'),
-    # not the comment (which contains 'canasta-backup-<id>').
+    # command line (which contains 'canasta backup create -i <id> '),
+    # not the comment (which contains 'canasta-backup-<id>'). The
+    # trailing space anchors the match so 'foo' doesn't match 'foo2'.
     - name: Filter backup schedule
       ansible.builtin.set_fact:
         _schedule_lines: >-
           {{ _cron_list.stdout_lines | default([])
-             | select('search', 'canasta backup create -i ' + instance_id + '\\b')
+             | select('search', 'canasta backup create -i ' + instance_id + ' ')
              | list }}
 
     - name: No schedule found


### PR DESCRIPTION
## Problem

Post-merge integration run failed: [tests run 24669750473](https://github.com/CanastaWiki/Canasta-Ansible/actions/runs/24669750473)

\`\`\`
Test 4: backup schedule list (no --purge)
Backup schedule set: 0 3 * * *
  FAIL: schedule list (no --purge) unexpected output: No backup schedule found for instance 'remote-test'.
\`\`\`

Schedule set succeeded, but the list filter matched no lines and fell through to the \"No backup schedule found\" branch.

## Root cause

The filter I added in #255 used a \`\b\` word boundary expressed as \`'\\\\b'\` in the Jinja-interpolated regex pattern. The escape wasn't being interpreted as a regex word boundary in practice, so the select matched nothing.

## Fix

Swap the word boundary for a trailing literal space. \`schedule_set.yml\` always emits \`--tag scheduled\` after the instance_id, so a space reliably anchors the match. This avoids Jinja/YAML regex-escape semantics entirely and still prevents false-prefix matches like \`foo\` matching \`foo2\` (because \`foo2\` isn't followed by a space in \`-i foo2\`).

## Test plan
- [x] Local reasoning: pattern \`canasta backup create -i remote-test \` appears verbatim in the cron line, doesn't appear in the \`#Ansible:\` comment, doesn't match \`-i remote-test-2\`
- [ ] Remote integration tests pass on next push to main