### PR TITLE
gitops push: always overwrite _shared/vars.yaml with host's credential values

### DIFF
--- a/roles/gitops/tasks/push_compose.yml
+++ b/roles/gitops/tasks/push_compose.yml
@@ -44,9 +44,12 @@
   when: _push_role not in ['source', 'both']
 
 # --- Auto-migrate shared-category keys to _shared/vars.yaml ---
-# Keys matching backup/cloud credential prefixes belong in the shared
-# file so all hosts inherit them. Move them on first push after the
-# feature is available; subsequent pushes are no-ops.
+# Keys matching backup/cloud/mail credential prefixes belong in the
+# shared file so all hosts inherit them. On every push, any such key
+# present in host vars.yaml is moved to _shared/vars.yaml (host's
+# value wins on merge) and removed from host vars.yaml. This also
+# keeps _shared in sync when 'canasta config set' updates a key
+# that already lived there.
 - name: Read host vars
   ansible.builtin.slurp:
     src: "{{ instance_path }}/hosts/{{ _push_hostname }}/vars.yaml"
@@ -75,7 +78,6 @@
     _push_keys_to_migrate: >-
       {{ _push_host_vars | dict2items
          | selectattr('key', 'match', '(' + gitops_shared_credential_prefixes | join('|') + ')')
-         | rejectattr('key', 'in', _push_shared_vars)
          | list }}
 
 - name: Write migrated shared vars


### PR DESCRIPTION
## Summary

- Remove the `rejectattr('key', 'in', _push_shared_vars)` filter from push-migration's key selection, so any shared-credential-prefixed key present in host vars.yaml always migrates to `_shared/vars.yaml` (host's value wins on `combine`) and is removed from host vars.yaml.
- Keeps `_shared` in sync with subsequent `canasta config set` updates to keys that had already been migrated — previously the new value was stranded in host vars.yaml as a stale duplicate.

Fixes #277 (follow-up to #271).

## Behavior before vs. after

**Before:** `_shared/vars.yaml` was written on first migration only; later `config set SMTP_PASSWORD=new` produced a divergent dupe (host had new value, shared still had old).

**After:** every push reconciles host → shared for credential-class keys. Shared always holds the latest value; host never holds a duplicate.

## Test plan

- [ ] Start with `smtp_password` in both `_shared/vars.yaml` (old) and `hosts/<h>/vars.yaml` (new, from a recent `config set`). After `canasta gitops push`: shared has the new value, host has no `smtp_password` key, git commit reflects both files.
- [ ] Fresh install, no shared migration yet: `config set AWS_ACCESS_KEY=foo && gitops push` still correctly migrates to `_shared` and removes from host (regression check of the original first-migration path).
- [ ] Running `gitops push` with no credential changes produces no diff (idempotency — `to_nice_yaml` output is deterministic).
- [ ] `make validate` + `make test-unit` + `make lint` still pass.

## Recovery for instances already in the divergent state

Either (a) merge this PR, upgrade, and run `canasta gitops push` — the new migration will fix the divergence automatically, or (b) manually edit `hosts/_shared/vars.yaml` to the correct value, then `canasta gitops add && gitops push`.
