### PR TITLE
Accept SMTP_ keys in config-set validator

### DIFF
--- a/roles/config/defaults/main.yml
+++ b/roles/config/defaults/main.yml
@@ -21,7 +21,7 @@ canasta_known_keys:
   - RESTIC_REPOSITORY
   - RESTIC_PASSWORD
 
-# Key prefixes that are always accepted (restic backend credentials)
+# Key prefixes that are always accepted (backup and mail credentials)
 canasta_known_prefixes:
   - "AWS_"
   - "AZURE_"
@@ -30,3 +30,4 @@ canasta_known_prefixes:
   - "OS_"
   - "ST_"
   - "RCLONE_"
+  - "SMTP_"

--- a/roles/config/tasks/_validate_key.yml
+++ b/roles/config/tasks/_validate_key.yml
@@ -18,8 +18,8 @@
       Unrecognized key '{{ _config_key }}'.
       Use --force to set unrecognized keys.
       Known keys: {{ canasta_known_keys | join(', ') }}
-      (Also accepted: keys starting with AWS_, AZURE_, B2_, GOOGLE_, OS_, ST_, RCLONE_)
+      (Also accepted: keys starting with {{ canasta_known_prefixes | join(', ') }})
   when:
     - not (force | default(false) | bool)
     - _config_key not in canasta_known_keys
-    - not (_config_key | regex_search('^(AWS_|AZURE_|B2_|GOOGLE_|OS_|ST_|RCLONE_)'))
+    - not (_config_key | regex_search('^(' + canasta_known_prefixes | join('|') + ')'))


### PR DESCRIPTION
## Summary

- Add `SMTP_` to `canasta_known_prefixes` so `canasta config set SMTP_PASSWORD=...` works without `--force`.
- Change `_validate_key.yml` to source its prefix regex and help text from `canasta_known_prefixes` instead of a separate hardcoded list, keeping the defaults, help message, and validation in sync.

Fixes #275 (follow-up to #271).

## Test plan

- [ ] `canasta config set SMTP_PASSWORD=foo` succeeds without `--force` on a compose instance.
- [ ] `canasta config set SOMETHING_ELSE=x` still fails with the unrecognized-key error, and the error now lists `SMTP_` among accepted prefixes.
- [ ] Pre-existing `AWS_`/`RCLONE_`/etc. acceptance still works.
- [ ] `make validate` + `make test-unit` + `make lint` still pass.
