### PR TITLE
Propagate credential vars set after gitops init (SMTP_PASSWORD, AWS_*)

### DIFF
--- a/roles/config/tasks/_ensure_env_template_placeholder.yml
+++ b/roles/config/tasks/_ensure_env_template_placeholder.yml
@@ -1,0 +1,23 @@
+---
+# Ensure env.template has a placeholder line for a single credential key.
+# Input: _ep_setting (str: "KEY=VALUE" or "KEY=...")
+# Requires: instance_path, gitops_placeholder_keys,
+#           gitops_secret_prefix_pattern
+
+- name: Parse key
+  ansible.builtin.set_fact:
+    _ep_key: "{{ _ep_setting.split('=', 1)[0] }}"
+
+- name: Decide whether key should be a placeholder
+  ansible.builtin.set_fact:
+    _ep_needs_placeholder: >-
+      {{ _ep_key in gitops_placeholder_keys
+         or (_ep_key | regex_search(gitops_secret_prefix_pattern)) is not none }}
+
+- name: Add placeholder line to env.template
+  ansible.builtin.lineinfile:
+    path: "{{ instance_path }}/env.template"
+    regexp: "^{{ _ep_key }}="
+    line: "{{ _ep_key }}={{ '{{' }}{{ _ep_key | lower }}{{ '}}' }}"
+    state: present
+  when: _ep_needs_placeholder

--- a/roles/config/tasks/set.yml
+++ b/roles/config/tasks/set.yml
@@ -24,10 +24,25 @@
     - _config_gitops_stat.stat.exists | default(false)
     - instance_orchestrator | default('compose') == 'compose'
   block:
+    - name: Load gitops placeholder definitions
+      ansible.builtin.include_vars:
+        file: "{{ canasta_root }}/roles/gitops/vars/main.yml"
+
     - name: Read .gitops-host
       ansible.builtin.slurp:
         src: "{{ instance_path }}/.gitops-host"
       register: _config_host_raw
+
+    # If config set introduces a new credential key (SMTP_PASSWORD,
+    # AWS_*, etc.) that wasn't in .env at gitops init time, env.template
+    # won't have a placeholder for it. Add one so the map-building step
+    # below picks it up and the propagation to vars.yaml fires.
+    - name: Ensure env.template has placeholders for new credential keys
+      ansible.builtin.include_tasks: _ensure_env_template_placeholder.yml
+      loop: "{{ settings.split() }}"
+      loop_control:
+        loop_var: _ep_setting
+        label: "{{ _ep_setting.split('=', 1)[0] }}"
 
     - name: Build key-to-placeholder map from env.template
       ansible.builtin.shell:

--- a/roles/gitops/tasks/init_compose.yml
+++ b/roles/gitops/tasks/init_compose.yml
@@ -169,12 +169,8 @@
 
 # --- Step 9: Create env.template and wikis.yaml.template ---
 # env.template replaces secret/host-specific values with {{placeholder}} syntax.
-# Other values are kept as literals.
-#
-# Placeholder keys (matching Go builtinSecretKeys + builtinHostKeys):
-#   MYSQL_PASSWORD, WIKI_DB_PASSWORD, MW_SECRET_KEY, RESTIC_REPOSITORY,
-#   RESTIC_PASSWORD, MW_SITE_SERVER, MW_SITE_FQDN, HTTPS_PORT, HTTP_PORT
-# Plus any key with prefix: AWS_, AZURE_, B2_, GOOGLE_, OS_, ST_, RCLONE_
+# Other values are kept as literals. Placeholder key list and secret
+# prefixes are defined in roles/gitops/vars/main.yml.
 
 - name: Read raw .env file for template extraction
   ansible.builtin.slurp:
@@ -187,20 +183,6 @@
     state: read_all
   register: _gitops_env
 
-- name: Define placeholder keys
-  ansible.builtin.set_fact:
-    _gitops_placeholder_keys:
-      - MYSQL_PASSWORD
-      - WIKI_DB_PASSWORD
-      - MW_SECRET_KEY
-      - RESTIC_REPOSITORY
-      - RESTIC_PASSWORD
-      - MW_SITE_SERVER
-      - MW_SITE_FQDN
-      - HTTPS_PORT
-      - HTTP_PORT
-    _gitops_secret_prefixes: "^(AWS_|AZURE_|B2_|GOOGLE_|OS_|ST_|RCLONE_)"
-
 - name: Generate env.template with placeholder syntax
   ansible.builtin.copy:
     content: |
@@ -209,7 +191,7 @@
       {{ line }}
       {% elif '=' in line %}
       {% set key = line.split('=', 1)[0] %}
-      {% if key in _gitops_placeholder_keys or key | regex_search(_gitops_secret_prefixes) %}
+      {% if key in gitops_placeholder_keys or key | regex_search(gitops_secret_prefix_pattern) %}
       {{ key }}={{ '{{' }}{{ key | lower }}{{ '}}' }}
       {% else %}
       {{ line }}
@@ -280,14 +262,14 @@
   ansible.builtin.copy:
     content: |
       # Host-specific values for placeholder keys in env.template
-      {% for k in _gitops_placeholder_keys %}
+      {% for k in gitops_placeholder_keys %}
       {% if k in _gitops_env.variables %}
       {{ k | lower }}: "{{ _gitops_env.variables[k] }}"
       {% endif %}
       {% endfor %}
       # Secret-prefix keys
       {% for k, v in _gitops_env.variables.items() %}
