### PR TITLE
Fix 'canasta version' reporting native installs as docker

### DIFF
--- a/canasta-docker
+++ b/canasta-docker
@@ -541,6 +541,10 @@ if [[ -t 0 ]]; then
     DOCKER_RUN_FLAGS+=(-t)
 fi
 
+# Tell canasta.py it's running under the docker wrapper, so
+# 'canasta version' reports the correct run mode.
+DOCKER_RUN_FLAGS+=(-e CANASTA_RUN_MODE=docker)
+
 # Dry-run mode for tests: print the assembled docker run command, one
 # argument per line, and exit. Does not invoke docker.
 if [[ -n "${CANASTA_DOCKER_DRY_RUN:-}" ]]; then

--- a/direct_commands.py
+++ b/direct_commands.py
@@ -533,9 +533,14 @@ def cmd_version(args):
     except OSError:
         version = "unknown"
 
+    # Run mode is set by the canasta-docker wrapper. Presence of
+    # BUILD_COMMIT isn't a reliable signal — native installs also
+    # write it (via 'make build-info') so 'canasta version' works
+    # outside a git checkout.
+    mode = "docker" if os.environ.get("CANASTA_RUN_MODE") == "docker" else "native"
+
     build_commit_file = os.path.join(script_dir, "BUILD_COMMIT")
     if os.path.isfile(build_commit_file):
-        mode = "docker"
         try:
             with open(build_commit_file) as f:
                 commit = f.read().strip()
@@ -545,7 +550,6 @@ def cmd_version(args):
             commit = "unknown"
             date = "unknown"
     else:
-        mode = "native"
         try:
             result = subprocess.run(
                 ["git", "rev-parse", "--short", "HEAD"],

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -634,6 +634,7 @@ class TestCmdVersion:
 
     def test_native_checkout(self, tmp_path, monkeypatch, capsys):
         (tmp_path / "VERSION").write_text("4.0.0\n")
+        monkeypatch.delenv("CANASTA_RUN_MODE", raising=False)
         monkeypatch.setattr(direct_commands, "_get_script_dir", lambda: str(tmp_path))
         monkeypatch.setattr(
             subprocess, "run",
@@ -653,6 +654,7 @@ class TestCmdVersion:
         (tmp_path / "VERSION").write_text("4.0.0\n")
         (tmp_path / "BUILD_COMMIT").write_text("def5678\n")
         (tmp_path / "BUILD_DATE").write_text("2026-04-18 10:00:00\n")
+        monkeypatch.setenv("CANASTA_RUN_MODE", "docker")
         monkeypatch.setattr(direct_commands, "_get_script_dir", lambda: str(tmp_path))
         rc = direct_commands.cmd_version(None)
         assert rc == 0
@@ -660,6 +662,22 @@ class TestCmdVersion:
         assert "v4.0.0" in out
         assert "docker" in out
         assert "def5678" in out
+
+    def test_native_with_build_files(self, tmp_path, monkeypatch, capsys):
+        """Native installs also write BUILD_COMMIT/BUILD_DATE (via
+        get-canasta.sh or make build-info). The presence of those
+        files must not cause mode to be misreported as docker."""
+        (tmp_path / "VERSION").write_text("4.0.0\n")
+        (tmp_path / "BUILD_COMMIT").write_text("abc1234\n")
+        (tmp_path / "BUILD_DATE").write_text("2026-04-20 14:00:00\n")
+        monkeypatch.delenv("CANASTA_RUN_MODE", raising=False)
+        monkeypatch.setattr(direct_commands, "_get_script_dir", lambda: str(tmp_path))
+        rc = direct_commands.cmd_version(None)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "v4.0.0" in out
+        assert "native" in out
+        assert "abc1234" in out
 
     def test_missing_version_file(self, tmp_path, monkeypatch, capsys):
         monkeypatch.setattr(direct_commands, "_get_script_dir", lambda: str(tmp_path))


### PR DESCRIPTION
## Problem

After a native install, \`canasta version\` reports the run mode as \`docker\`:

\`\`\`
$ canasta version
Canasta CLI v4.0.0 (docker, commit f8d1f0c, built 2026-04-20 10:24:44)
\`\`\`

Even though \`/usr/local/bin/canasta\` is symlinked to \`canasta-native\`.

## Root cause

\`cmd_version\` in \`direct_commands.py\` keyed the mode on whether \`BUILD_COMMIT\` existed on disk:

\`\`\`python
if os.path.isfile(build_commit_file):
    mode = \"docker\"
else:
    mode = \"native\"
\`\`\`

That was only true when BUILD_COMMIT existed exclusively in the Docker image. But \`get-canasta.sh\` writes BUILD_COMMIT/BUILD_DATE for native installs too (so \`canasta version\` keeps working when the install dir isn't a full git checkout), and the README's \`sudo make build-info\` step does the same. So every native install ended up reporting as docker.

## Fix

Decouple mode detection from file presence:

- \`canasta-docker\` now passes \`-e CANASTA_RUN_MODE=docker\` into the container
- \`cmd_version\` reads \`CANASTA_RUN_MODE\` — defaults to \`native\` when unset
- Commit/date still come from \`BUILD_COMMIT\`/\`BUILD_DATE\` when present, falling back to \`git rev-parse\` in the checkout

## Tests

- Updated \`test_docker_mode\` to set the env var (since file presence no longer drives mode)
- Added \`test_native_with_build_files\` to guard the specific regression — native install with baked-in build metadata must still report as \`native\`

All 464 unit tests pass locally.