### PR TITLE
K8s external database: auto-populate values.yaml from .env on create

### DIFF
--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -288,6 +288,11 @@
 #   MW_SITE_FQDN         → domains: [<value>]
 #   CANASTA_ENABLE_VARNISH → varnish.enabled: <bool>
 #   CANASTA_ENABLE_ELASTICSEARCH → elasticsearch.enabled: <bool>
+#
+# External DB keys (USE_EXTERNAL_DB, MYSQL_*) are intentionally NOT
+# propagated here — _validate_key.yml blocks them as immutable after
+# create. The values.yaml mapping is populated at create time only
+# (see roles/create/tasks/main.yml and templates/k8s_values.yaml.j2).
 - name: Propagate config key to K8s values.yaml
   when:
     - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']

--- a/roles/create/tasks/main.yml
+++ b/roles/create/tasks/main.yml
@@ -522,6 +522,25 @@
         - _default_sc.value is not none
         - _default_sc.value | length > 0
 
+    # Read external-DB configuration from .env so the values.yaml
+    # template can switch db.enabled and populate externalDatabase.
+    # When USE_EXTERNAL_DB=true, the user's envfile has supplied
+    # MYSQL_HOST/PORT/USER/SSL; we surface those as Ansible vars.
+    - name: Read external DB config from .env
+      canasta_env:
+        path: "{{ instance_path }}/.env"
+        state: read_all
+      register: _k8s_env_for_values
+
+    - name: Set external DB facts for values.yaml template
+      ansible.builtin.set_fact:
+        _use_external_db: >-
+          {{ (_k8s_env_for_values.variables.USE_EXTERNAL_DB | default('false') | lower) == 'true' }}
+        _external_db_host: "{{ _k8s_env_for_values.variables.MYSQL_HOST | default('') }}"
+        _external_db_port: "{{ _k8s_env_for_values.variables.MYSQL_PORT | default('3306') }}"
+        _external_db_user: "{{ _k8s_env_for_values.variables.MYSQL_USER | default('root') }}"
+        _external_db_ssl: "{{ _k8s_env_for_values.variables.MYSQL_SSL | default('false') }}"
+
     - name: Generate instance values.yaml
       ansible.builtin.template:
         src: "{{ canasta_root }}/roles/orchestrator/templates/k8s_values.yaml.j2"

