### PR TITLE
Fix CLI ergonomics: 'config get' positional keys, 'maintenance script' flag hoisting

### DIFF
--- a/canasta.py
+++ b/canasta.py
@@ -96,6 +96,48 @@ def display_name(internal):
     return internal.replace("_", "-")
 
 
+_REMAINDER_HOIST_FLAGS = {
+    "-w": "wiki", "--wiki": "wiki",
+    "-i": "id", "--id": "id",
+}
+
+
+def hoist_flags_from_remainder(args):
+    """Lift canasta subcommand flags out of a REMAINDER positional.
+
+    Example: ``canasta maintenance script showJobs.php -w main`` — argparse
+    sees ``showJobs.php`` as the first positional of ``script_args``
+    (nargs=REMAINDER), so ``-w main`` gets eaten into the list instead of
+    being recognized as the ``--wiki`` flag. Walk the list and lift any
+    recognized flag (``-w``/``--wiki``, ``-i``/``--id``) plus its value out,
+    setting the corresponding attribute on ``args`` if unset.
+
+    Only applies to REMAINDER positionals (list values). Passthrough args
+    supplied after ``--`` arrive as a pre-joined string and are not
+    rewritten here — users who need a literal ``-w`` passed through to the
+    inner script can use ``--`` explicitly.
+    """
+    for pos_name in ("script_args", "exec_args"):
+        val = getattr(args, pos_name, None)
+        if not isinstance(val, list):
+            continue
+        new_args = []
+        i = 0
+        while i < len(val):
+            tok = val[i]
+            dest = _REMAINDER_HOIST_FLAGS.get(tok)
+            # Hoist only when the canasta flag isn't already set. If the user
+            # typed the flag twice, preserve the second occurrence in the
+            # positional list so it can be passed through to the inner script.
+            if dest and i + 1 < len(val) and not getattr(args, dest, None):
+                setattr(args, dest, val[i + 1])
+                i += 2
+                continue
+            new_args.append(tok)
+            i += 1
+        setattr(args, pos_name, new_args)
+
+
 def add_params_to_parser(parser, params):
     """Add command parameters to an argparse parser based on definitions."""
     for param in params:
@@ -733,6 +775,8 @@ def main():
                       if p.get("positional")]
         if pos_params:
             setattr(args, pos_params[0], passthrough)
+
+    hoist_flags_from_remainder(args)
 
     if not args.command:
         parser.print_help()

--- a/meta/command_definitions.yml
+++ b/meta/command_definitions.yml
@@ -455,21 +455,23 @@ commands:
     description: "Show configuration settings"
     long_description: |
       Show configuration settings from the instance .env file.
-      With no --key, prints all settings. With --key, prints
-      just that value.
+      With no keys, prints all settings. With one or more keys,
+      prints just those values.
     examples:
       - "canasta config get -i mysite"
-      - "canasta config get -i mysite --key MW_SITE_SERVER"
+      - "canasta config get -i mysite MW_SITE_SERVER"
+      - "canasta config get -i mysite MW_SITE_SERVER HTTPS_PORT"
     playbook: config_get.yml
     parameters:
       - name: id
         short: i
         type: string
         description: "Canasta instance ID"
-      - name: key
-        short: k
+      - name: keys
         type: string
-        description: "Configuration key to query"
+        positional: true
+        multi: true
+        description: "Configuration key(s) to query"
       - name: force
         short: f
         type: bool

--- a/roles/config/tasks/_get_single.yml
+++ b/roles/config/tasks/_get_single.yml
@@ -1,0 +1,20 @@
+---
+# Read and display a single config key.
+# Input: _config_get_key (str), instance_path
+
+- name: Read specific key
+  canasta_env:
+    path: "{{ instance_path }}/.env"
+    state: read
+    key: "{{ _config_get_key }}"
+  register: _config_val
+
+- name: Display value
+  ansible.builtin.debug:
+    msg: "{{ _config_get_key }}={{ _config_val.value }}"
+  when: _config_val.found
+
+- name: Key not found
+  ansible.builtin.debug:
+    msg: "Key '{{ _config_get_key }}' not found."
+  when: not _config_val.found

--- a/roles/config/tasks/get.yml
+++ b/roles/config/tasks/get.yml
@@ -1,34 +1,20 @@
 ---
 # canasta config get - Show configuration settings.
