### PR TITLE
Skip DB readiness wait when using external database

### DIFF
--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -100,12 +100,22 @@
           changed_when: true
           ignore_errors: true  # OK if some deployments don't exist
 
+    # Skip the DB readiness wait when the instance uses an external
+    # database (db.enabled: false). In that case there's no bundled
+    # -db StatefulSet and the rollout-status call errors with NotFound.
+    - name: Read db.enabled from values.yaml
+      ansible.builtin.set_fact:
+        _db_enabled: >-
+          {{ (lookup('file', instance_path ~ '/values.yaml')
+              | from_yaml).get('db', {}).get('enabled', true) }}
+
     - name: Wait for DB readiness
       ansible.builtin.command:
         cmd: >-
           kubectl rollout status statefulset/canasta-{{ instance_id }}-db
           -n {{ _k8s_namespace }} --timeout=300s
       changed_when: false
+      when: _db_enabled | bool
 
     - name: Wait for web readiness
       ansible.builtin.command:


### PR DESCRIPTION
## Problem

Second bug discovered during the same live validation of #262 on \`dev.amethyst-ck.com\`. After #264 landed, \`canasta restart\` on an external-DB K8s instance still failed:

\`\`\`
$ canasta restart
Error: non-zero return code
Error from server (NotFound): statefulsets.apps \"canasta-extdbtest-db\" not found
\`\`\`

## Root cause

\`start.yml\` has a \`Wait for DB readiness\` task that unconditionally runs:

\`\`\`yaml
kubectl rollout status statefulset/canasta-{{ instance_id }}-db ...
\`\`\`

With external DB (\`db.enabled: false\`, added in #262) that StatefulSet doesn't exist, so \`rollout status\` errors with NotFound.

## Fix

Read \`db.enabled\` from the instance's \`values.yaml\` and gate the wait on it. Matches the pattern used elsewhere in the same file (web \`replicaCount\` lookup at line 60-64, Argo CD sync policy lookup at line 134-138).

## Test plan
- [ ] \`canasta restart -i <external-db-instance>\` completes cleanly on a K8s external-DB instance
- [ ] \`canasta restart -i <bundled-db-instance>\` still waits for the \`-db\` StatefulSet rollout