### PR TITLE
Keep CI failure diagnostics permanently

### DIFF
--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -33,11 +33,10 @@
       changed_when: true
       failed_when: false
 
-    # Temporary: Ansible's default callback swallows stderr/stdout for
-    # failed command modules under the new compact "[ERROR]: Task
-    # failed: ..." rendering. Surface the full output explicitly so
-    # post-merge integration test failures are diagnosable in the CI
-    # log. Remove once the 3.5.7 regression is diagnosed.
+    # Ansible's default callback swallows stderr/stdout for failed
+    # command modules under the compact "[ERROR]: Task failed: ..."
+    # rendering. Register with failed_when: false and fail explicitly
+    # so the full output is visible in CI/operator logs.
     - name: Fail with full output if docker compose up failed
       ansible.builtin.fail:
         msg: |-

--- a/tests/integration/remote/run_tests.sh
+++ b/tests/integration/remote/run_tests.sh
@@ -68,9 +68,32 @@ fail() {
     echo "  FAIL: $1"
 }
 
+dump_failure_diagnostics() {
+    # Only runs when a test has already failed. Dumps container state
+    # and logs for every container whose name starts with the instance
+    # ID, so CI failures are diagnosable without a second round-trip.
+    echo ""
+    echo "=== Failure diagnostics ==="
+    echo "--- docker ps -a ---"
+    docker ps -a || true
+    for c in $(docker ps -aq --filter "name=${INSTANCE_ID}"); do
+        name=$(docker inspect --format='{{.Name}}' "$c" 2>/dev/null | sed 's:^/::')
+        echo "--- ${name} health ---"
+        docker inspect --format='{{json .State.Health}}' "$c" 2>/dev/null || true
+        echo ""
+        echo "--- ${name} logs (last 200) ---"
+        docker logs --tail 200 "$c" 2>&1 || true
+        echo ""
+    done
+}
+
 cleanup() {
     echo ""
     echo "=== Cleaning up ==="
+    # Surface container state/logs on failure before we tear anything down.
+    if [ "${FAIL:-0}" -gt 0 ]; then
+        dump_failure_diagnostics
+    fi
     # Best-effort delete of instance if it still exists
     canasta delete -i "${INSTANCE_ID}" -y 2>/dev/null || true
     # Teardown the mock remote host


### PR DESCRIPTION
Closes #296.

## Summary

- Drop the "temporary, remove once 3.5.7 regression is diagnosed" framing on the explicit-fail task in `roles/orchestrator/tasks/start.yml`. The pattern (register with `failed_when: false`, then fail with stdout/stderr embedded in the message) is always useful because Ansible's default callback swallows command-module output under the compact error rendering.
- Add an on-failure diagnostic dump to `tests/integration/remote/run_tests.sh`: `docker ps -a`, `docker inspect --format='{{.State.Health}}'`, and `docker logs --tail 200` for every container whose name starts with the instance ID. Gated on `FAIL > 0` so passing runs stay clean.

Motivation in #296: without persistent diagnostics, every CI failure forces a round-trip "add debug → re-trigger → diagnose → revert" cycle. Keeping them in place costs nothing on green runs.

## Test plan

- [ ] Merge and let the post-merge `remote-integration` job run. If `remote-test-web-1` is still unhealthy (the current 3.5.7 regression we're chasing), the job should now print the web container's logs and health state in the failure output, which is the whole point of this PR.
- [ ] Confirm passing integration runs aren't noisier (the dump is gated on `FAIL > 0`).
