### PR TITLE
Fix native install to avoid root-owned repo and user-local collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,18 +72,51 @@ run and whenever `canasta upgrade` is invoked.
 
 ### Option 2: Native install
 
+Run the installer:
+
 ```bash
+curl -fsSL https://get.canasta.wiki | bash -s -- --native
+```
+
+Log out and back in for group membership to take effect.
+
+<details>
+<summary>What the installer does (for manual installs)</summary>
+
+```bash
+# System prerequisites
+sudo apt-get install -y git python3 python3-venv
+
+# Create a 'canasta' group so non-root users can write to the install dir
+sudo groupadd --system canasta
+sudo usermod -aG canasta "$USER"
+
+# Clone and set group-writable permissions
 sudo git clone https://github.com/CanastaWiki/Canasta-Ansible.git /opt/canasta-ansible
-cd /opt/canasta-ansible
-sudo python3 -m venv .venv
-sudo .venv/bin/pip install -r requirements.txt
-sudo .venv/bin/ansible-galaxy collection install -r requirements.yml
-sudo make build-info   # capture version metadata — the sudo clone
-                       # leaves .git root-owned, so runtime 'git
-                       # rev-parse' refuses under the non-root user
+sudo chgrp -R canasta /opt/canasta-ansible
+sudo chmod -R g+w /opt/canasta-ansible
+
+# Mark as safe for git (needed because git refuses operations on
+# directories owned by a different user)
+sudo git config --system --add safe.directory /opt/canasta-ansible
+
+# Python venv and Ansible collections (collections go to a
+# system-wide path so all users can see them)
+sudo python3 -m venv /opt/canasta-ansible/.venv
+sudo /opt/canasta-ansible/.venv/bin/pip install -r /opt/canasta-ansible/requirements.txt
+sudo /opt/canasta-ansible/.venv/bin/ansible-galaxy collection install \
+  -r /opt/canasta-ansible/requirements.yml \
+  -p /usr/share/ansible/collections
+sudo chgrp -R canasta /opt/canasta-ansible/.venv
+sudo chmod -R g+w /opt/canasta-ansible/.venv
+
+# Build metadata and symlinks
+sudo make -C /opt/canasta-ansible build-info
 sudo ln -sf /opt/canasta-ansible/canasta-native /usr/local/bin/canasta-native
 sudo ln -sf /usr/local/bin/canasta-native /usr/local/bin/canasta
 ```
+
+</details>
 
 ### Both wrappers available
 

--- a/roles/install/tasks/canasta.yml
+++ b/roles/install/tasks/canasta.yml
@@ -56,11 +56,35 @@
         state: present
       when: ansible_os_family | default('') == 'RedHat'
 
+    - name: Ensure 'canasta' system group exists
+      ansible.builtin.group:
+        name: canasta
+        system: true
+        state: present
+
     - name: Clone Canasta-Ansible repository
       ansible.builtin.git:
         repo: "https://github.com/CanastaWiki/Canasta-Ansible.git"
         dest: /opt/canasta-ansible
         version: main
+
+    # Install dir needs to be writable by non-root users so that
+    # 'canasta upgrade' (which runs git pull) and 'canasta install'
+    # (which writes build metadata) don't fail under the regular user.
+    - name: Set group ownership and group-writable permissions
+      ansible.builtin.file:
+        path: /opt/canasta-ansible
+        group: canasta
+        mode: g+w
+        recurse: true
+
+    # Git refuses operations on repositories owned by a different
+    # user (the 'dubious ownership' check). Mark as safe system-wide
+    # so non-root users can run git commands against the install dir.
+    - name: Mark install dir as a git safe.directory
+      ansible.builtin.command:
+        cmd: "git config --system --add safe.directory /opt/canasta-ansible"
+      changed_when: true
 
     - name: Create Python virtual environment
       ansible.builtin.command:
@@ -72,9 +96,14 @@
         cmd: "/opt/canasta-ansible/.venv/bin/pip install -r /opt/canasta-ansible/requirements.txt"
       changed_when: true
 
+    # Install to a system-wide path so the collections are visible to
+    # all users, not just root (default is root's ~/.ansible/collections).
     - name: Install Ansible collections
       ansible.builtin.command:
-        cmd: "/opt/canasta-ansible/.venv/bin/ansible-galaxy collection install -r /opt/canasta-ansible/requirements.yml"
+        cmd: >-
+          /opt/canasta-ansible/.venv/bin/ansible-galaxy collection install
+          -r /opt/canasta-ansible/requirements.yml
+          -p /usr/share/ansible/collections
       changed_when: true
 
     - name: Generate build info
@@ -82,6 +111,13 @@
         cmd: "git rev-parse --short HEAD > BUILD_COMMIT && git log -1 --format=%cd --date=format:'%Y-%m-%d %H:%M:%S' > BUILD_DATE"
         chdir: "/opt/canasta-ansible"
       changed_when: true
+
+    - name: Re-apply group ownership after venv/build-info writes
+      ansible.builtin.file:
+        path: /opt/canasta-ansible
+        group: canasta
+        mode: g+w
+        recurse: true
 
     - name: Create canasta-native symlink
       ansible.builtin.file:
@@ -97,4 +133,7 @@
 
     - name: Report canasta installed
       ansible.builtin.debug:
-        msg: "canasta-native installed at /opt/canasta-ansible."
+        msg: >-
+          canasta-native installed at /opt/canasta-ansible.
+          Add users to the 'canasta' group to let them run
+          'canasta upgrade' and 'canasta install' without sudo.


### PR DESCRIPTION
## Problem

Both the README's Option 2 manual steps and \`canasta install canasta\` leave the install dir root-owned and install Ansible collections under root's home. Regular users then hit two separate failures:

\`canasta upgrade\`:
\`\`\`
Error: non-zero return code
fatal: detected dubious ownership in repository at '/opt/canasta-ansible'
\`\`\`

\`canasta <any command using kubernetes.core>\`:
\`\`\`
[WARNING]: Error loading plugin 'kubernetes.core.k8s': No module named 'ansible_collections.kubernetes'
[ERROR]: couldn't resolve module/action 'kubernetes.core.k8s'.
\`\`\`

## Fix

Align both the README and \`canasta install canasta\` with what \`get-canasta.sh\` already does:

1. Create a \`canasta\` system group and \`chgrp -R canasta + chmod g+w\` the install dir
2. \`git config --system --add safe.directory /opt/canasta-ansible\`
3. Install collections to \`/usr/share/ansible/collections\` (Ansible's default system search path, visible to all users), not root's home

README also now recommends \`curl -fsSL https://get.canasta.wiki | bash -s -- --native\` as the primary install path, with the manual steps preserved in a collapsed \`<details>\` block for anyone who wants to see what the installer does.

## Related
- Noticed during ESIP rollout: user installed via README's manual steps, then hit both errors.
- \`get-canasta.sh\` already does all this correctly — this PR makes the other two paths consistent.

## Test plan
- [ ] \`canasta --host <fresh-host> install canasta\` followed by \`canasta --host <fresh-host> upgrade\` as a non-root user completes without errors
- [ ] \`canasta --host <fresh-host> install canasta\` then \`canasta --host <fresh-host> doctor\` shows kubernetes.core working
- [ ] README manual steps produce the same working state as the \`--native\` installer