-      {% if k | regex_search(_gitops_secret_prefixes) %}
+      {% if k | regex_search(gitops_secret_prefix_pattern) %}
       {{ k | lower }}: "{{ v }}"
       {% endif %}
       {% endfor %}

--- a/roles/gitops/tasks/push_compose.yml
+++ b/roles/gitops/tasks/push_compose.yml
@@ -69,21 +69,12 @@
     _push_shared_vars: >-
       {{ (_push_shared_stat.stat.exists
           | ternary(_push_shared_vars_raw.content | b64decode | from_yaml, {})) }}
-    _push_shared_prefixes:
-      - "restic_"
-      - "aws_"
-      - "azure_"
-      - "b2_"
-      - "google_"
-      - "os_"
-      - "st_"
-      - "rclone_"
 
 - name: Identify keys to migrate
   ansible.builtin.set_fact:
     _push_keys_to_migrate: >-
       {{ _push_host_vars | dict2items
-         | selectattr('key', 'match', '(' + _push_shared_prefixes | join('|') + ')')
+         | selectattr('key', 'match', '(' + gitops_shared_credential_prefixes | join('|') + ')')
          | rejectattr('key', 'in', _push_shared_vars)
          | list }}
 
@@ -114,7 +105,7 @@
       ansible.builtin.copy:
         content: >-
           {{ _push_host_vars | dict2items
-             | rejectattr('key', 'match', '(' + _push_shared_prefixes | join('|') + ')')
+             | rejectattr('key', 'match', '(' + gitops_shared_credential_prefixes | join('|') + ')')
              | items2dict
              | to_nice_yaml(indent=2) }}
         dest: "{{ instance_path }}/hosts/{{ _push_hostname }}/vars.yaml"

--- a/roles/gitops/vars/main.yml
+++ b/roles/gitops/vars/main.yml
@@ -1,0 +1,31 @@
+---
+# Keys whose values are secrets or host-specific; rendered as
+# {{ placeholder }} in env.template and stored in hosts/<host>/vars.yaml.
+gitops_placeholder_keys:
+  - MYSQL_PASSWORD
+  - WIKI_DB_PASSWORD
+  - MW_SECRET_KEY
+  - RESTIC_REPOSITORY
+  - RESTIC_PASSWORD
+  - MW_SITE_SERVER
+  - MW_SITE_FQDN
+  - HTTPS_PORT
+  - HTTP_PORT
+
+# Keys whose name starts with any of these prefixes are treated as
+# credentials and get placeholders in env.template.
+gitops_secret_prefix_pattern: "^(AWS_|AZURE_|B2_|GOOGLE_|OS_|ST_|RCLONE_|SMTP_)"
+
+# Credential-class prefixes (lowercase) whose values belong in
+# hosts/_shared/vars.yaml rather than per-host vars.yaml. Auto-migrated
+# on gitops push.
+gitops_shared_credential_prefixes:
+  - restic_
+  - aws_
+  - azure_
+  - b2_
+  - google_
+  - os_
+  - st_
+  - rclone_
+  - smtp_


### PR DESCRIPTION
## Summary

- Fix credential propagation gap when `canasta config set` writes keys that weren't in `.env` at `gitops init` time (e.g. `SMTP_PASSWORD`, `AWS_*` on instances where those were set after init).
- Add `SMTP_` to the init-time secret-prefix pattern so new installs get an env.template placeholder for it.
- Add `smtp_` to the push-time shared-credential allowlist so SMTP credentials migrate to `hosts/_shared/vars.yaml` like the other cloud/backup creds.
- Extract the placeholder-key list, secret-prefix pattern, and shared-credential-prefix list from inline `set_fact` declarations into `roles/gitops/vars/main.yml` so `init`, `push`, and `config set` read from one source.

Fixes #271.

## How the fix works

In `roles/config/tasks/set.yml`, after `.env` is updated, if the instance is gitops-managed:

1. Load `roles/gitops/vars/main.yml` so the placeholder criteria are available.
2. For each key being set, if it's in `gitops_placeholder_keys` or matches `gitops_secret_prefix_pattern` and isn't already present in `env.template`, append a `KEY={{ key_lower }}` placeholder line. This is a new per-setting included task: `roles/config/tasks/_ensure_env_template_placeholder.yml`.
3. The existing "build placeholder map → update vars.yaml" steps then see the new line and propagate the value normally.

On the next `gitops push`, shared-credential prefixes migrate from host vars.yaml to `hosts/_shared/vars.yaml` as before — now including `smtp_`.

## Test plan

- [ ] On a fresh compose instance with gitops initialized: `canasta config set SMTP_PASSWORD=secret` should (a) add `SMTP_PASSWORD={{ smtp_password }}` to `env.template`, (b) add `smtp_password: secret` to `hosts/<host>/vars.yaml`. `gitops status` shows the changes.
- [ ] `canasta gitops push` migrates `smtp_password` to `hosts/_shared/vars.yaml`.
- [ ] `canasta config set AWS_ACCESS_KEY=foo AWS_SECRET_KEY=bar` on an instance where AWS was not set at init produces placeholders + shared-vars entries on push.
- [ ] Regression: `canasta config set` with a non-credential key (e.g. `MW_SITE_NAME=Foo`) still writes to `.env` only; does not touch `env.template` or `vars.yaml`.
- [ ] Regression: `canasta gitops init` on an instance where `SMTP_PASSWORD` is in `.env` at init time produces a placeholder for it (now covered by `SMTP_` prefix).
- [ ] `make validate` + `make test-unit` + `make lint` still pass.
