### PR TITLE
Bring direct_commands.py to parity with recent Ansible-path fixes

### DIFF
--- a/direct_commands.py
+++ b/direct_commands.py
@@ -487,6 +487,34 @@ def _gather_all_instances(instances):
     return [results[iid] for iid in ordered_ids]
 
 
+def _classify_for_cleanup(inst_id, inst):
+    """Classify an instance for cleanup purposes.
+
+    Returns one of:
+      'exists'      — the instance directory is present on its host
+      'missing'     — the host is reachable and confirmed the path is gone
+      'unreachable' — SSH transport failure (DNS, connection refused,
+                      timeout, auth, host key) — no information about
+                      whether the instance actually still exists
+    """
+    host = inst.get("host") or "localhost"
+    path = inst.get("path", "")
+
+    if _is_localhost(host):
+        return "exists" if os.path.isdir(path) else "missing"
+
+    # OpenSSH returns rc=255 specifically for transport-layer failures.
+    # Any other non-zero rc means the remote command ran and failed on
+    # its own terms — for 'test -d' that means the directory really is
+    # missing on the remote host.
+    rc, _ = _ssh_run(host, "test -d %s" % _shell_quote(path))
+    if rc == 0:
+        return "exists"
+    if rc == 255:
+        return "unreachable"
+    return "missing"
+
+
 @register("list")
 def cmd_list(args):
     config_dir = _get_config_dir()
@@ -494,15 +522,56 @@ def cmd_list(args):
 
     if getattr(args, "cleanup", False):
         instances = _read_registry(conf_path)
-        to_remove = [
-            iid for iid, inst in instances.items()
-            if not os.path.isdir(inst.get("path", ""))
-        ]
-        if to_remove:
-            for iid in to_remove:
-                del instances[iid]
-            _write_registry(conf_path, instances)
-            print("Removed stale entries: %s" % ", ".join(to_remove))
+        force = getattr(args, "force", False)
+        dry_run = getattr(args, "dry_run", False)
+
+        # Probe all instances in parallel — remote classify can SSH.
+        classifications = {}
+        if instances:
+            with ThreadPoolExecutor(max_workers=len(instances)) as pool:
+                futures = {
+                    pool.submit(_classify_for_cleanup, iid, inst): iid
+                    for iid, inst in instances.items()
+                }
+                for future in as_completed(futures):
+                    iid = futures[future]
+                    try:
+                        classifications[iid] = future.result()
+                    except Exception:
+                        # On unexpected error treat as unreachable so we
+                        # don't drop the entry by surprise.
+                        classifications[iid] = "unreachable"
+
+        missing = sorted(
+            iid for iid, c in classifications.items() if c == "missing"
+        )
+        unreachable = sorted(
+            iid for iid, c in classifications.items() if c == "unreachable"
+        )
+
+        if dry_run:
+            print("Dry run — no changes made.")
+            print("Would remove (confirmed missing): %s"
+                  % (", ".join(missing) if missing else "(none)"))
+            if force:
+                print("Would remove (unreachable, --force): %s"
+                      % (", ".join(unreachable) if unreachable else "(none)"))
+            else:
+                print("Skipped (unreachable; pass --force to remove): %s"
+                      % (", ".join(unreachable) if unreachable else "(none)"))
+        else:
+            to_remove = list(missing) + (list(unreachable) if force else [])
+            if to_remove:
+                for iid in to_remove:
+                    del instances[iid]
+                _write_registry(conf_path, instances)
+                print("Removed stale entries: %s" % ", ".join(to_remove))
+            if unreachable and not force:
+                plural = "y" if len(unreachable) == 1 else "ies"
+                print(
+                    "Kept %d unreachable entr%s (pass --force to remove): %s"
+                    % (len(unreachable), plural, ", ".join(unreachable))
+                )
 
     instances = _read_registry(conf_path)
     host_filter = getattr(args, "host", None)
@@ -522,6 +591,44 @@ def cmd_list(args):
 # canasta version
 # ---------------------------------------------------------------------------
 
