### PR TITLE
Fix 'wiki is undefined' across maintenance script/update and sitemap generate/remove

### DIFF
--- a/roles/maintenance/tasks/script.yml
+++ b/roles/maintenance/tasks/script.yml
@@ -12,7 +12,7 @@
 
 - name: Build script command
   ansible.builtin.set_fact:
-    _script_cmd: "php maintenance/{{ script_args }}{{ ((wiki | default('')) != '') | ternary(' --wiki=' + (wiki | quote), '') }}"
+    _script_cmd: "php maintenance/{{ script_args }}{{ ((wiki | default('')) != '') | ternary(' --wiki=' + (wiki | default('') | quote), '') }}"
 
 - name: Run maintenance script
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"

--- a/roles/maintenance/tasks/update.yml
+++ b/roles/maintenance/tasks/update.yml
@@ -17,8 +17,7 @@
 - name: Determine wikis to update
   ansible.builtin.set_fact:
     _update_wikis: >-
-      {{ ((wiki | default('')) != '')
-         | ternary([wiki], _maint_wikis.wiki_ids) }}
+      {{ [wiki] if (wiki | default('') != '') else _maint_wikis.wiki_ids }}
 
 - name: Run update.php for each wiki
   ansible.builtin.include_tasks: >-

--- a/roles/sitemap/tasks/generate.yml
+++ b/roles/sitemap/tasks/generate.yml
@@ -21,7 +21,7 @@
 
 - name: Determine wikis for sitemap generation
   ansible.builtin.set_fact:
-    _sitemap_targets: "{{ ((wiki | default('')) != '') | ternary([wiki], _sitemap_wikis.wiki_ids) }}"
+    _sitemap_targets: "{{ [wiki] if (wiki | default('') != '') else _sitemap_wikis.wiki_ids }}"
 
 - name: Create sitemap directories and generate for each wiki
   ansible.builtin.include_tasks: _generate_single.yml

--- a/roles/sitemap/tasks/remove.yml
+++ b/roles/sitemap/tasks/remove.yml
@@ -14,7 +14,7 @@
 
 - name: Determine wikis for sitemap removal
   ansible.builtin.set_fact:
-    _sitemap_targets: "{{ ((wiki | default('')) != '') | ternary([wiki], _sitemap_wikis.wiki_ids) }}"
+    _sitemap_targets: "{{ [wiki] if (wiki | default('') != '') else _sitemap_wikis.wiki_ids }}"
 
 - name: Remove sitemaps for each wiki
   ansible.builtin.include_tasks: "{{ canasta_root }}/roles/orchestrator/tasks/exec.yml"


### PR DESCRIPTION
## Problem

\`canasta maintenance script <file>\` (without \`-w\`) fails before the script runs:

\`\`\`
Error: Task failed: Finalization of task args for 'ansible.builtin.set_fact' failed:
  Error while resolving value for '_script_cmd': 'wiki' is undefined
\`\`\`

Same bug lurks in three other places that use the same pattern.

## Root cause

Jinja's \`ternary\` filter evaluates **both** branches before selecting. If the true branch references an undefined variable, it raises even when the false branch would be chosen.

## Scope — fixed everywhere we use this shape

| File | Before | After |
|---|---|---|
| \`roles/maintenance/tasks/script.yml\` | \`ternary(' --wiki=' + (wiki\\|quote), '')\` | added \`\\| default('')\` before \`\\| quote\` |
| \`roles/maintenance/tasks/update.yml\` | \`ternary([wiki], _maint_wikis.wiki_ids)\` | \`[wiki] if (wiki\\|default('') != '') else ...\` |
| \`roles/sitemap/tasks/generate.yml\` | \`ternary([wiki], _sitemap_wikis.wiki_ids)\` | lazy conditional |
| \`roles/sitemap/tasks/remove.yml\` | \`ternary([wiki], _sitemap_wikis.wiki_ids)\` | lazy conditional |

For the \`[wiki]\` cases, switched to Jinja's conditional expression (\`X if Y else Z\`) which IS lazy — only the selected branch is evaluated. Cleaner than wrapping \`wiki\` with \`default('')\` inside the list.

Scanned all other \`ternary(...)\` calls under \`roles/\`; the remaining ones either use constants, already-defaulted vars, or vars that are guaranteed defined by surrounding logic.

## Related
- #251 fixed the same shape in \`roles/maintenance/tasks/extension.yml\`. That one was caught first; these four slipped through.

## UX footnote (not in scope)

Separately: \`script_args\` uses \`nargs=argparse.REMAINDER\`, so any flag after the script name is consumed as part of the args. Workaround: put flags first — \`canasta maintenance script -i pge -w pge -- refreshLinks.php\`. Could be worth documenting more prominently or tightening, but out of scope for this bug-fix PR.

## Test plan
- [ ] \`canasta maintenance script -i mysite -- rebuildall.php\` (no \`-w\`) completes without the undefined error
- [ ] \`canasta maintenance script -i mysite -w main -- rebuildall.php\` still passes \`--wiki\` through
- [ ] \`canasta maintenance update -i mysite\` (no \`-w\`) iterates all wikis
- [ ] \`canasta maintenance update -i mysite -w main\` targets just main
- [ ] \`canasta sitemap generate\` and \`canasta sitemap remove\` behave the same way