### PR TITLE
Fix wrong @register target for gitops_status (post-merge regression from #303)

### DIFF
--- a/direct_commands.py
+++ b/direct_commands.py
@@ -1033,7 +1033,6 @@ def _parse_gitops_status(stdout, instance_id):
     return "\n".join(lines)
 
 
-@register("gitops_status")
 def _gitops_argocd_status(instance_id):
     """Query Argo CD Application for this instance; return parsed status.
 
@@ -1105,6 +1104,7 @@ def _parse_gitops_status_k8s(stdout, instance_id, argocd):
     return "\n".join(lines)
 
 
+@register("gitops_status")
 def cmd_gitops_status(args):
     inst_id, inst = _resolve_instance(args)
     host = inst.get("host") or "localhost"

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1358,6 +1358,36 @@ class TestCmdGitopsStatus:
     def test_registered(self):
         assert direct_commands.is_direct_command("gitops_status")
 
+    def test_registered_to_correct_function(self):
+        # Catches a class of bug where the @register decorator drifts
+        # onto an adjacent helper function. (See the gitops_status
+        # regression: the @register decorator attached to the Argo CD
+        # helper instead of cmd_gitops_status, so 'canasta gitops
+        # status' returned the helper's tuple and sys.exit(tuple)
+        # printed the tuple repr with rc=1.)
+        assert direct_commands.DIRECT_COMMANDS["gitops_status"] is (
+            direct_commands.cmd_gitops_status
+        )
+
+
+class TestDirectCommandRegistry:
+    """Module-wide invariants on the direct-command registry."""
+
+    def test_all_handlers_are_cmd_functions(self):
+        # Every @register-decorated handler must be a top-level cmd_*
+        # function, not a private helper. Guards against decorator
+        # drift: when you edit near a @register line it can silently
+        # end up above the wrong def.
+        wrong = []
+        for name, fn in direct_commands.DIRECT_COMMANDS.items():
+            fname = getattr(fn, "__name__", "")
+            if not fname.startswith("cmd_"):
+                wrong.append("%s -> %s" % (name, fname))
+        assert not wrong, (
+            "direct-command handlers must be cmd_* functions: %s"
+            % ", ".join(wrong)
+        )
+
     def test_remote_uses_ssh(self, monkeypatch, capsys):
         d = direct_commands._SENTINEL
         ssh_output = (


### PR DESCRIPTION
Closes #304.

## Summary

Hotfix for the post-merge regression introduced by #303. `canasta gitops status` is currently broken on main — it prints `('Not registered', 'N/A', 'never', 'unknown')` and exits rc=1 for every instance.

**Root cause**: when #303 inserted `_gitops_argocd_status()` above `cmd_gitops_status()`, the `@register("gitops_status")` decorator ended up attached to `_gitops_argocd_status` instead of `cmd_gitops_status`. Python decorators attach to the *next* `def` — so inserting a new function between the decorator and its intended target silently moved registration onto the helper. At runtime, `run_direct_command("gitops_status", args)` called the Argo CD helper, which returned its fallback tuple. `canasta.py`'s `sys.exit(result)` then printed the tuple repr and exited with rc=1.

**Why unit tests missed it**: the existing tests call `cmd_gitops_status(args)` directly, bypassing the registry. `test_registered` only checked that *something* was registered under the name.

## Changes

- Move `@register("gitops_status")` back onto `cmd_gitops_status` (`direct_commands.py`).
- `test_registered_to_correct_function`: asserts `DIRECT_COMMANDS["gitops_status"] is cmd_gitops_status`.
- `TestDirectCommandRegistry.test_all_handlers_are_cmd_functions`: module-wide invariant — every registered handler must be a `cmd_*`-named function. Catches the same class of decorator-drift bug for *any* future command.

## Test plan

- [x] Full unit suite: 522 passed (was 520; +2 new registry tests)
- [x] Sanity: `DIRECT_COMMANDS["gitops_status"] is cmd_gitops_status` → True
- [x] Sanity: `_gitops_argocd_status` no longer in the registry
- [ ] Post-merge Integration: GitOps job should go green again.