+def _read_instance_image(inst_id, inst):
+    """Return 'CANASTA_IMAGE (running: X)' for a single instance entry.
+
+    'running' comes from /tmp/canasta-version inside the web container;
+    absent when the container isn't up or the command fails for any
+    reason. Never raises.
+    """
+    host = inst.get("host") or "localhost"
+    path = inst.get("path", "")
+    env_vars = _read_env_file(path, host)
+    image = env_vars.get("CANASTA_IMAGE", "(unset)")
+
+    # Running Canasta version — line 2 of /tmp/canasta-version inside
+    # the web container. Best effort; fall back silently.
+    running = "(not running)"
+    compose_cmd = (
+        "cd %s && docker compose exec -T web sh -c "
+        "\"cat /tmp/canasta-version 2>/dev/null | sed -n '2p'\" 2>/dev/null"
+        % _shell_quote(path)
+    )
+    if _is_localhost(host):
+        try:
+            result = subprocess.run(
+                ["sh", "-c", compose_cmd],
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                running = result.stdout.strip()
+        except (subprocess.TimeoutExpired, OSError):
+            pass
+    else:
+        rc, stdout = _ssh_run(host, compose_cmd)
+        if rc == 0 and stdout.strip():
+            running = stdout.strip()
+
+    return image, running
+
+
 @register("version")
 def cmd_version(args):
     script_dir = _get_script_dir()
@@ -532,6 +639,17 @@ def cmd_version(args):
             version = f.read().strip()
     except OSError:
         version = "unknown"
+
+    # Target Canasta version — what this CLI was built to deploy.
+    # Always shown, even when no instances are registered. This is the
+    # CANASTA_VERSION file bundled with Canasta-Ansible, distinct from
+    # any particular instance's pinned CANASTA_IMAGE tag.
+    target_version_file = os.path.join(script_dir, "CANASTA_VERSION")
+    try:
+        with open(target_version_file) as f:
+            target_canasta_version = f.read().strip()
+    except OSError:
+        target_canasta_version = "unknown"
 
     # Run mode is set by the canasta-docker wrapper. Presence of
     # BUILD_COMMIT isn't a reliable signal — native installs also
@@ -568,6 +686,51 @@ def cmd_version(args):
             date = "unknown"
 
     print("Canasta CLI v%s (%s, commit %s, built %s)" % (version, mode, commit, date))
+    print("Target Canasta version: %s" % target_canasta_version)
+
+    # Per-instance image reports (on demand)
+    inst_id = getattr(args, "id", None)
+    want_all = getattr(args, "all", False)
+
+    if want_all:
+        # Report every instance on the current host.
+        config_dir = _get_config_dir()
+        conf_path = os.path.join(config_dir, "conf.json")
+        instances = _read_registry(conf_path)
+        host_filter = getattr(args, "host", None)
+        instances = _filter_by_host(instances, host_filter)
+        if not instances:
+            print("No instances registered.")
+            return 0
+        for iid in sorted(instances.keys()):
+            image, running = _read_instance_image(iid, instances[iid])
+            print("Instance '%s': %s (running: %s)" % (iid, image, running))
+        return 0
+
+    if inst_id:
+        # Explicit -i: resolve and report.
+        inst_id, inst = _resolve_instance(args)
+        image, running = _read_instance_image(inst_id, inst)
+        print("Instance '%s': %s (running: %s)" % (inst_id, image, running))
+        return 0
+
+    # No -i / --all: try to auto-resolve from PWD, report if we find
+    # a match. Outside any instance directory is the common case and
+    # not an error — just stop at the two-line CLI/target report.
+    config_dir = _get_config_dir()
+    conf_path = os.path.join(config_dir, "conf.json")
+    instances = _read_registry(conf_path)
+    cwd = os.path.abspath(os.getcwd())
+    while True:
+        for iid, inst in instances.items():
+            if os.path.abspath(inst.get("path", "")) == cwd:
+                image, running = _read_instance_image(iid, inst)
+                print("Instance '%s': %s (running: %s)" % (iid, image, running))
+                return 0
+        parent = os.path.dirname(cwd)
+        if parent == cwd:
+            break
+        cwd = parent
     return 0
 
 
@@ -586,12 +749,16 @@ def cmd_config_get(args):
         print("No configuration found.", file=sys.stderr)
         return 1
 
-    key = getattr(args, "key", None)
-    if key:
-        if key in env_vars:
-            print(env_vars[key])
-        else:
-            print("Key '%s' not found." % key)
+    # Positional 'keys' comes from argparse as a list when run through
+    # canasta.py. For each explicitly requested key, print KEY=value or
+    # a not-found message. With no keys, dump every setting, sorted.
+    keys = getattr(args, "keys", None) or []
+    if keys:
+        for k in keys:
+            if k in env_vars:
+                print("%s=%s" % (k, env_vars[k]))
+            else:
+                print("Key '%s' not found." % k)
         return 0
 
     for k in sorted(env_vars.keys()):

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -377,6 +377,97 @@ class TestCleanup:
         out = capsys.readouterr().out
         assert "Removed stale entries" in out
 
+    def test_cleanup_keeps_unreachable_remote_by_default(
+        self, registry_with_remote, monkeypatch, capsys
+    ):
+        """Remote entry whose SSH probe fails (rc=255) must not be
+        auto-removed — it's 'unreachable', not 'missing'."""
+        tmp_path, _ = registry_with_remote
+        # Simulate SSH transport failure for the remote host
+        monkeypatch.setattr(
+            direct_commands, "_ssh_run", lambda host, cmd: (255, ""),
+        )
+
+        args = type("Args", (), {
+            "cleanup": True, "host": None, "force": False, "dry_run": False,
+        })()
+        direct_commands.cmd_list(args)
+
+        instances = direct_commands._read_registry(
+            str(tmp_path / "conf.json")
+        )
+        assert "remote" in instances  # kept despite being unreachable
+        assert "local" in instances
+        out = capsys.readouterr().out
+        assert "Kept" in out
+        assert "unreachable" in out
+
+    def test_cleanup_removes_unreachable_with_force(
+        self, registry_with_remote, monkeypatch, capsys
+    ):
+        tmp_path, _ = registry_with_remote
+        monkeypatch.setattr(
+            direct_commands, "_ssh_run", lambda host, cmd: (255, ""),
+        )
+
+        args = type("Args", (), {
+            "cleanup": True, "host": None, "force": True, "dry_run": False,
+        })()
+        direct_commands.cmd_list(args)
+
+        instances = direct_commands._read_registry(
+            str(tmp_path / "conf.json")
+        )
+        assert "remote" not in instances  # removed by --force
+        assert "local" in instances
+
+    def test_cleanup_removes_confirmed_missing_remote(
+        self, registry_with_remote, monkeypatch, capsys
+    ):
+        """SSH succeeds but 'test -d' returns non-zero (dir really is
+        gone on the remote host) — safe to remove without --force."""
+        tmp_path, _ = registry_with_remote
+        # rc=1 means test -d failed; SSH itself was fine
+        monkeypatch.setattr(
+            direct_commands, "_ssh_run", lambda host, cmd: (1, ""),
+        )
+
+        args = type("Args", (), {
+            "cleanup": True, "host": None, "force": False, "dry_run": False,
+        })()
+        direct_commands.cmd_list(args)
+
+        instances = direct_commands._read_registry(
+            str(tmp_path / "conf.json")
+        )
+        assert "remote" not in instances
+        assert "local" in instances
+        out = capsys.readouterr().out
+        assert "Removed stale entries" in out
+
+    def test_cleanup_dry_run_does_not_modify(
+        self, registry_with_remote, monkeypatch, capsys
+    ):
+        tmp_path, _ = registry_with_remote
+        monkeypatch.setattr(
+            direct_commands, "_ssh_run", lambda host, cmd: (1, ""),
+        )
+
+        args = type("Args", (), {
+            "cleanup": True, "host": None, "force": False, "dry_run": True,
+        })()
+        direct_commands.cmd_list(args)
+
+        # Registry unchanged
+        instances = direct_commands._read_registry(
+            str(tmp_path / "conf.json")
+        )
+        assert "remote" in instances
+        assert "local" in instances
+        out = capsys.readouterr().out
+        assert "Dry run" in out
+        assert "Would remove" in out
+
 
 # ---------------------------------------------------------------------------
 # End-to-end cmd_list tests
@@ -663,6 +754,38 @@ class TestCmdVersion:
         assert "docker" in out
         assert "def5678" in out
 
+    def test_target_canasta_version_line(self, tmp_path, monkeypatch, capsys):
+        """When CANASTA_VERSION file is present, the target version line
+        is always printed, even without -i/--all."""
+        (tmp_path / "VERSION").write_text("4.0.0\n")
+        (tmp_path / "CANASTA_VERSION").write_text("3.5.7\n")
+        (tmp_path / "BUILD_COMMIT").write_text("abc1234\n")
+        (tmp_path / "BUILD_DATE").write_text("2026-04-23 00:00:00\n")
+        monkeypatch.setenv("CANASTA_RUN_MODE", "docker")
+        monkeypatch.setattr(direct_commands, "_get_script_dir", lambda: str(tmp_path))
+        # No instances registered — PWD auto-resolve should be a no-op.
+        monkeypatch.setenv("CANASTA_CONFIG_DIR", str(tmp_path))
+        args = type("Args", (), {"id": None, "all": False, "host": None})()
+        rc = direct_commands.cmd_version(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Target Canasta version: 3.5.7" in out
+
+    def test_missing_canasta_version_file(self, tmp_path, monkeypatch, capsys):
+        """If CANASTA_VERSION file is absent, target shown as 'unknown'
+        (doesn't crash)."""
+        (tmp_path / "VERSION").write_text("4.0.0\n")
+        (tmp_path / "BUILD_COMMIT").write_text("abc1234\n")
+        (tmp_path / "BUILD_DATE").write_text("2026-04-23 00:00:00\n")
+        monkeypatch.setenv("CANASTA_RUN_MODE", "docker")
+        monkeypatch.setattr(direct_commands, "_get_script_dir", lambda: str(tmp_path))
+        monkeypatch.setenv("CANASTA_CONFIG_DIR", str(tmp_path))
+        args = type("Args", (), {"id": None, "all": False, "host": None})()
+        rc = direct_commands.cmd_version(args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Target Canasta version: unknown" in out
+
     def test_native_with_build_files(self, tmp_path, monkeypatch, capsys):
         """Native installs also write BUILD_COMMIT/BUILD_DATE (via
         get-canasta.sh or make build-info). The presence of those
@@ -754,10 +877,27 @@ class TestCmdConfigGet:
             direct_commands, "_resolve_instance",
             lambda args: ("test", {"path": str(tmp_path), "orchestrator": "compose"}),
         )
-        args = type("Args", (), {"id": "test", "key": "MW_SITE_SERVER", "force": False})()
+        args = type("Args", (), {
+            "id": "test", "keys": ["MW_SITE_SERVER"], "force": False,
+        })()
         rc = direct_commands.cmd_config_get(args)
         assert rc == 0
-        assert capsys.readouterr().out.strip() == "https://example.com"
+        assert capsys.readouterr().out.strip() == "MW_SITE_SERVER=https://example.com"
+
+    def test_get_multiple_keys(self, tmp_path, monkeypatch, capsys):
+        env = tmp_path / ".env"
+        env.write_text("A=1\nB=2\nC=3\n")
+        monkeypatch.setattr(
+            direct_commands, "_resolve_instance",
+            lambda args: ("test", {"path": str(tmp_path), "orchestrator": "compose"}),
+        )
+        args = type("Args", (), {
+            "id": "test", "keys": ["A", "C"], "force": False,
+        })()
+        rc = direct_commands.cmd_config_get(args)
+        assert rc == 0
+        out = capsys.readouterr().out.strip().splitlines()
+        assert out == ["A=1", "C=3"]
 
     def test_get_missing_key(self, tmp_path, monkeypatch, capsys):
         env = tmp_path / ".env"
@@ -766,7 +906,9 @@ class TestCmdConfigGet:
             direct_commands, "_resolve_instance",
             lambda args: ("test", {"path": str(tmp_path), "orchestrator": "compose"}),
         )
-        args = type("Args", (), {"id": "test", "key": "NOPE", "force": False})()
+        args = type("Args", (), {
+            "id": "test", "keys": ["NOPE"], "force": False,
+        })()
         rc = direct_commands.cmd_config_get(args)
         assert rc == 0
         assert "not found" in capsys.readouterr().out.lower()


### PR DESCRIPTION
## Summary

`direct_commands.py` is the fast-path module that `canasta.py` routes simple commands through to avoid the ~3–5s cost of spinning up Ansible. Recent feature work (PRs #281, #283, #287) only updated the Ansible playbook side of three commands that `direct_commands` shadows — so end users never actually saw any of the new behavior.

Verified before this PR:

```
$ canasta version
Canasta CLI v4.0.0 (native, commit c30d6bc, built ...)
# (no "Target Canasta version: ..." line — #283 was bypassed)

$ CANASTA_FORCE_ANSIBLE=1 canasta version
['Canasta CLI v4.0.0 ...', 'Target Canasta version: 3.5.6']
# (Ansible path works — direct path doesn't)
```

Same gap for `canasta config get POSITIONAL_KEY` (still fell back to the old `--key` singular semantics) and `canasta list --cleanup` (still deleted every remote entry via the `os.path.isdir` bug #287 was supposed to fix).

## What changed

### `cmd_version` (addresses #282 / #283)

- Always prints the target Canasta version line (from `CANASTA_VERSION` file).
- `-i/--id` reports `CANASTA_IMAGE` from the instance's `.env` plus the running Canasta version from `/tmp/canasta-version` inside the web container.
- `--all` does the same for every instance on the current host.
- With no flags, auto-resolves the current working directory to a registered instance (walking parents) and reports on it if found — matching the Ansible playbook's PWD behavior.

### `cmd_config_get` (addresses #280 / #281)

- Accepts positional `keys` (list) instead of the removed singular `--key`.
- Output is `KEY=value` per line, whether one key, many keys, or all keys.
- `Key 'X' not found.` message preserved for missing keys.

### `cmd_list` `--cleanup` (addresses #284 / #287)

The old code did `os.path.isdir(inst.path)` on the controller for *every* entry — every remote instance's path (like `/home/wikiworks/sebok`) obviously doesn't exist on the local laptop filesystem, so every remote entry got silently deleted from the registry regardless of whether it was actually healthy on its remote host.

Fix: per-entry classifier that uses:
- `os.path.isdir` for localhost entries
- `ssh test -d` for remote entries, classified by return code:
  - `rc == 0` → **exists** (keep)
  - `rc == 255` → **unreachable** (OpenSSH's reserved code for transport failures — DNS, refused, timeout, auth, host-key)
  - any other non-zero → **missing** (SSH connected, path is gone)

Behavior:
- Default `--cleanup` removes only `missing` entries.
- `--force` additionally removes `unreachable` entries.
- `--dry-run` prints the plan and makes no changes.
- Unreachable entries kept under the default are named in the output alongside the `--force` remediation.
- Probes run in parallel so `--cleanup` doesn't serialize SSH on N remote hosts.

## Tests

Seven new tests cover:

**`cmd_config_get`**
- positional single key → `KEY=value`
- positional multiple keys → each on its own line
- missing key → "not found" message

**`cmd_list` cleanup**
- unreachable remote kept by default (rc=255 simulated via `_ssh_run` monkeypatch)
- unreachable remote removed with `--force`
- confirmed-missing remote (rc=1) removed without `--force`
- `--dry-run` does not modify the registry

**`cmd_version`**
- `Target Canasta version:` line always present when `CANASTA_VERSION` exists
- missing `CANASTA_VERSION` file → `unknown` (no crash)

All 509 tests pass (502 prior + 7 new).

## Follow-up

The fact that this drift happened quietly — tests green, Ansible side fixed, CI green, users see nothing — is the real lesson. A separate consolidation PR should either:
1. Delete the Ansible playbook for commands fully handled by `direct_commands` (`version`, `host_*`), or
2. Add parity CI that runs each affected command under both paths and diffs the output.

I'd file that as a follow-up. For now, this PR gets the features to users.
