### PR TITLE
Close Compose parity for start/restart (profile sync + failure diagnostics)

### DIFF
--- a/direct_commands.py
+++ b/direct_commands.py
@@ -58,35 +58,117 @@ def _resolve_instance(args):
     return inst["id"], inst
 
 
-def _read_env_file(path, host):
-    """Read and parse a .env file, returning a dict of key=value pairs."""
+def _read_env_content(path, host):
+    """Read raw .env file content. Returns '' if missing or unreadable."""
     env_path = os.path.join(path, ".env")
-    try:
-        if _is_localhost(host):
+    if _is_localhost(host):
+        try:
             with open(env_path) as f:
-                content = f.read()
-        else:
-            rc, content = _ssh_run(host, "cat %s" % _shell_quote(env_path))
-            if rc != 0:
-                return {}
-    except OSError:
-        return {}
+                return f.read()
+        except OSError:
+            return ""
+    rc, content = _ssh_run(host, "cat %s 2>/dev/null" % _shell_quote(env_path))
+    return content if rc == 0 else ""
 
-    result = {}
+
+def _parse_env_entries(content):
+    """Parse .env content into ordered (key, value, is_comment) tuples.
+
+    Preserves comments and blank lines so a round-trip through
+    _entries_to_content leaves untouched lines intact. Mirrors
+    canasta_env.parse_env_file() in the Ansible module.
+    """
+    entries = []
     for line in content.split("\n"):
         stripped = line.strip()
         if not stripped or stripped.startswith("#"):
+            entries.append((None, line, True))
             continue
         parts = stripped.split("=", 1)
         if len(parts) == 2:
             key = parts[0].strip()
             value = parts[1].strip()