-# Matches Go: single key prints value; all keys sorted.
-# Input: id (optional), key (optional), force (bool)
+# Input: id (optional), keys (str: space-separated keys), force (bool)
 
 - name: Resolve instance
   ansible.builtin.include_tasks: >-
     {{ canasta_root }}/roles/common/tasks/resolve_instance.yml
 
-- name: Get single key
-  when: key is defined and key != ''
-  block:
-    - name: Read specific key
-      canasta_env:
-        path: "{{ instance_path }}/.env"
-        state: read
-        key: "{{ key }}"
-      register: _config_val
-
-    - name: Display value
-      ansible.builtin.debug:
-        msg: "{{ _config_val.value }}"
-      when: _config_val.found
-
-    - name: Key not found
-      ansible.builtin.debug:
-        msg: "Key '{{ key }}' not found."
-      when: not _config_val.found
+- name: Get specified keys
+  when: keys is defined and keys | length > 0
+  ansible.builtin.include_tasks: _get_single.yml
+  loop: "{{ keys.split() }}"
+  loop_control:
+    loop_var: _config_get_key
 
 - name: Get all settings
-  when: key is not defined or key == ''
+  when: keys is not defined or keys | length == 0
   block:
     - name: Read all settings
       canasta_env:

--- a/tests/integration/run_tests.py
+++ b/tests/integration/run_tests.py
@@ -603,7 +603,7 @@ def test_config_side_effects(inst):
 
     print("Reading the value back with config get...")
     output = inst.run_quiet(
-        "config", "get", "-i", inst.id, "--key", "HTTP_PORT",
+        "config", "get", "-i", inst.id, "HTTP_PORT",
     )
     assert new_http_port in output, (
         "config get HTTP_PORT did not return %s:\n%s"

--- a/tests/unit/test_canasta_cli.py
+++ b/tests/unit/test_canasta_cli.py
@@ -81,21 +81,21 @@ class TestBuildParser:
                 "-o", "invalid"
             ])
 
-    def test_config_get_key_flag(self, parser):
+    def test_config_get_single_positional_key(self, parser):
         args = parser.parse_args(
-            ["config", "get", "-i", "mysite", "--key", "KEY"],
+            ["config", "get", "-i", "mysite", "KEY"],
         )
-        assert args.key == "KEY"
+        assert args.keys == ["KEY"]
 
-    def test_config_get_key_short_flag(self, parser):
+    def test_config_get_multiple_positional_keys(self, parser):
         args = parser.parse_args(
-            ["config", "get", "-i", "mysite", "-k", "KEY"],
+            ["config", "get", "-i", "mysite", "KEY1", "KEY2"],
         )
-        assert args.key == "KEY"
+        assert args.keys == ["KEY1", "KEY2"]
 
-    def test_config_get_key_optional(self, parser):
+    def test_config_get_keys_optional(self, parser):
         args = parser.parse_args(["config", "get", "-i", "mysite"])
-        assert args.key is None
+        assert args.keys == []
 
     def test_config_regenerate_subcommand(self, parser):
         args = parser.parse_args(
@@ -471,6 +471,73 @@ class TestRemainderArgs:
             "maintenance", "exec", "-i", "mysite"
         ])
         assert args.exec_args == []
