### PR TITLE
Fix stop/start failing when namespace has no statefulsets

### DIFF
--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -63,12 +63,22 @@
               {{ (lookup('file', instance_path ~ '/values.yaml')
                   | from_yaml).get('web', {}).get('replicaCount', 1) }}
 
+        # External-DB instances with Elasticsearch disabled have no
+        # StatefulSets; 'kubectl scale --all' errors with "no objects
+        # passed to scale". Check first and skip if none exist.
+        - name: Check for statefulsets before scaling
+          ansible.builtin.command:
+            cmd: "kubectl get statefulset -n {{ _k8s_namespace }} -o name"
+          register: _start_sts_list
+          changed_when: false
+
         - name: Scale up statefulsets
           ansible.builtin.command:
             cmd: >-
               kubectl scale statefulset --all --replicas=1
               -n {{ _k8s_namespace }}
           changed_when: true
+          when: _start_sts_list.stdout_lines | length > 0
 
         - name: Scale up web deployment
           ansible.builtin.command:

--- a/roles/orchestrator/tasks/stop.yml
+++ b/roles/orchestrator/tasks/stop.yml
@@ -57,7 +57,18 @@
         cmd: "kubectl scale deployment --all --replicas=0 -n {{ _k8s_namespace }}"
       changed_when: true
 
+    # When the instance uses an external DB (db.enabled: false) and
+    # Elasticsearch is disabled, the namespace has zero StatefulSets
+    # and 'kubectl scale --all' errors with "no objects passed to
+    # scale". Check first and skip the scale step in that case.
+    - name: Check for statefulsets before scaling
+      ansible.builtin.command:
+        cmd: "kubectl get statefulset -n {{ _k8s_namespace }} -o name"
+      register: _stop_sts_list
+      changed_when: false
+
     - name: Scale down all statefulsets
       ansible.builtin.command:
         cmd: "kubectl scale statefulset --all --replicas=0 -n {{ _k8s_namespace }}"
       changed_when: true
+      when: _stop_sts_list.stdout_lines | length > 0


### PR DESCRIPTION
## Problem

When an instance uses external DB (\`db.enabled: false\`, added in #262) and Elasticsearch is disabled, the instance's namespace has zero StatefulSets. \`kubectl scale statefulset --all --replicas=N\` then errors with:

\`\`\`
Error: non-zero return code
error: no objects passed to scale
\`\`\`

This broke \`canasta restart\` and \`canasta config set\` (which triggers a restart side-effect) on external-DB K8s instances.

## Reproduction

Surfaced live on \`dev.amethyst-ck.com\` during post-merge validation of #262:

\`\`\`
$ canasta config set -i extdbtest \\
    MW_SITE_FQDN=dev.amethyst-ck.com MW_SITE_SERVER=https://dev.amethyst-ck.com
Error: non-zero return code
error: no objects passed to scale
\`\`\`

## Fix

Pre-check for statefulsets in the namespace. Skip the scale step when none exist. Applied in both \`stop.yml\` and \`start.yml\`.

Deliberately used a pre-check rather than \`failed_when: false\` — the latter would also swallow legitimate kubectl failures (cluster unreachable, RBAC denied, etc.) and hide real problems.

## Test plan
- [ ] \`canasta restart -i <external-db-instance>\` completes cleanly on a K8s instance with \`db.enabled: false\`
- [ ] \`canasta config set\` triggering a restart no longer errors
- [ ] \`canasta restart\` on an instance with bundled DB (default) still scales the \`-db\` StatefulSet