-            if len(value) >= 2:
-                if (value.startswith('"') and value.endswith('"')) or \
-                   (value.startswith("'") and value.endswith("'")):
-                    value = value[1:-1]
-            result[key] = value
-    return result
+            if len(value) >= 2 and (
+                (value.startswith('"') and value.endswith('"'))
+                or (value.startswith("'") and value.endswith("'"))
+            ):
+                value = value[1:-1]
+            entries.append((key, value, False))
+        else:
+            entries.append((None, line, True))
+    return entries
+
+
+def _entries_to_content(entries):
+    lines = []
+    for key, value, is_comment in entries:
+        if is_comment:
+            lines.append(value)
+        else:
+            lines.append("%s=%s" % (key, value))
+    return "\n".join(lines)
+
+
+def _set_env_entry(entries, key, value):
+    """Update first occurrence, drop duplicate lines for the same key,
+    append if absent. Matches canasta_env.set_variable() in Ansible."""
+    found = False
+    new_entries = []
+    for k, v, c in entries:
+        if not c and k == key:
+            if not found:
+                new_entries.append((key, value, False))
+                found = True
+            # Drop subsequent duplicates
+        else:
+            new_entries.append((k, v, c))
+    if not found:
+        new_entries.append((key, value, False))
+    return new_entries
+
+
+def _write_env_content(path, host, content):
+    """Write content to .env. Returns True on success.
+
+    Remote writes pipe stdin through 'cat > file' over SSH — avoids
+    escaping the entire file content into a command line.
+    """
+    env_path = os.path.join(path, ".env")
+    if _is_localhost(host):
+        try:
+            with open(env_path, "w") as f:
+                f.write(content)
+            return True
+        except OSError as e:
+            print("Error writing %s: %s" % (env_path, e), file=sys.stderr)
+            return False
+
+    ssh_cmd = (
+        ["ssh"] + _ssh_args()
+        + [host, "cat > %s" % _shell_quote(env_path)]
+    )
+    try:
+        result = subprocess.run(
+            ssh_cmd, input=content, text=True,
+            capture_output=True, timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        print("Error writing remote %s: %s" % (env_path, e), file=sys.stderr)
+        return False
+    if result.returncode != 0:
+        print(
+            "Error writing remote %s: %s"
+            % (env_path, (result.stderr or "").strip()),
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def _read_env_file(path, host):
+    """Read and parse a .env file, returning a dict of key=value pairs."""
+    content = _read_env_content(path, host)
+    return {k: v for k, v, c in _parse_env_entries(content) if not c and k}
 
 
 def _compose_file_args(path, host, devmode=False):
@@ -135,6 +217,93 @@ def _run_compose(inst_id, inst, action_args):
         if stdout.strip():
             print(stdout.strip())
         return rc
+
+
+# Profiles that Canasta derives from CANASTA_ENABLE_* feature flags.
+# (profile_name, flag_name, default_when_flag_unset)
+# Matches roles/orchestrator/tasks/sync_compose_profiles.yml.
+_MANAGED_PROFILES = [
+    ("observable", "CANASTA_ENABLE_OBSERVABILITY", "false"),
+    ("elasticsearch", "CANASTA_ENABLE_ELASTICSEARCH", "false"),
+    ("varnish", "CANASTA_ENABLE_VARNISH", "true"),
+]
+
+
+def _sync_compose_profiles(inst):
+    """Align COMPOSE_PROFILES in .env with the CANASTA_ENABLE_* feature flags.
+
+    Called before 'docker compose up' so hand-edited .env files, gitops
+    pulls, or any other drift between the managed flags and
+    COMPOSE_PROFILES gets reconciled before compose is invoked. Mirrors
+    roles/orchestrator/tasks/sync_compose_profiles.yml — canasta config
+    set has its own copy that fires on the relevant keys.
+    """
+    host = inst.get("host") or "localhost"
+    path = inst.get("path", "")
+    content = _read_env_content(path, host)
+    if not content:
+        return  # No .env to sync
+
+    entries = _parse_env_entries(content)
+    env = {k: v for k, v, c in entries if not c and k}
+    managed_names = {p for p, _flag, _default in _MANAGED_PROFILES}
+
+    current_raw = env.get("COMPOSE_PROFILES", "")
+    current = [p.strip() for p in current_raw.split(",") if p.strip()]
+
+    desired = [p for p in current if p not in managed_names]
+    for profile, flag, default in _MANAGED_PROFILES:
+        if env.get(flag, default).strip().lower() == "true":
+            desired.append(profile)
+
+    if sorted(desired) == sorted(current):
+        return  # No change needed
+
+    new_entries = _set_env_entry(
+        entries, "COMPOSE_PROFILES", ",".join(desired),
+    )
+    _write_env_content(path, host, _entries_to_content(new_entries))
+
+
+def _dump_compose_failure(inst):
+    """Print docker compose ps + logs to stderr after a failed 'up'.
+
+    Matches the diagnostic block in roles/orchestrator/tasks/start.yml:
+    the caller usually rolls back (docker compose down) on failure,
+    which wipes the containers — so capturing ps/logs here, right
+    after the failed 'up' and before the rollback, is the only
+    reliable way to see why a container was unhealthy.
+    """
+    host = inst.get("host") or "localhost"
+    path = inst.get("path", "")
+    devmode = inst.get("devMode", False)
+    file_args = _compose_file_args(path, host, devmode)
+
+    steps = [
+        (["ps", "-a"], "docker compose ps -a"),
+        (["logs", "--tail=200", "--no-color"], "docker compose logs (last 200)"),
+    ]
+    for action, label in steps:
+        if _is_localhost(host):
+            try:
+                result = subprocess.run(
+                    ["docker", "compose"] + file_args + action,
+                    cwd=path, capture_output=True, text=True, timeout=30,
+                )
+                output = result.stdout or result.stderr
+            except (subprocess.TimeoutExpired, OSError) as e:
+                output = "(failed to capture: %s)" % e
+        else:
+            action_str = " ".join(action)
+            file_str = " ".join(file_args)
+            _rc, output = _ssh_run(
+                host,
+                "cd %s && docker compose %s %s" % (
+                    _shell_quote(path), file_str, action_str,
+                ),
+            )
+        print("--- %s ---" % label, file=sys.stderr)
+        print(output.strip() if output else "(empty)", file=sys.stderr)
 
 
 def _k8s_get_pod(namespace, component="web"):
@@ -827,7 +996,11 @@ def cmd_start(args):
         # these are multi-step controller-to-remote operations that
         # need Ansible.
         return FALLBACK
-    return _run_compose(inst_id, inst, ["up", "-d"])
+    _sync_compose_profiles(inst)
+    rc = _run_compose(inst_id, inst, ["up", "-d"])
+    if rc != 0:
+        _dump_compose_failure(inst)
+    return rc
 
 
 @register("stop")
@@ -847,7 +1020,11 @@ def cmd_restart(args):
     rc = _run_compose(inst_id, inst, ["down"])
     if rc != 0:
         return rc
-    return _run_compose(inst_id, inst, ["up", "-d"])
+    _sync_compose_profiles(inst)
+    rc = _run_compose(inst_id, inst, ["up", "-d"])
+    if rc != 0:
+        _dump_compose_failure(inst)
+    return rc
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_direct_commands.py
+++ b/tests/unit/test_direct_commands.py
@@ -1185,6 +1185,7 @@ class TestLifecycleCommands:
 
         def mock_ssh(host, cmd):
             ssh_cmds.append((host, cmd))
+            # Return empty .env for the sync-profiles read
             return 0, ""
 
         monkeypatch.setattr(direct_commands, "_ssh_run", mock_ssh)
@@ -1204,9 +1205,169 @@ class TestLifecycleCommands:
         args = type("Args", (), {"id": "test"})()
         rc = direct_commands.cmd_start(args)
         assert rc == 0
-        assert len(ssh_cmds) == 1
-        assert "up -d" in ssh_cmds[0][1]
-        assert ssh_cmds[0][0] == "admin@remote"
+        # The sync-profiles read + the up -d: 2 SSH calls total.
+        # Empty .env returned above → no write.
+        up_calls = [c for _, c in ssh_cmds if "up -d" in c]
+        assert len(up_calls) == 1
+        assert all(h == "admin@remote" for h, _ in ssh_cmds)
+
+
+class TestEnvFileWriter:
+    """_parse_env_entries + _set_env_entry + _entries_to_content round trip."""
+
+    def test_round_trip_preserves_comments_and_blanks(self):
+        content = "# header comment\n\nKEY=value\n# inline\nOTHER=x\n"
+        entries = direct_commands._parse_env_entries(content)
+        out = direct_commands._entries_to_content(entries)
+        assert out == content.rstrip("\n") or out == content
+        # Specifically: comment + blank + entry + comment + entry
+        assert entries[0] == (None, "# header comment", True)
+        assert entries[1] == (None, "", True)
+        assert entries[2] == ("KEY", "value", False)
+        assert entries[3] == (None, "# inline", True)
+        assert entries[4] == ("OTHER", "x", False)
+
+    def test_parse_strips_matching_quotes(self):
+        entries = direct_commands._parse_env_entries(
+            'A="quoted"\nB=\'single\'\nC=bare\n'
+        )
+        vals = {k: v for k, v, c in entries if not c}
+        assert vals == {"A": "quoted", "B": "single", "C": "bare"}
+
+    def test_set_updates_first_occurrence_and_dedupes(self):
+        entries = direct_commands._parse_env_entries("K=old\nK=dup\nX=y\n")
+        new = direct_commands._set_env_entry(entries, "K", "new")
+        out = direct_commands._entries_to_content(new)
+        # First occurrence updated, duplicate dropped, other untouched
+        assert out.split("\n") == ["K=new", "X=y", ""]
+
+    def test_set_appends_when_absent(self):
+        entries = direct_commands._parse_env_entries("A=1\n")
+        new = direct_commands._set_env_entry(entries, "B", "2")
+        out = direct_commands._entries_to_content(new)
+        assert out == "A=1\n\nB=2" or out.endswith("B=2")
+        assert "B=2" in out
+
+    def test_write_env_content_local(self, tmp_path):
+        p = str(tmp_path)
+        ok = direct_commands._write_env_content(p, "localhost", "K=v\n")
+        assert ok is True
+        with open(tmp_path / ".env") as f:
+            assert f.read() == "K=v\n"
+
+
+class TestSyncComposeProfiles:
+    def _inst(self, tmp_path):
+        return {"path": str(tmp_path), "host": "localhost"}
+
+    def test_adds_elasticsearch_when_flag_true(self, tmp_path):
+        # User toggled CANASTA_ENABLE_ELASTICSEARCH=true by hand-editing
+        # .env. COMPOSE_PROFILES hasn't been updated. _sync should fix it.
+        (tmp_path / ".env").write_text(
+            "CANASTA_ENABLE_ELASTICSEARCH=true\nCOMPOSE_PROFILES=\n"
+        )
+        direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        content = (tmp_path / ".env").read_text()
+        assert "COMPOSE_PROFILES=elasticsearch" in content
+
+    def test_adds_varnish_by_default(self, tmp_path):
+        # CANASTA_ENABLE_VARNISH defaults to true even when unset.
+        (tmp_path / ".env").write_text("COMPOSE_PROFILES=\n")
+        direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        content = (tmp_path / ".env").read_text()
+        assert "COMPOSE_PROFILES=varnish" in content
+
+    def test_removes_stale_managed_profile(self, tmp_path):
+        # COMPOSE_PROFILES has 'elasticsearch' but the flag is false.
+        (tmp_path / ".env").write_text(
+            "CANASTA_ENABLE_ELASTICSEARCH=false\n"
+            "CANASTA_ENABLE_VARNISH=false\n"
+            "CANASTA_ENABLE_OBSERVABILITY=false\n"
+            "COMPOSE_PROFILES=elasticsearch,varnish\n"
+        )
+        direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        content = (tmp_path / ".env").read_text()
+        # Every managed profile is dropped because all flags are false
+        for line in content.split("\n"):
+            if line.startswith("COMPOSE_PROFILES="):
+                assert line == "COMPOSE_PROFILES="
+                break
+
+    def test_preserves_unmanaged_profiles(self, tmp_path):
+        # User has a custom profile 'mytest' not in the managed set.
+        # It must survive the sync.
+        (tmp_path / ".env").write_text(
+            "CANASTA_ENABLE_VARNISH=false\n"
+            "CANASTA_ENABLE_ELASTICSEARCH=false\n"
+            "CANASTA_ENABLE_OBSERVABILITY=false\n"
+            "COMPOSE_PROFILES=mytest,varnish\n"
+        )
+        direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        content = (tmp_path / ".env").read_text()
+        for line in content.split("\n"):
+            if line.startswith("COMPOSE_PROFILES="):
+                assert "mytest" in line
+                assert "varnish" not in line
+                break
+
+    def test_no_write_when_already_in_sync(self, tmp_path):
+        env_path = tmp_path / ".env"
+        env_path.write_text(
+            "CANASTA_ENABLE_VARNISH=true\nCOMPOSE_PROFILES=varnish\n"
+        )
+        original_mtime = env_path.stat().st_mtime_ns
+        direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        # If _sync wrote the file, mtime would update. The guard in
+        # _sync (sorted(desired) == sorted(current)) must prevent that.
+        assert env_path.stat().st_mtime_ns == original_mtime
+
+    def test_no_env_file_is_a_noop(self, tmp_path):
+        # Nothing to sync; must not create a file or raise.
+        direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        assert not (tmp_path / ".env").exists()
+
+    def test_preserves_comments_on_write(self, tmp_path):
+        (tmp_path / ".env").write_text(
+            "# Canasta config\n"
+            "CANASTA_ENABLE_VARNISH=true\n"
+            "# profiles below\n"
+            "COMPOSE_PROFILES=\n"
+        )
+        direct_commands._sync_compose_profiles(self._inst(tmp_path))
+        content = (tmp_path / ".env").read_text()
+        assert "# Canasta config" in content
+        assert "# profiles below" in content
+
+
+class TestDumpComposeFailure:
+    def test_prints_ps_and_logs_to_stderr(self, monkeypatch, capsys):
+        # Return deterministic output for both ps and logs commands.
+        def fake_run(cmd, **kw):
+            if "ps" in cmd:
+                return type("R", (), {
+                    "returncode": 0,
+                    "stdout": "NAME STATUS\nweb-1 Restarting",
+                    "stderr": "",
+                })()
+            return type("R", (), {
+                "returncode": 0,
+                "stdout": "web-1 | exec format error",
+                "stderr": "",
+            })()
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            direct_commands, "_compose_file_args",
+            lambda *a, **kw: ["-f", "docker-compose.yml"],
+        )
+        direct_commands._dump_compose_failure({
+            "path": "/srv/test", "host": "localhost",
+        })
+        err = capsys.readouterr().err
+        assert "docker compose ps -a" in err
+        assert "docker compose logs" in err
+        assert "Restarting" in err
+        assert "exec format error" in err
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #308. Part of #292 (Phase 3).

## Summary

`start` and `restart` stay **hybrid** — direct handles Compose, Ansible handles K8s via FALLBACK. Porting helm + rollout-status + Argo CD re-enable into Python subprocess calls isn't worth the rewrite. But the Compose direct path had two real gaps vs. the Ansible path:

1. **`sync_compose_profiles` didn't run** before `docker compose up`. `canasta config set` has its own copy of the sync for the three `CANASTA_ENABLE_*` keys, so set→start works. But **hand-edited `.env`** or **gitops-pulled `.env`** with drifted `COMPOSE_PROFILES` silently fails to bring up the expected services, with no warning.
2. **No failure diagnostics.** The Ansible side (#297/#299) captures `docker compose ps -a` + `logs --tail=200 --no-color` when `up` fails, so operators can see *why* a container was unhealthy. Direct had no such capture.

## Changes

- **`.env` writer helpers** in `direct_commands.py` mirroring `roles/common/library/canasta_env.py`:
  - `_parse_env_entries` / `_entries_to_content` — round-trip preserving comments and blank lines
  - `_set_env_entry` — update first occurrence, drop duplicates, append if absent
  - `_read_env_content` / `_write_env_content` — local + remote (remote write pipes content through `cat > file` via SSH stdin)
- **`_sync_compose_profiles(inst)`** — reads `.env`, drops managed profiles (`observable`/`elasticsearch`/`varnish`), re-adds based on `CANASTA_ENABLE_*` flags, writes back **only if the computed list differs**.
- **`_dump_compose_failure(inst)`** — runs `docker compose ps -a` + `logs --tail=200 --no-color`, prints labeled output to stderr. Called only when `docker compose up` returns non-zero.
- **`cmd_start` / `cmd_restart`** (Compose branch only) now call sync before `up` and dump on failure.
- Playbooks + role tasks preserved — still needed for K8s FALLBACK and for non-command callers (upgrade, devmode, migrations).

No `direct_only: true` marker added — `start` / `restart` are explicitly hybrid.

## Test plan

- [x] `make validate`: `Validation passed: 61 commands, 54 playbooks`
- [x] Full unit suite: **536 passed** (was 523; +13 new tests)
  - `TestEnvFileWriter`: round-trip comments/blanks, quote stripping on read, update-and-dedupe, append-when-absent, local write
  - `TestSyncComposeProfiles`: adds elasticsearch when flag true, adds varnish by default (flag unset), removes stale managed profile when flag false, **preserves unmanaged custom profiles**, no-write when already in sync (mtime unchanged), no-op on missing `.env`, preserves comments
  - `TestDumpComposeFailure`: prints both `ps -a` and `logs --tail=200` to stderr
- [x] Existing `test_remote_start_uses_ssh` updated — now expects 2 SSH calls (sync-read + up) rather than 1, and verifies the `up -d` call is among them

## Out of scope

- `list` → direct_only: separate audit PR.
- Formalizing "hybrid" in `command_definitions.yml` / validator: future.
