### PR TITLE
Add optional file path argument to 'canasta gitops add'

### DIFF
--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -1149,8 +1149,12 @@ commands:
 
   - name: gitops_add
     description: "Add configuration changes to git"
-    long_description: "Stage configuration changes for the next gitops push."
+    long_description: |
+      Stage configuration changes for the next gitops push. If a file
+      path is given, stage just that path. Without a path, stage all
+      changes under the config directory (existing behavior).
     examples:
+      - "canasta gitops add -i mysite extensions/WikiWorks/LocalSettings.php"
       - "canasta gitops add -i mysite"
     playbook: gitops_add.yml
     parameters:
@@ -1158,6 +1162,10 @@ commands:
         short: i
         type: string
         description: "Canasta instance ID"
+      - name: path
+        type: string
+        positional: true
+        description: "File path to stage (relative to instance root)"
 
   - name: gitops_rm
     description: "Remove configuration from git tracking"

--- a/roles/gitops/tasks/add.yml
+++ b/roles/gitops/tasks/add.yml
@@ -2,9 +2,18 @@
 - name: Resolve instance
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/common/tasks/resolve_instance.yml"
 
-- name: Stage changes
+- name: Stage specific file
+  ansible.builtin.command:
+    cmd: "git add {{ path }}"
+    chdir: "{{ instance_path }}"
+  register: _git_add_path
+  changed_when: _git_add_path.rc == 0
+  when: path is defined and path != ''
+
+- name: Stage all changes under config/
   ansible.builtin.command:
     cmd: "git add -A"
     chdir: "{{ instance_path }}/config"
   register: _git_add
   changed_when: _git_add.rc == 0
+  when: path is not defined or path == ''


### PR DESCRIPTION
## Summary

Mirror the file-path argument that \`canasta gitops rm\` got in #241. The original intent for #241 was for both \`add\` and \`rm\` to accept an optional path; this PR brings \`add\` to parity.

Behavior:
- \`canasta gitops add -i mysite\` — stage everything in \`config/\` (unchanged)
- \`canasta gitops add -i mysite extensions/WikiWorks/LocalSettings.php\` — stage just that path, relative to the instance root

## Why

Today, \`gitops add\` only knows how to stage changes under \`config/\`. When the user has a local edit outside that tree (a committed-in-tree extension's Settings.php, a public_asset file, etc.) there's no way to stage it without falling back to raw \`git add\` in the instance dir. The path-argument form unblocks that.

## Test plan
- [ ] \`canasta gitops add -i X\` (no path) — existing behavior, stages config/ changes
- [ ] \`canasta gitops add -i X path/to/file\` — stages exactly that file
- [ ] \`canasta gitops status -i X\` after each reflects the correct staged state