### PR TITLE
Capture compose logs on failure before rollback wipes them

### DIFF
--- a/roles/orchestrator/tasks/start.yml
+++ b/roles/orchestrator/tasks/start.yml
@@ -33,6 +33,30 @@
       changed_when: true
       failed_when: false
 
+    # When docker compose up fails (typically an unhealthy container),
+    # capture per-service logs and state before we bail out. The caller
+    # usually rolls back (docker compose down) on failure, which wipes
+    # the containers — so any post-hoc dump from the controller sees
+    # nothing. Capturing here, before propagating the error, is the
+    # only reliable way to see WHY a container was unhealthy.
+    - name: Capture compose state on failure
+      ansible.builtin.command:
+        cmd: "docker compose {{ _compose_files | join(' ') }} ps -a"
+        chdir: "{{ instance_path }}"
+      register: _start_ps
+      changed_when: false
+      failed_when: false
+      when: _start_result.rc != 0
+
+    - name: Capture compose logs on failure
+      ansible.builtin.command:
+        cmd: "docker compose {{ _compose_files | join(' ') }} logs --tail=200 --no-color"
+        chdir: "{{ instance_path }}"
+      register: _start_logs
+      changed_when: false
+      failed_when: false
+      when: _start_result.rc != 0
+
     # Ansible's default callback swallows stderr/stdout for failed
     # command modules under the compact "[ERROR]: Task failed: ..."
     # rendering. Register with failed_when: false and fail explicitly
@@ -45,6 +69,10 @@
           {{ _start_result.stdout | default('(empty)') }}
           --- STDERR ---
           {{ _start_result.stderr | default('(empty)') }}
+          --- docker compose ps -a ---
+          {{ _start_ps.stdout | default('(not captured)') }}
+          --- docker compose logs (last 200) ---
+          {{ _start_logs.stdout | default('(not captured)') }}
       when: _start_result.rc != 0
 
 - name: Start (Kubernetes)


### PR DESCRIPTION
Closes #298.

## Summary

Follow-up to #297. The on-failure dump in `tests/integration/remote/run_tests.sh` fires from the cleanup trap — *after* `canasta create`'s rollback has already run `docker compose down` and removed the instance containers. The CI run on c8fa14f (main after #297) proved this: `docker ps -a` showed only the SSH-host container; the web container was gone, with no logs captured.

Move the capture *inside* `roles/orchestrator/tasks/start.yml`, between the failed `docker compose up` and the explicit `fail` task. At that point the containers are still around. The captured `ps -a` and `logs --tail=200` output is appended to the existing fail message.

Both new tasks are gated on `_start_result.rc != 0` and use `failed_when: false`, so the happy path is unaffected.

## Test plan

- [ ] Merge. Next post-merge `remote-integration` run should either pass, or fail with the web container's logs now embedded in the "docker compose up exited with rc=1" fail message — finally letting us see *why* `remote-test-web-1` is unhealthy on amd64.
