### PR TITLE
Fix get-canasta.sh leaving BUILD_COMMIT root-owned after native install

### DIFF
--- a/get-canasta.sh
+++ b/get-canasta.sh
@@ -195,12 +195,8 @@ install_native_linux() {
         $SUDO git clone "$REPO_URL" "$install_dir"
     fi
 
-    # Set group ownership
-    info "Setting group ownership to 'canasta'..."
-    $SUDO chgrp -R canasta "$install_dir"
-    $SUDO chmod -R g+w "$install_dir"
-
-    # Mark as safe directory for git
+    # Mark as safe directory for git (so non-root users can run git
+    # commands against the root-owned repo during e.g. 'canasta upgrade')
     $SUDO git config --system --add safe.directory "$install_dir" 2>/dev/null || true
 
     # Create venv and install deps
@@ -208,21 +204,25 @@ install_native_linux() {
     $SUDO python3 -m venv "${install_dir}/.venv"
     $SUDO "${install_dir}/.venv/bin/pip" install --quiet -r "${install_dir}/requirements.txt"
 
-    # Set group ownership on venv too
-    $SUDO chgrp -R canasta "${install_dir}/.venv"
-    $SUDO chmod -R g+w "${install_dir}/.venv"
-
-    # Build metadata
+    # Build metadata (written as root, group-fixed in the final pass below)
     info "Writing build metadata..."
     $SUDO bash -c "cd '${install_dir}' && git rev-parse --short HEAD > BUILD_COMMIT && git log -1 --format=%cd --date=format:'%Y-%m-%d %H:%M:%S' > BUILD_DATE"
 
-    # Install Ansible collections
+    # Install Ansible collections (system path, not root's home)
     if [[ -f "${install_dir}/requirements.yml" ]]; then
         info "Installing Ansible collections..."
         $SUDO "${install_dir}/.venv/bin/ansible-galaxy" collection install \
             -r "${install_dir}/requirements.yml" \
             -p /usr/share/ansible/collections 2>/dev/null || true
     fi
+
+    # Set group ownership AFTER all file writes so BUILD_COMMIT,
+    # BUILD_DATE, and venv files are group-writable. Running before
+    # these writes leaves the new files root:root, which blocks
+    # non-root upgrades.
+    info "Setting group ownership to 'canasta'..."
+    $SUDO chgrp -R canasta "$install_dir"
+    $SUDO chmod -R g+w "$install_dir"
 
     # Create symlinks
     info "Creating symlinks in ${BIN_DIR}..."


### PR DESCRIPTION
## Problem

After a fresh \`get-canasta.sh --native\` install, \`canasta upgrade\` fails for non-root users:

\`\`\`
$ canasta upgrade
Error: non-zero return code
/bin/sh: 1: cannot create BUILD_COMMIT: Permission denied
\`\`\`

\`canasta upgrade\` regenerates BUILD_COMMIT/BUILD_DATE after \`git pull\`. The files exist from install time but are owned \`root:root\` mode \`0644\`, so non-root users in the \`canasta\` group can't truncate them.

## Root cause

In \`install_native_linux\`, the \`chgrp -R canasta\` / \`chmod -R g+w\` passes ran **before** the shell that writes BUILD_COMMIT and BUILD_DATE:

\`\`\`bash
chgrp -R canasta  ...
chmod -R g+w ...
...
bash -c \"cd ... && git rev-parse > BUILD_COMMIT && ... > BUILD_DATE\"
\`\`\`

Because that shell runs under \`sudo\`, the new files inherit root's primary group, not \`canasta\`.

## Fix

Move the single \`chgrp + chmod g+w\` pass to the end of the function, after all file writes (venv + build-info). Drop the redundant venv-specific pass.

## Related
- \`canasta install canasta\` (roles/install/tasks/canasta.yml) had the same bug — fixed in #257 with a \"re-apply\" pass after the build-info write. This PR brings the standalone shell installer to parity.

## Test plan
- [ ] Fresh install: \`curl -fsSL https://get.canasta.wiki | bash -s -- --native\` followed by logout/login
- [ ] Verify: \`ls -la /opt/canasta-ansible/BUILD_COMMIT\` shows group \`canasta\` mode \`-rw-rw-r--\`
- [ ] \`canasta upgrade\` completes without permission errors under the regular user