--- a/roles/orchestrator/files/helm/canasta/templates/service-aliases.yaml
+++ b/roles/orchestrator/files/helm/canasta/templates/service-aliases.yaml
@@ -25,6 +25,7 @@ spec:
   selector:
     {{- include "canasta.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: caddy
+{{- if .Values.db.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -44,6 +45,7 @@ spec:
   selector:
     {{- include "canasta.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: db
+{{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/roles/orchestrator/templates/k8s_values.yaml.j2
+++ b/roles/orchestrator/templates/k8s_values.yaml.j2
@@ -31,6 +31,21 @@ secrets:
 
 argocd:
   namespace: {{ argocd_namespace | default('argocd') }}
+
+{% if _use_external_db | default(false) %}
+# External database: Canasta points at a DB server the user operates
+# (managed service like RDS/Aurora/CloudSQL, or a self-hosted cluster
+# such as Galera/MaxScale/Percona XtraDB). The bundled db StatefulSet
+# is not deployed when db.enabled is false.
+db:
+  enabled: false
+
+externalDatabase:
+  host: "{{ _external_db_host | default('') }}"
+  port: "{{ _external_db_port | default('3306') }}"
+  user: "{{ _external_db_user | default('root') }}"
+  ssl: "{{ _external_db_ssl | default('false') }}"
+{% endif %}
 {% if (storage_class is defined and storage_class != '') or (access_mode is defined and access_mode != '') %}
 
 persistence:

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -167,6 +167,82 @@ class TestHelmChart:
         )
 
 
+class TestExternalDatabase:
+    """External DB support on the K8s path: chart gates db.enabled,
+    surfaces externalDatabase, and the service alias for the internal
+    db is only rendered when db.enabled=true."""
+
+    def test_chart_values_has_external_database_defaults(self):
+        with open(os.path.join(HELM_CHART, "values.yaml")) as f:
+            values = yaml.safe_load(f)
+        assert "externalDatabase" in values, (
+            "values.yaml must expose externalDatabase for the external DB path"
+        )
+        assert values["db"]["enabled"] is True, (
+            "Default db.enabled must be true (internal DB is the default)"
+        )
+
+    def test_statefulset_db_is_gated_on_db_enabled(self):
+        path = os.path.join(HELM_CHART, "templates", "statefulset-db.yaml")
+        with open(path) as f:
+            content = f.read()
+        assert "{{- if .Values.db.enabled }}" in content, (
+            "statefulset-db.yaml must be gated on .Values.db.enabled"
+        )
+
+    def test_service_alias_db_is_gated_on_db_enabled(self):
+        """The 'db' Service alias in service-aliases.yaml must only
+        render when db.enabled=true. Otherwise we leave a dangling
+        Service with no endpoints on external-DB deployments."""
+        path = os.path.join(HELM_CHART, "templates", "service-aliases.yaml")
+        with open(path) as f:
+            content = f.read()
+        # Find the section declaring the 'db' alias Service and verify
+        # it sits inside a .Values.db.enabled guard.
+        assert "name: db" in content, "service-aliases.yaml should declare a 'db' Service"
+        db_idx = content.index("name: db")
+        preceding = content[:db_idx]
+        assert "{{- if .Values.db.enabled }}" in preceding.splitlines()[-10:][0:10].__str__() \
+            or "{{- if .Values.db.enabled }}" in "\n".join(preceding.splitlines()[-5:]), (
+            "The 'db' Service in service-aliases.yaml must be wrapped in "
+            "a {{- if .Values.db.enabled }} guard"
+        )
+
+    def test_web_and_jobrunner_switch_mysql_host_on_db_enabled(self):
+        """Both deployment templates must pick MYSQL_HOST from
+        externalDatabase.host when db.enabled is false."""
+        templates = os.path.join(HELM_CHART, "templates")
+        for template_name in ("deployment-web.yaml", "deployment-jobrunner.yaml"):
+            with open(os.path.join(templates, template_name)) as f:
+                content = f.read()
+            assert ".Values.externalDatabase.host" in content, (
+                "%s must reference .Values.externalDatabase.host for "
+                "external DB support" % template_name
+            )
+            assert ".Values.db.enabled" in content, (
+                "%s must gate MYSQL_HOST on .Values.db.enabled" % template_name
+            )
+
+    def test_values_template_emits_external_db_when_flagged(self):
+        """The Ansible k8s_values.yaml.j2 template must emit db.enabled
+        and externalDatabase when _use_external_db is true."""
+        template_path = os.path.join(
+            REPO_ROOT, "roles", "orchestrator", "templates",
+            "k8s_values.yaml.j2",
+        )
+        with open(template_path) as f:
+            content = f.read()
+        assert "_use_external_db" in content, (
+            "k8s_values.yaml.j2 must consult the _use_external_db fact"
+        )
+        assert "externalDatabase:" in content, (
+            "k8s_values.yaml.j2 must render an externalDatabase section"
+        )
+        assert "enabled: false" in content, (
+            "k8s_values.yaml.j2 must flip db.enabled to false when external"
+        )
+
+
 class TestGitopsDispatchers:
     """Verify that each dispatched gitops command has both variants."""
 


### PR DESCRIPTION
## Summary

PR #211 shipped external-DB support for Compose and wired the Helm chart with \`db.enabled\` + \`externalDatabase\` values. The K8s side of the CLI still rendered \`values.yaml\` from chart defaults only, so passing \`USE_EXTERNAL_DB=true\` via \`-e envfile\` landed the value in \`.env\` but never in the Helm values — Helm kept deploying the bundled db StatefulSet.

This PR closes the gap by threading external-DB config from \`.env\` through to the rendered \`values.yaml\` at create time.

## Changes

1. **\`roles/orchestrator/templates/k8s_values.yaml.j2\`** — when \`_use_external_db\` is true, emit \`db.enabled: false\` and an \`externalDatabase\` block with \`host\`/\`port\`/\`user\`/\`ssl\`. Internal-DB path is unchanged (block omitted, chart defaults apply).
2. **\`roles/create/tasks/main.yml\`** — before generating values.yaml for K8s, read \`USE_EXTERNAL_DB\` / \`MYSQL_HOST\` / \`MYSQL_PORT\` / \`MYSQL_USER\` / \`MYSQL_SSL\` from \`.env\` and expose them as facts for the template.
3. **\`roles/orchestrator/files/helm/canasta/templates/service-aliases.yaml\`** — gate the \`db\` Service alias on \`.Values.db.enabled\`. Without this, external-DB deployments left a dangling Service whose selector matched nothing.
4. **\`roles/config/tasks/_side_effects.yml\`** — documents that external-DB keys are intentionally NOT propagated by \`config set\` (the post-create \`USE_EXTERNAL_DB\` / \`MYSQL_*\` keys are blocked as immutable in \`_validate_key.yml\`).

Password handling was already correct before this PR — \`create/main.yml\` overrides \`_wikidbpass\` with the envfile's \`MYSQL_PASSWORD\` when \`USE_EXTERNAL_DB=true\`, and \`k8s_apply_secrets.yml\` writes it into the \`db-credentials\` Secret. No changes needed there.

## Usage

\`\`\`bash
cat > external-db.env <<'EOF2'
USE_EXTERNAL_DB=true
MYSQL_HOST=rds.example.com
MYSQL_PORT=3306
MYSQL_USER=wiki
MYSQL_PASSWORD=secret
MYSQL_SSL=false
EOF2

canasta create -i mysite -w main -n example.com \\
  --orchestrator kubernetes -e external-db.env
\`\`\`

Result: the instance's \`values.yaml\` has \`db.enabled: false\` + populated \`externalDatabase\`; the Helm chart skips \`statefulset-db\` and the internal \`db\` Service alias; web and jobrunner pods resolve MYSQL_HOST to the external endpoint.

## Context — #347 (CanastaWiki/Canasta-CLI)

Completes the second orchestrator for \"Phase 1\" of the HA DB story tracked in Canasta-CLI #347. External DB is now supported on both Compose and Kubernetes. With that, the canonical HA story is: users operate whatever HA DB topology they prefer (managed RDS/Aurora/CloudSQL, self-hosted MariaDB Galera / Percona XtraDB / MaxScale-fronted replicas) and point Canasta at it. MediaWiki's \`\$wgDBservers\` already handles read replicas and chronology protection.

## Tests

- 5 new unit tests under \`TestExternalDatabase\` in \`test_kubernetes_structure.py\` — chart defaults, \`statefulset-db\` gating, service-alias gating, deployment MYSQL_HOST switching, values.yaml.j2 external-DB branch.
- All 469 unit tests pass.
- Verified via \`helm template\` with both internal and external DB values that the rendered manifests point at the correct hostnames and that no \`db\` Service is emitted when \`db.enabled=false\`.

## Test plan (not covered locally)

- [ ] Live: \`canasta create --orchestrator kubernetes -e external-db.env\` against a real external MariaDB, verify wiki installs and runs
- [ ] Verify Argo CD syncs the rendered values.yaml and the StatefulSet stays absent after \`canasta restart\` / post-create edits