### PR TITLE
Exclude config/persistent/ from gitops tracking

### DIFF
--- a/roles/gitops/files/gitignore.default
+++ b/roles/gitops/files/gitignore.default
@@ -19,6 +19,9 @@ config/backup/
 # Uploaded files (use canasta backup)
 images/
 
+# Runtime state (e.g. Semantic MediaWiki rebuild status)
+config/persistent/
+
 # Gitops state (host-specific, not shared)
 .gitops-applied
 .gitops-host


### PR DESCRIPTION
## Summary

- Add `config/persistent/` to the default gitignore so SMW runtime state (`config/persistent/.smw.json` and similar scratch files) is not tracked by gitops.

Fixes #272.

## Notes

- Only affects newly-initialized gitops repos. Existing instances need to add the line to their tracked `.gitignore` manually.

## Test plan

- [ ] `canasta gitops init` on a fresh instance produces a `.gitignore` containing `config/persistent/`.
- [ ] On an SMW-enabled wiki, routine rebuild activity no longer shows `config/persistent/.smw.json` as a dirty file in `canasta gitops status`.
