### PR TITLE
Enable TLS when MW_SITE_SERVER changes from localhost to real domain

### DIFF
--- a/roles/config/tasks/_side_effects.yml
+++ b/roles/config/tasks/_side_effects.yml
@@ -337,9 +337,10 @@
 - name: Cascade MW_SITE_SERVER domain change
   when: _config_key == 'MW_SITE_SERVER'
   block:
-    - name: Extract new FQDN from MW_SITE_SERVER
+    - name: Extract new FQDN and scheme from MW_SITE_SERVER
       ansible.builtin.set_fact:
-        _new_fqdn: "{{ _config_value | regex_replace('^https?://', '') }}"
+        _new_fqdn: "{{ _config_value | regex_replace('^https?://', '') | regex_replace('/.*$', '') }}"
+        _new_scheme: "{{ _config_value | regex_replace('^(https?)://.*$', '\\1') }}"
 
     - name: Read current MW_SITE_FQDN
       canasta_env:
@@ -361,3 +362,48 @@
         regexp: "{{ _se_old_fqdn.value | regex_escape() }}"
         replace: "{{ _new_fqdn }}"
       when: _se_old_fqdn.found and _se_old_fqdn.value != _new_fqdn
+
+    # Localhost → real-domain TLS cascade (K8s only).
+    # Instances created with `-n localhost` don't install cert-manager
+    # or enable ingress TLS. When the user later changes the domain
+    # to a real FQDN with an https:// scheme, install cert-manager
+    # (idempotent) and patch values.yaml so the Ingress gets a proper
+    # Let's Encrypt cert on the next restart. Without this, the user
+    # would either serve Traefik's default self-signed cert or have
+    # to delete and recreate the instance.
+    - name: Enable TLS for K8s instance on localhost→domain change
+      when:
+        - instance_orchestrator | default('compose') in ['kubernetes', 'k8s']
+        - _new_fqdn != 'localhost'
+        - _new_scheme == 'https'
+      block:
+        - name: Install cert-manager and Let's Encrypt issuer (idempotent)
+          ansible.builtin.include_tasks: >-
+            {{ canasta_root }}/roles/orchestrator/tasks/k8s_certmanager.yml
+
+        - name: Read values.yaml for TLS cascade
+          ansible.builtin.slurp:
+            src: "{{ instance_path }}/values.yaml"
+          register: _se_tls_values_raw
+
+        - name: Parse values.yaml
+          ansible.builtin.set_fact:
+            _se_tls_values: "{{ _se_tls_values_raw.content | b64decode | from_yaml }}"
+
+        - name: Build TLS ingress override
+          ansible.builtin.set_fact:
+            _se_tls_override:
+              ingress:
+                tls: true
+                certManager:
+                  enabled: true
+                  issuer: letsencrypt-prod
+
+        - name: Write updated values.yaml with TLS enabled
+          ansible.builtin.copy:
+            content: >-
+              {{ _se_tls_values
+                 | combine(_se_tls_override, recursive=True)
+                 | to_nice_yaml(indent=2) }}
+            dest: "{{ instance_path }}/values.yaml"
+            mode: "0644"

--- a/tests/unit/test_kubernetes_structure.py
+++ b/tests/unit/test_kubernetes_structure.py
@@ -223,6 +223,32 @@ class TestExternalDatabase:
                 "%s must gate MYSQL_HOST on .Values.db.enabled" % template_name
             )
 
+    def test_tls_cascade_on_localhost_to_domain_change(self):
+        """When a user changes MW_SITE_SERVER from localhost to a
+        real https:// domain on a K8s instance, _side_effects.yml
+        should install cert-manager and patch values.yaml to enable
+        ingress.tls — not force the user to delete and recreate."""
+        path = os.path.join(
+            REPO_ROOT, "roles", "config", "tasks", "_side_effects.yml",
+        )
+        with open(path) as f:
+            content = f.read()
+        # Gates the cascade on K8s + non-localhost + https scheme
+        assert "_new_scheme" in content, (
+            "_side_effects.yml must capture the scheme from MW_SITE_SERVER"
+        )
+        assert "_new_fqdn != 'localhost'" in content, (
+            "_side_effects.yml must not re-enable TLS on localhost changes"
+        )
+        # Installs cert-manager idempotently
+        assert "k8s_certmanager.yml" in content, (
+            "_side_effects.yml must install cert-manager on domain change"
+        )
+        # Patches values.yaml to enable ingress TLS
+        assert "letsencrypt-prod" in content, (
+            "_side_effects.yml must set the Let's Encrypt issuer"
+        )
+
     def test_values_template_emits_external_db_when_flagged(self):
         """The Ansible k8s_values.yaml.j2 template must emit db.enabled
         and externalDatabase when _use_external_db is true."""


### PR DESCRIPTION
## Problem

Natural workflow: create a K8s instance with \`-n localhost\` for testing, later assign it a real domain via \`canasta config set MW_SITE_SERVER=https://foo.example.com\`, expect HTTPS to start working.

Today that doesn't happen. The instance was created with cert-manager skipped (the install task gates on \`domain_name != localhost\`), and \`values.yaml\` was rendered without \`ingress.tls: true\`. The existing \`MW_SITE_SERVER\` cascade updates \`MW_SITE_FQDN\`, \`wikis.yaml\`, and \`values.yaml\` \`domains:\`, but leaves TLS off. Result: Traefik serves its self-signed default cert, browser warns, user either tolerates it, manually fixes things, or destroys and recreates the instance.

## Fix

Extend the cascade so a \`localhost → real-https-domain\` change also:

1. Installs cert-manager + Let's Encrypt ClusterIssuer (\`k8s_certmanager.yml\` is already idempotent).
2. Patches \`values.yaml\` to set:
   - \`ingress.tls: true\`
   - \`ingress.certManager.enabled: true\`
   - \`ingress.certManager.issuer: letsencrypt-prod\`

The restart that \`config set\` already triggers does the Helm upgrade; the Ingress gets a proper \`tls:\` block; cert-manager provisions the Let's Encrypt cert.

Gate conditions:
- \`instance_orchestrator\` is kubernetes/k8s
- new FQDN is not \`localhost\` (guards against re-enabling on domain→localhost)
- scheme is \`https://\` (so \`MW_SITE_SERVER=http://...\` stays HTTP-only)

## Scope / deferred

Forward-only (localhost → domain). The reverse (domain → localhost) is trickier because cert-manager is cluster-wide and may serve other instances; we shouldn't uninstall it, but we should disable TLS in values.yaml. Deferred to a separate change if it becomes needed.

## Test plan

- [x] Unit test: cascade references \`_new_scheme\`, \`_new_fqdn != 'localhost'\`, \`k8s_certmanager.yml\`, and \`letsencrypt-prod\`.
- [x] All 470 unit tests pass.
- [ ] Live on dev.amethyst-ck.com:
  - create with \`-n localhost\`
  - \`canasta config set MW_SITE_SERVER=https://<real-domain>\`
  - verify: cert-manager pods up in \`cert-manager\` namespace; values.yaml has \`ingress.tls: true\`; browser loads \`https://<real-domain>\` without a cert warning once cert-manager finishes the challenge.