### PR TITLE
doctor: skip www-data group check on non-Linux hosts

### DIFF
--- a/playbooks/doctor.yml
+++ b/playbooks/doctor.yml
@@ -35,12 +35,24 @@
   changed_when: false
   ignore_errors: true  # Checking if daemon running
 
-- name: Check www-data group membership
+- name: Detect host OS
+  ansible.builtin.command:
+    cmd: uname -s
+  register: _doc_os
+  changed_when: false
+  ignore_errors: true
+
+- name: Check www-data group membership (Linux only)
+  # On macOS, Docker Desktop handles UID remapping transparently — there is
+  # no www-data user/group on the host and membership is irrelevant. Only
+  # run the group check on Linux, where host-side file permissions matter
+  # for volume mounts into the Canasta containers.
   ansible.builtin.command:
     cmd: id -nG
   register: _doc_groups
   changed_when: false
   ignore_errors: true  # Some GIDs may not resolve to names
+  when: (_doc_os.stdout | default('') | trim) == 'Linux'
 
 # --- Required for Kubernetes ---
 - name: Check kubectl
@@ -150,7 +162,19 @@
       System:
         Memory:          {{ _doc_memory.stdout | default('unknown') | trim }}
         Disk (/ avail):  {{ _doc_disk.stdout | default('unknown') | trim }}
-        www-data group:  {{ ('www-data' in (_doc_groups.stdout | default('')).split()) | ternary('OK (member)', 'NOT A MEMBER — Canasta containers write files as www-data; add yourself with: sudo usermod -aG www-data ' + ansible_user | default('$USER') + ' (then log out and back in, or start a new shell, for the change to take effect)') }}
+        www-data group:  {{
+          'N/A (Docker Desktop handles UID mapping on ' + (_doc_os.stdout | default('this OS') | trim) + ')'
+          if (_doc_os.stdout | default('') | trim) != 'Linux'
+          else (
+            ('www-data' in (_doc_groups.stdout | default('')).split())
+            | ternary(
+              'OK (member)',
+              'NOT A MEMBER — Canasta containers write files as www-data; add yourself with: sudo usermod -aG www-data '
+                + (ansible_user | default('$USER'))
+                + ' (then log out and back in, or start a new shell, for the change to take effect)'
+            )
+          )
+        }}
 
 - name: Fail if core dependencies missing
   ansible.builtin.fail:


### PR DESCRIPTION
## Summary

`canasta doctor` on macOS unconditionally reports `www-data group: NOT A MEMBER` and suggests a `sudo usermod -aG www-data $USER` fix. But `www-data` doesn't exist on macOS, `usermod` isn't installed, and Docker Desktop handles UID remapping transparently — host-side group membership is irrelevant. The message made fresh macOS installs look broken when they aren't.

Fixes #288.

## Fix

Detect the host OS up front with `uname -s`. Run the `id -nG` membership probe only on Linux. Non-Linux hosts get a clear informational line instead of a misleading remediation.

## Sample output

**On macOS (Darwin):**

```
System:
  Memory:          36 GB
  Disk (/ avail):  461Gi
  www-data group:  N/A (Docker Desktop handles UID mapping on Darwin)
```

**On Linux (unchanged):**

```
System:
  Memory:          8 GB
  Disk (/ avail):  120G
  www-data group:  OK (member)
```

or when not a member:

```
  www-data group:  NOT A MEMBER — Canasta containers write files as www-data; add yourself with: sudo usermod -aG www-data wikiworks (then log out and back in, or start a new shell, for the change to take effect)
```

## Test plan

- [ ] `canasta doctor` on macOS shows `N/A (Docker Desktop handles UID mapping on Darwin)` instead of the bogus `NOT A MEMBER` line.
- [ ] `canasta doctor` on a Linux host where the user is in `www-data` still reports `OK (member)`.
- [ ] `canasta doctor` on a Linux host where the user is not in `www-data` still reports `NOT A MEMBER` with the original `usermod` remediation.
- [ ] `make validate` + `make test-unit` + `make lint` pass (502 tests still pass — no new unit tests because the change is display-level and the new behavior is platform-specific).