+
+
+class TestRemainderFlagHoisting:
+    """Canasta flags trapped inside script_args/exec_args by REMAINDER
+    should be lifted back out (#279)."""
+
+    def _parse_and_hoist(self, parser, argv):
+        args = parser.parse_args(argv)
+        canasta_cli.hoist_flags_from_remainder(args)
+        return args
+
+    def test_wiki_flag_after_script_name(self, parser):
+        args = self._parse_and_hoist(parser, [
+            "maintenance", "script", "-i", "mysite",
+            "showJobs.php", "-w", "main"
+        ])
+        assert args.wiki == "main"
+        assert args.script_args == ["showJobs.php"]
+
+    def test_long_wiki_flag_after_script_name(self, parser):
+        args = self._parse_and_hoist(parser, [
+            "maintenance", "script", "-i", "mysite",
+            "showJobs.php", "--wiki", "main"
+        ])
+        assert args.wiki == "main"
+        assert args.script_args == ["showJobs.php"]
+
+    def test_wiki_flag_before_script_name_unchanged(self, parser):
+        args = self._parse_and_hoist(parser, [
+            "maintenance", "script", "-i", "mysite",
+            "-w", "main", "showJobs.php"
+        ])
+        assert args.wiki == "main"
+        assert args.script_args == ["showJobs.php"]
+
+    def test_duplicate_wiki_flag_preserves_second_in_passthrough(self, parser):
+        # -w main is for canasta; -w other stays in script_args
+        # so it can be passed through to the inner script.
+        args = self._parse_and_hoist(parser, [
+            "maintenance", "script", "-i", "mysite",
+            "-w", "main", "myScript.php", "-w", "other"
+        ])
+        assert args.wiki == "main"
+        assert args.script_args == ["myScript.php", "-w", "other"]
+
+    def test_id_flag_after_positional(self, parser):
+        args = self._parse_and_hoist(parser, [
+            "maintenance", "exec", "php", "-v", "-i", "mysite"
+        ])
+        assert args.id == "mysite"
+        assert args.exec_args == ["php", "-v"]
+
+    def test_exec_args_with_no_canasta_flags(self, parser):
+        args = self._parse_and_hoist(parser, [
+            "maintenance", "exec", "-i", "mysite", "ls", "-la", "/var/www"
+        ])
+        assert args.id == "mysite"
+        assert args.exec_args == ["ls", "-la", "/var/www"]
+
+    def test_hoist_noop_on_non_remainder_commands(self, parser):
+        # config set uses a non-REMAINDER positional; hoist should leave it
+        # alone.
+        args = self._parse_and_hoist(parser, [
+            "config", "set", "-i", "mysite", "KEY=value"
+        ])
+        assert args.id == "mysite"
+        assert args.settings == ["KEY=value"]
 
 
 class TestPassthrough:


### PR DESCRIPTION
## Summary

Two small CLI ergonomics fixes surfaced during tonight's SEBoK migration cutover.

### 1. `canasta config get` accepts keys positionally (#280)

Was: `canasta config get --key MY_KEY`
Now: `canasta config get MY_KEY [MY_KEY2 ...]`

Matches `canasta config unset` (always accepted positional keys) and how most tools expose GET-style lookups (`git config --get`, `docker compose config`, etc.). Plain `canasta config get` still dumps everything, sorted. Multi-key output is `KEY=value` per line.

The single-key readback is extracted into `_get_single.yml`, mirroring the `unset.yml` / `_unset_single.yml` split.

### 2. `canasta maintenance script` accepts `-w/--wiki` and `-i/--id` in any position (#279)

Was:

```
canasta maintenance script -w main showJobs.php    # ok
canasta maintenance script showJobs.php -w main    # ERROR: Unexpected option --w!
```

The second form failed because `script_args` uses `argparse.REMAINDER`, which swallows every remaining token verbatim.

Now: after argparse, walk the populated `script_args` / `exec_args` list and lift recognized canasta flags (`-w/--wiki`, `-i/--id`) plus their values out, setting the corresponding `args` attribute **only when it wasn't already provided** in the normal pre-positional slot. Users who genuinely want `-w` passed through to the inner script can still use `--` — that path arrives as a pre-joined string and isn't rewritten. A duplicate occurrence of the same flag inside the positional is also left in place to reach the inner script.

The logic is extracted into a module-level `hoist_flags_from_remainder(args)` so it's unit-testable.

Fixes #279, #280.

## Test plan

- [ ] `canasta config get KEY` prints `KEY=value`.
- [ ] `canasta config get KEY1 KEY2` prints both lines.
- [ ] `canasta config get` (no args) prints every setting, sorted (pre-existing behavior preserved).
- [ ] `canasta config get MISSING` prints `Key 'MISSING' not found.` (pre-existing behavior preserved).
- [ ] `canasta maintenance script -w main showJobs.php` still works.
- [ ] `canasta maintenance script showJobs.php -w main` now works.
- [ ] `canasta maintenance script showJobs.php --wiki main` also works.
- [ ] `canasta maintenance script -- php -v` preserves passthrough semantics (script_args = `php -v`).
- [ ] `canasta maintenance script -w main -- myScript.php -w other` preserves the second `-w` as passthrough.
- [ ] `make validate` + `make test-unit` + `make lint` pass (495 tests pass locally, 7 new).

