### PR TITLE
debug: surface docker compose up stderr on failure (temporary)

### DIFF
--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -29,7 +29,24 @@
       ansible.builtin.command:
         cmd: "docker compose {{ _compose_files | join(' ') }} up -d"
         chdir: "{{ instance_path }}"
+      register: _start_result
       changed_when: true
+      failed_when: false
+
+    # Temporary: Ansible's default callback swallows stderr/stdout for
+    # failed command modules under the new compact "[ERROR]: Task
+    # failed: ..." rendering. Surface the full output explicitly so
+    # post-merge integration test failures are diagnosable in the CI
+    # log. Remove once the 3.5.7 regression is diagnosed.
+    - name: Fail with full output if docker compose up failed
+      ansible.builtin.fail:
+        msg: |-
+          docker compose up exited with rc={{ _start_result.rc }}
+          --- STDOUT ---
+          {{ _start_result.stdout | default('(empty)') }}
+          --- STDERR ---
+          {{ _start_result.stderr | default('(empty)') }}
+      when: _start_result.rc != 0
 
 - name: Start (Kubernetes)
   when: instance_orchestrator | default('compose') in ['kubernetes', 'k8s']


### PR DESCRIPTION
## Summary

Temporary instrumentation to diagnose the `docker compose up -d` failures that have been breaking post-merge integration tests on main since PR #291 (the `CANASTA_VERSION` 3.5.6 → 3.5.7 bump).

## Why we can't see the real error today

`tests/integration/run_tests.py` invokes `canasta` with `--verbose`. That falls back to Ansible's default stdout callback (not `canasta_minimal`, which would render stderr). The default callback's new compact error format is:

```
[ERROR]: Task failed: Module failed: non-zero return code
Origin: roles/orchestrator/tasks/start.yml:28:7
26     msg: "Starting containers..."
27
28   - name: Start containers
         ^ column 7
```

Notably missing: the actual `stderr` and `stdout` from `docker compose up -d`. Every failing job in [run 24841252526](https://github.com/CanastaWiki/Canasta-Ansible/actions/runs/24841252526) ends on this line with no context about what went wrong.

## What this PR does

In `roles/orchestrator/tasks/start.yml`, register the command result and explicitly `ansible.builtin.fail` with `stdout`/`stderr` embedded in the message. The default callback *does* render `fail` messages in full, so the real error becomes visible in CI logs on the next failing run.

```yaml
- name: Start containers
  ansible.builtin.command:
    cmd: "docker compose {{ _compose_files | join(' ') }} up -d"
    chdir: "{{ instance_path }}"
  register: _start_result
  changed_when: true
  failed_when: false

- name: Fail with full output if docker compose up failed
  ansible.builtin.fail:
    msg: |-
      docker compose up exited with rc={{ _start_result.rc }}
      --- STDOUT ---
      {{ _start_result.stdout | default('(empty)') }}
      --- STDERR ---
      {{ _start_result.stderr | default('(empty)') }}
  when: _start_result.rc != 0
```

## Not a permanent fix

Two follow-ups once we know the root cause of the 3.5.7 regression:

1. **Revert this commit** (it's just diagnostic noise when `docker compose up` is actually working).
2. **Consider a permanent solution** — e.g. teach the canasta callback to render stderr on command-module failures even under `--verbose`, so all future regressions are debuggable without PR-cycle instrumentation. That's scoped for a separate issue/PR.

## Test plan

- [ ] On merge, CI runs the same integration tests. When they fail (as expected), the log now contains the actual stderr of `docker compose up -d` — enough to diagnose.
- [ ] Local `canasta create` still succeeds on my Mac (arm64); the change doesn't affect the success path (just renames the failure-surface).
- [ ] `make test-unit` + `make validate` pass (511 tests, no new ones; diagnostic-only change).

